### PR TITLE
2 minor javadoc fixes for links (remove warnings)

### DIFF
--- a/src/main/java/io/stargate/sgv3/docsapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv3/docsapi/api/model/command/Command.java
@@ -9,7 +9,8 @@ import io.stargate.sgv3.docsapi.api.model.command.impl.InsertOneCommand;
  * POJO object (data no behavior) that represents a syntactically and grammatically valid command as
  * defined in the API spec.
  *
- * <p>The behavior about *how* to run a Command is in the {@link CommandResolver}.
+ * <p>The behavior about *how* to run a Command is in the {@link
+ * io.stargate.sgv3.docsapi.service.resolver.model.CommandResolver}.
  *
  * <p>Commands <b>should not</b> include JSON other than for documents we want to insert. They
  * should represent a translate of the API request into an internal representation. e.g. this

--- a/src/main/java/io/stargate/sgv3/docsapi/service/resolver/model/CommandResolver.java
+++ b/src/main/java/io/stargate/sgv3/docsapi/service/resolver/model/CommandResolver.java
@@ -35,7 +35,7 @@ public interface CommandResolver<C extends Command> {
    * CommandContext} so it knows the db and other contextual info, and as well has all the data it
    * needs.
    *
-   * @param commandContext {@link CommandContext}
+   * @param ctx {@link CommandContext}
    * @param command {@link Command}
    * @return Operation, must no be <code>null</code>
    */


### PR DESCRIPTION
Include 2 tiny doc fixes from bigger merge (since that has conflicts).
