### PR TITLE
closes #87: handle unknown command

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/exception/GenericExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/exception/GenericExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.api.exception;
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableCommandResultSupplier;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -11,8 +12,9 @@ import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
  */
 public class GenericExceptionMapper {
 
-  @ServerExceptionMapper()
-  public RestResponse<CommandResult> genericExceptionMapper(Exception e) {
+  // explicitly add types to override Quarkus mappers
+  @ServerExceptionMapper({Exception.class, MismatchedInputException.class})
+  public RestResponse<CommandResult> genericExceptionMapper(Throwable e) {
     CommandResult commandResult = new ThrowableCommandResultSupplier(e).get();
     return RestResponse.ok(commandResult);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -5,6 +5,7 @@ import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -62,6 +63,28 @@ class CollectionResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .body("errors[0].exceptionClass", is("WebApplicationException"))
           .body("errors[1].message", is(not(blankString())))
           .body("errors[1].exceptionClass", is("JsonParseException"));
+    }
+
+    @Test
+    public void unknownCommand() {
+      String json =
+          """
+                  {
+                    "unknownCommand": {
+                    }
+                  }
+                  """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors[0].message", startsWith("Could not resolve type id 'unknownCommand'"))
+          .body("errors[0].exceptionClass", is("InvalidTypeIdException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
@@ -5,6 +5,7 @@ import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -169,6 +170,28 @@ class GeneralResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .body("errors[0].exceptionClass", is("WebApplicationException"))
           .body("errors[1].message", is(not(blankString())))
           .body("errors[1].exceptionClass", is("JsonParseException"));
+    }
+
+    @Test
+    public void unknownCommand() {
+      String json =
+          """
+                  {
+                    "unknownCommand": {
+                    }
+                  }
+                  """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("errors[0].message", startsWith("Could not resolve type id 'unknownCommand'"))
+          .body("errors[0].exceptionClass", is("InvalidTypeIdException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
@@ -5,6 +5,7 @@ import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -87,6 +88,28 @@ class NamespaceResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .body("errors[0].exceptionClass", is("WebApplicationException"))
           .body("errors[1].message", is(not(blankString())))
           .body("errors[1].exceptionClass", is("JsonParseException"));
+    }
+
+    @Test
+    public void unknownCommand() {
+      String json =
+          """
+                  {
+                    "unknownCommand": {
+                    }
+                  }
+                  """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(NamespaceResource.BASE_PATH, keyspaceId.asInternal())
+          .then()
+          .statusCode(200)
+          .body("errors[0].message", startsWith("Could not resolve type id 'unknownCommand'"))
+          .body("errors[0].exceptionClass", is("InvalidTypeIdException"));
     }
 
     @Test


### PR DESCRIPTION
Override the Quarkus mapper for the `MismatchedInputException`. When sending unknown command, we get now:

```
$ curl -X 'POST' \
>   'http://localhost:8080/v1' \
>   -H 'accept: application/json' \
>   -H 'X-Cassandra-Token: asdasda' \
>   -H 'Content-Type: application/json' \
>   -d '{
>   "serveBeer": {
>     "name": "cycling"
>   }
> }' -v | jq
Note: Unnecessary use of -X or --request, POST is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /v1 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> accept: application/json
> X-Cassandra-Token: asdasda
> Content-Type: application/json
> Content-Length: 46
> 
} [46 bytes data]
* upload completely sent off: 46 out of 46 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json;charset=UTF-8
< content-length: 372
< 
{ [372 bytes data]
100   418  100   372  100    46  41333   5111 --:--:-- --:--:-- --:--:-- 46444
* Connection #0 to host localhost left intact
{
  "errors": [
    {
      "message": "Could not resolve type id 'serveBeer' as a subtype of `io.stargate.sgv2.jsonapi.api.model.command.GeneralCommand`: known type ids = [createCollection, createNamespace, deleteOne, find, findOne, findOneAndUpdate, insertMany, insertOne, updateOne]\n at [Source: (ByteArrayInputStream); line: 2, column: 3]",
      "exceptionClass": "InvalidTypeIdException"
    }
  ]
}

```