### PR TITLE
relates to C2-2413: create and publish docker image on the main push

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -51,3 +51,45 @@ jobs:
       - name: Build and push (Amazon ECR)
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{github.sha}}
+
+  # signs docker image with cosign
+  sign:
+    name: Sign image
+    needs: [main]
+    runs-on: ubuntu-latest
+
+    env:
+      # not a newest version, this reflects riptano action target version
+      COSIGN_VERSION: v1.9.0
+      IMAGE_NAME: docsapi
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: ${COSIGN_VERSION}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Sign a docker image
+        shell: bash
+        env:
+          COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/${IMAGE_NAME}:${{github.sha}}
+          COSIGN_PRIVATE_BASE64: ${{ secrets.COSIGN_PRIVATE_BASE64}}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD}}
+          COSIGN_KEY_FILE: _cosign_key_
+          AUX_KEY: signedby
+          AUX_VALUE: stargate
+        run: |
+          echo $COSIGN_PRIVATE_BASE64 | base64 --decode > $COSIGN_KEY_FILE
+          echo "=== signing image [$COSIGN_IMAGE] ..."
+          cosign sign --key $COSIGN_KEY_FILE -a $AUX_KEY=$AUX_VALUE $COSIGN_IMAGE


### PR DESCRIPTION
Creates and publishes the docker image to the AWS repository on each push to `main` branch. See [explanation on C2-2413](https://datastax.jira.com/browse/C2-2413?focusedCommentId=545234) for further details.

Open points:
* [x] Let's agree on the naming, should we renaming the image name. Current image is : `stargateio/docsapi:v3.0.0-SNAPSHOT`, should we rename to `stargateio/jsonapi` (version is irrelenat here, cause we will use git sha for the tag)
* [x] Once we know the image name, we need to initalize the repository, will not work without
* [x] Should we immediately sing the images as we do for all SG2 images we publish to the AWS? I would say yes
* [x] build the image without `v3` tag if we go for this solution