### PR TITLE
Expose vector dimensions in `findEmbeddingProviders`

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/PropertyBasedEmbeddingProviderConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/PropertyBasedEmbeddingProviderConfig.java
@@ -62,6 +62,9 @@ public interface PropertyBasedEmbeddingProviderConfig {
       String name();
 
       @JsonProperty
+      Integer vectorDimension();
+
+      @JsonProperty
       List<ParameterConfig> parameters();
 
       @JsonProperty

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindEmbeddingProvidersOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindEmbeddingProvidersOperation.java
@@ -91,7 +91,8 @@ public record FindEmbeddingProvidersOperation(
       ArrayList<ModelConfigResponse> modelsRemoveProperties = new ArrayList<>();
       for (PropertyBasedEmbeddingProviderConfig.EmbeddingProviderConfig.ModelConfig model :
           embeddingProviderConfig.models()) {
-        ModelConfigResponse returnModel = new ModelConfigResponse(model.name(), model.parameters());
+        ModelConfigResponse returnModel =
+            new ModelConfigResponse(model.name(), model.vectorDimension(), model.parameters());
         modelsRemoveProperties.add(returnModel);
       }
       return new EmbeddingProviderResponse(
@@ -108,10 +109,12 @@ public record FindEmbeddingProvidersOperation(
    * timeout etc.).
    *
    * @param name Identifier name of the model.
+   * @param vectorDimension vector dimension of the model.
    * @param parameters Parameters for customizing the model.
    */
   private record ModelConfigResponse(
       String name,
+      Integer vectorDimension,
       List<PropertyBasedEmbeddingProviderConfig.EmbeddingProviderConfig.ParameterConfig>
           parameters) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -369,7 +369,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
                         "Model name '%s' for provider '%s' is not supported",
                         userConfig.modelName(), userConfig.provider()));
 
-    Integer configVectorDimension = Integer.parseInt(model.properties().get("vector-dimension"));
+    Integer configVectorDimension = model.vectorDimension();
     if (userVectorDimension == null) {
       return configVectorDimension; // Use config dimension if user didn't provide one
     } else if (!configVectorDimension.equals(userVectorDimension)) {

--- a/src/main/resources/embedding-providers-config.yaml
+++ b/src/main/resources/embedding-providers-config.yaml
@@ -12,14 +12,11 @@ stargate:
             - "HEADER"
           models:
             - name: text-embedding-3-small
-              properties:
-                vector-dimension: 1536
+              vector-dimension: 1536
             - name: text-embedding-3-large
-              properties:
-                vector-dimension: 3072
+              vector-dimension: 3072
             - name: text-embedding-ada-002
-              properties:
-                vector-dimension: 1536
+              vector-dimension: 1536
 
         # Hugging face embedding service configuration
         huggingface:
@@ -30,8 +27,7 @@ stargate:
             - "HEADER"
           models:
             - name: sentence-transformers/all-MiniLM-L6-v2
-              properties:
-                vector-dimension: 384
+              vector-dimension: 384
 
         # Vertex AI embedding service configuration
         vertexai:
@@ -50,6 +46,7 @@ stargate:
             timeout-ms: 1000
           models:
             - name: textembedding-gecko@003
+              vector-dimension: 768
               parameters:
                 - name: "autoTruncate"
                   type: BOOLEAN
@@ -57,7 +54,7 @@ stargate:
                   default-value: true
               properties:
                 max-tokens: 3072
-                vector-dimension: 768
+
 
 
         # Cohere embedding service configuration
@@ -69,11 +66,9 @@ stargate:
             - "HEADER"
           models:
             - name: embed-english-v3.0
-              properties:
-                vector-dimension: 1024
+              vector-dimension: 1024
             - name: embed-english-v2.0
-              properties:
-                vector-dimension: 4096
+              vector-dimension: 4096
 
         # NVidia embedding service configuration
         nvidia:
@@ -84,10 +79,10 @@ stargate:
             - "HEADER"
           models:
             - name: NVIDIA Retrieval QA Embedding Model-1.0
+              vector-dimension: 1024
               properties:
-                vector-dimension: 1024
                 max-tokens: 512
             - name: NV-Embed-QA
+              vector-dimension: 1024
               properties:
-                vector-dimension: 1024
                 max-tokens: 512

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindEmbeddingProvidersIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindEmbeddingProvidersIntegrationTest.java
@@ -38,7 +38,9 @@ public class FindEmbeddingProvidersIntegrationTest extends AbstractNamespaceInte
           .post(GeneralResource.BASE_PATH)
           .then()
           .statusCode(200)
-          .body("status.embeddingProviders", notNullValue());
+          .body("status.embeddingProviders", notNullValue())
+          .body("status.embeddingProviders.nvidia.url", notNullValue())
+          .body("status.embeddingProviders.nvidia.models[0].vectorDimension", equalTo(1024));
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Expose vector dimensions in `findEmbeddingProviders`. The sample return body is like:
```
{
    "status": {
        "embeddingProviders": {
            "cohere": {
                "url": "https://api.cohere.ai/v1/",
                "supportedAuthentication": [
                    "HEADER"
                ],
                "parameters": [],
                "models": [
                    {
                        "name": "embed-english-v3.0",
                        "vectorDimension": 1024,
                        "parameters": []
                    },
                    {
                        "name": "embed-english-v2.0",
                        "vectorDimension": 4096,
                        "parameters": []
                    }
                ]
            }
        }
    }
}  
```

**Which issue(s) this PR fixes**:
Fixes #969 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
