### PR TITLE
closes #102: protect against metric tag explosion on unauthorized access

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,8 @@ quarkus:
         # we need to define uri templating on our own for now
         # note that order is important
         match-patterns: |
+          /v1/[^/]+=/v1/{namespace},
+          /v1/.+/.+=/v1/{namespace}/{collection}
 
   # adapt path of the open api definitions
   smallrye-openapi:

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/UnauthorizedMetricsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/UnauthorizedMetricsTest.java
@@ -1,0 +1,84 @@
+package io.stargate.sgv2.jsonapi.api;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class UnauthorizedMetricsTest {
+
+  @Test
+  public void namespaceResource() {
+    String json =
+        """
+        {
+          "createCollection": {
+            "name": "whatever"
+          }
+        }
+        """;
+
+    // ensure namespace not in tags when no auth token used
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(NamespaceResource.BASE_PATH, "keyspace")
+        .then()
+        .statusCode(200);
+
+    String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
+    List<String> httpMetrics =
+        metrics.lines().filter(line -> line.startsWith("http_server_requests_seconds")).toList();
+
+    assertThat(httpMetrics)
+        .allSatisfy(
+            line ->
+                assertThat(line)
+                    .containsAnyOf(
+                        "uri=\"/v1\"",
+                        "uri=\"/v1/{namespace}\"",
+                        "uri=\"/v1/{namespace}/{collection}\""));
+  }
+
+  @Test
+  public void collectionResource() {
+    String json = """
+        {
+          "find": {
+          }
+        }
+        """;
+
+    // ensure namespace not in tags when no auth token used
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, "keyspace", "collection")
+        .then()
+        .statusCode(200);
+
+    String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
+    List<String> httpMetrics =
+        metrics.lines().filter(line -> line.startsWith("http_server_requests_seconds")).toList();
+
+    assertThat(httpMetrics)
+        .allSatisfy(
+            line ->
+                assertThat(line)
+                    .containsAnyOf(
+                        "uri=\"/v1\"",
+                        "uri=\"/v1/{namespace}\"",
+                        "uri=\"/v1/{namespace}/{collection}\""));
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -30,28 +30,6 @@ class CollectionResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
   }
 
-  @Test
-  public final void createCollection() {
-    String json =
-        String.format(
-            """
-            {
-              "createCollection": {
-                "name": "%s"
-              }
-            }
-            """,
-            collectionName);
-    given()
-        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-        .contentType(ContentType.JSON)
-        .body(json)
-        .when()
-        .post(NamespaceResource.BASE_PATH, keyspaceId.asInternal())
-        .then()
-        .statusCode(200);
-  }
-
   @Nested
   class ClientErrors {
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,3 +3,8 @@
 stargate:
   data-store:
     ignore-bridge: true
+
+# change test port from 8081 (used by other SG services)
+quarkus:
+  http:
+    test-port: 9080


### PR DESCRIPTION
Adds protection against tags explosion in case of unauthenticated access. Added test as well, just in case somebody alters the application config.