### PR TITLE
Fix #713: change max-String-value length from 16,000 to 8,000

### DIFF
--- a/docs/jsonapi-spec.md
+++ b/docs/jsonapi-spec.md
@@ -408,16 +408,14 @@ has 3 fields: `root`, `root.branch`, and `root.branch.leaf`, for purposes of thi
 
 The maximum size of field values are:
 
-| JSON Type | Maximum Value                               |
-|-----------|---------------------------------------------|
-| `string`  | Maximum length of 16,000 unicode characters |
-| `number`  | Maximum length of 50 number characters      |
-
+| JSON Type | Maximum Value                              |
+|-----------|--------------------------------------------|
+| `string`  | Maximum length of 8,000 unicode characters |
+| `number`  | Maximum length of 50 number characters     |
 
 #### Document Array Limits
 
 The maximum length of an array is 100 elements.
-
 
 ### Equality handling with arrays and subdocs
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -39,8 +39,11 @@ public interface DocumentLimitsConfig {
   /** Defines the maximum length of property names in JSON documents */
   int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 48;
 
-  /** Defines the default maximum length of a single String value */
-  int DEFAULT_MAX_STRING_LENGTH = 16_000;
+  /**
+   * Defines the default maximum length of a single String value: 8,000 characters with 1.0.0-BETA-6
+   * and later (16,000 before)
+   */
+  int DEFAULT_MAX_STRING_LENGTH = 8_000;
 
   /**
    * @return Defines the maximum document size, defaults to {@code 1 meg} (1 million characters).

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -44,8 +44,8 @@ public class ShredderDocLimitsTest {
     @Test
     public void catchTooBigDoc() {
       // Let's construct document above 1 meg limit (but otherwise legal), with
-      // 100 x 10k String values, divided in 10 sub documents of 10 properties
-      final ObjectNode bigDoc = createBigDoc(10, 10);
+      // 144 x 7.5k String values, divided in 12 sub documents of 12 properties
+      final ObjectNode bigDoc = createBigDoc(12, 12);
 
       Exception e = catchException(() -> shredder.shred(bigDoc));
       assertThat(e)
@@ -63,7 +63,7 @@ public class ShredderDocLimitsTest {
       for (int ix1 = 0; ix1 < mainProps; ++ix1) {
         ObjectNode mainProp = bigDoc.putObject("prop" + ix1);
         for (int ix2 = 0; ix2 < subProps; ++ix2) {
-          mainProp.put("sub" + ix2, RandomStringUtils.randomAscii(10_000));
+          mainProp.put("sub" + ix2, RandomStringUtils.randomAscii(7_500));
         }
       }
       return bigDoc;
@@ -243,7 +243,7 @@ public class ShredderDocLimitsTest {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       // Max is 16_000 so do a bit less
-      doc.put("text", RandomStringUtils.randomAscii(12_000));
+      doc.put("text", RandomStringUtils.randomAscii(7_500));
       assertThat(shredder.shred(doc)).isNotNull();
     }
 


### PR DESCRIPTION
**What this PR does**:

Reduces maximum (indexed) String value length down to 8,000 characters from 16,000 characters, as needed to work with SAI limits (to be raised to 8k)

**Which issue(s) this PR fixes**:
Fixes #713

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
