### PR TITLE
avoid saving docker images on failed runs

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -81,18 +81,3 @@ jobs:
         run: |
           ./mvnw -B -ntp verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} ${{ matrix.profile }}
 
-      # lets upload with docker image in case test fails
-      # first export
-      - name: Export docker image (if failed)
-        if: ${{ failure() }}
-        run: |
-          docker save --output ${{ matrix.type }}-${{ github.sha }}.tar stargateio/${{ matrix.image }}:${{ github.sha }}
-
-      # then upload
-      - name: Upload docker Image (if failed)
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: img-${{ matrix.type }}-${{ github.sha }}
-          path: ${{ matrix.type }}-${{ github.sha }}.tar
-          retention-days: 3


### PR DESCRIPTION
We're using up resources too quickly with current settings. 