### PR TITLE
circular reference fix and add operationId for each path

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
     example = """
              {"name": "Aaron", "country": "US"}
               """)
-public record FilterClause(LogicalExpression logicalExpression) {
+public record FilterClause(@Schema(hidden = true) LogicalExpression logicalExpression) {
   public void validate(CommandContext commandContext) {
     DocumentProjector indexingProjector = commandContext.indexingProjector();
     // If nothing specified, everything indexed

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -72,7 +72,8 @@ public class CollectionResource {
 
   @Operation(
       summary = "Execute command",
-      description = "Executes a single command against a collection.")
+      description = "Executes a single command against a collection.",
+      operationId = "collection operation")
   @Parameters(
       value = {
         @Parameter(name = "namespace", ref = "namespace"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
@@ -43,7 +43,10 @@ public class GeneralResource {
     this.meteredCommandProcessor = meteredCommandProcessor;
   }
 
-  @Operation(summary = "Execute command", description = "Executes a single general command.")
+  @Operation(
+      summary = "Execute command",
+      description = "Executes a single general command.",
+      operationId = "general operation")
   @RequestBody(
       content =
           @Content(

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResource.java
@@ -52,7 +52,8 @@ public class NamespaceResource {
 
   @Operation(
       summary = "Execute command",
-      description = "Executes a single command against a collection.")
+      description = "Executes a single command against a collection.",
+      operationId = "namespace operation")
   @Parameters(value = {@Parameter(name = "namespace", ref = "namespace")})
   @RequestBody(
       content =


### PR DESCRIPTION
One issue we have for data api OpenAPI spec is that logicalExpression has circular reference, which will cause OpenAPI spec validation failure.
Also add operationId for each path.
- /v1
- /v1/{namespace}
- /v1/{namespace}/{collection}

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
