### PR TITLE
Add metrics for vectorize call

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
@@ -71,8 +71,8 @@ public interface JsonApiMetricsConfig {
   String metricsName();
 
   @NotBlank
-  @WithDefault("vectorize.external.call.duration")
-  String vectorizeExternalCallDurationMetrics();
+  @WithDefault("vectorize.call.duration")
+  String vectorizeCallDurationMetrics();
 
   @NotBlank
   @WithDefault("vectorize.input.bytes")

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
@@ -75,6 +75,10 @@ public interface JsonApiMetricsConfig {
   String vectorizeTimerMetrics();
 
   @NotBlank
+  @WithDefault("vectorize.string.bytes")
+  String vectorizeStringBytesMetrics();
+
+  @NotBlank
   @WithDefault("embedding.provider")
   String embeddingProvider();
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
@@ -71,12 +71,12 @@ public interface JsonApiMetricsConfig {
   String metricsName();
 
   @NotBlank
-  @WithDefault("vectorize.time")
-  String vectorizeTimerMetrics();
+  @WithDefault("vectorize.external.call.duration")
+  String vectorizeExternalCallDurationMetrics();
 
   @NotBlank
-  @WithDefault("vectorize.string.bytes")
-  String vectorizeStringBytesMetrics();
+  @WithDefault("vectorize.input.bytes")
+  String vectorizeInputBytesMetrics();
 
   @NotBlank
   @WithDefault("embedding.provider")

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
@@ -70,6 +70,14 @@ public interface JsonApiMetricsConfig {
   @WithDefault("command.processor.process")
   String metricsName();
 
+  @NotBlank
+  @WithDefault("vectorize.time")
+  String vectorizeTimerMetrics();
+
+  @NotBlank
+  @WithDefault("embedding.provider")
+  String embeddingProvider();
+
   /** List of values that can be used as value for metrics sort_type. */
   enum SortType {
     // Uses vertor search sorting for document resolution

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
@@ -252,6 +252,6 @@ public interface OperationsConfig {
     }
   }
   /** @return Flag to enable server side vectorization. */
-  @WithDefault("true")
+  @WithDefault("false")
   boolean vectorizeEnabled();
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
@@ -252,6 +252,6 @@ public interface OperationsConfig {
     }
   }
   /** @return Flag to enable server side vectorization. */
-  @WithDefault("false")
+  @WithDefault("true")
   boolean vectorizeEnabled();
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -11,11 +11,11 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A {@link RequestScoped} provider for embedding operations that includes metrics tracking.
- * It wraps around another {@code EmbeddingProvider} to add monitoring of operation times,
- * input sizes, and other relevant metrics using a {@link MeterRegistry}. This provider
- * is designed to operate within the context of a request, collecting and reporting metrics
- * specific to embedding operations.
+ * A {@link RequestScoped} provider for embedding operations that includes metrics tracking. It
+ * wraps around another {@code EmbeddingProvider} to add monitoring of operation times, input sizes,
+ * and other relevant metrics using a {@link MeterRegistry}. This provider is designed to operate
+ * within the context of a request, collecting and reporting metrics specific to embedding
+ * operations.
  */
 @RequestScoped
 public class MeteredEmbeddingProvider implements EmbeddingProvider {
@@ -44,7 +44,7 @@ public class MeteredEmbeddingProvider implements EmbeddingProvider {
    * Sets the underlying embedding client and the command name for metrics tagging.
    *
    * @param embeddingClient The embedding provider client to be used for vectorization.
-   * @param commandName     The name of the command, for metrics tagging purposes.
+   * @param commandName The name of the command, for metrics tagging purposes.
    * @return The current instance of {@link MeteredEmbeddingProvider}, allowing for method chaining.
    */
   public MeteredEmbeddingProvider setEmbeddingClient(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -1,0 +1,68 @@
+package io.stargate.sgv2.jsonapi.service.embedding.operation;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.api.common.config.MetricsConfig;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
+import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+@ApplicationScoped
+public class MeteredEmbeddingProvider implements EmbeddingProvider {
+  MeterRegistry meterRegistry;
+  JsonApiMetricsConfig jsonApiMetricsConfig;
+  DataApiRequestInfo dataApiRequestInfo;
+  private static final String UNKNOWN_VALUE = "unknown";
+  private final MetricsConfig.TenantRequestCounterConfig tenantConfig;
+  EmbeddingProvider embeddingClient;
+
+  String commandName;
+
+  @Inject
+  public MeteredEmbeddingProvider(
+      MeterRegistry meterRegistry,
+      JsonApiMetricsConfig jsonApiMetricsConfig,
+      DataApiRequestInfo dataApiRequestInfo,
+      MetricsConfig metricsConfig) {
+    this.meterRegistry = meterRegistry;
+    this.jsonApiMetricsConfig = jsonApiMetricsConfig;
+    this.dataApiRequestInfo = dataApiRequestInfo;
+    tenantConfig = metricsConfig.tenantRequestCounter();
+  }
+
+  public MeteredEmbeddingProvider setEmbeddingClient(
+      EmbeddingProvider embeddingClient, String commandName) {
+    this.embeddingClient = embeddingClient;
+    this.commandName = commandName;
+    return this;
+  }
+
+  @Override
+  public Uni<List<float[]>> vectorize(
+      List<String> texts,
+      Optional<String> apiKeyOverride,
+      EmbeddingRequestType embeddingRequestType) {
+    Timer.Sample sample = Timer.start(meterRegistry);
+    Uni<List<float[]>> result =
+        embeddingClient.vectorize(texts, apiKeyOverride, embeddingRequestType);
+    Tags tags = getCustomTags();
+    sample.stop(meterRegistry.timer(jsonApiMetricsConfig.vectorizeTimerMetrics(), tags));
+    return result;
+  }
+
+  private Tags getCustomTags() {
+    Tag commandTag = Tag.of(jsonApiMetricsConfig.command(), commandName);
+    Tag tenantTag =
+        Tag.of(tenantConfig.tenantTag(), dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE));
+    Tag embeddingProviderTag =
+        Tag.of(
+            jsonApiMetricsConfig.embeddingProvider(), embeddingClient.getClass().getSimpleName());
+    return Tags.of(commandTag, tenantTag, embeddingProviderTag);
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -5,55 +5,48 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.api.common.config.MetricsConfig;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * A {@link RequestScoped} provider for embedding operations that includes metrics tracking. It
- * wraps around another {@code EmbeddingProvider} to add monitoring of operation times, input sizes,
- * and other relevant metrics using a {@link MeterRegistry}. This provider is designed to operate
- * within the context of a request, collecting and reporting metrics specific to embedding
- * operations.
+ * Provides a metered version of an {@link EmbeddingProvider}, adding metrics collection to the
+ * embedding process. This class is designed to wrap around an existing {@link EmbeddingProvider} to
+ * collect and report various metrics, such as the duration of vectorization calls and the size of
+ * input texts.
  */
-@RequestScoped
 public class MeteredEmbeddingProvider implements EmbeddingProvider {
-  MeterRegistry meterRegistry;
-  JsonApiMetricsConfig jsonApiMetricsConfig;
-  DataApiRequestInfo dataApiRequestInfo;
+  private final MeterRegistry meterRegistry;
+  private final JsonApiMetricsConfig jsonApiMetricsConfig;
+  private final DataApiRequestInfo dataApiRequestInfo;
   private static final String UNKNOWN_VALUE = "unknown";
   private final MetricsConfig.TenantRequestCounterConfig tenantConfig;
-  EmbeddingProvider embeddingClient;
+  private final EmbeddingProvider embeddingProvider;
+  private final String commandName;
 
-  String commandName;
-
-  @Inject
   public MeteredEmbeddingProvider(
       MeterRegistry meterRegistry,
       JsonApiMetricsConfig jsonApiMetricsConfig,
       DataApiRequestInfo dataApiRequestInfo,
-      MetricsConfig metricsConfig) {
+      MetricsConfig metricsConfig,
+      EmbeddingProvider embeddingProvider,
+      String commandName) {
     this.meterRegistry = meterRegistry;
     this.jsonApiMetricsConfig = jsonApiMetricsConfig;
     this.dataApiRequestInfo = dataApiRequestInfo;
     tenantConfig = metricsConfig.tenantRequestCounter();
+    this.embeddingProvider = embeddingProvider;
+    this.commandName = commandName;
   }
 
   /**
-   * Sets the underlying embedding client and the command name for metrics tagging.
+   * Vectorizes a list of texts, adding metrics collection for the duration of the vectorization
+   * call and the size of the input texts.
    *
-   * @param embeddingClient The embedding provider client to be used for vectorization.
-   * @param commandName The name of the command, for metrics tagging purposes.
-   * @return The current instance of {@link MeteredEmbeddingProvider}, allowing for method chaining.
+   * @param texts the list of texts to vectorize.
+   * @param apiKeyOverride optional API key to override any default authentication mechanism.
+   * @param embeddingRequestType the type of embedding request, influencing how texts are processed.
+   * @return a {@link Uni} that will provide the list of vectorized texts, as arrays of floats.
    */
-  public MeteredEmbeddingProvider setEmbeddingClient(
-      EmbeddingProvider embeddingClient, String commandName) {
-    this.embeddingClient = embeddingClient;
-    this.commandName = commandName;
-    return this;
-  }
-
   @Override
   public Uni<List<float[]>> vectorize(
       List<String> texts,
@@ -62,7 +55,7 @@ public class MeteredEmbeddingProvider implements EmbeddingProvider {
     // timer metrics for vectorize call
     Timer.Sample sample = Timer.start(meterRegistry);
     Uni<List<float[]>> result =
-        embeddingClient.vectorize(texts, apiKeyOverride, embeddingRequestType);
+        embeddingProvider.vectorize(texts, apiKeyOverride, embeddingRequestType);
     Tags tags = getCustomTags();
     sample.stop(meterRegistry.timer(jsonApiMetricsConfig.vectorizeCallDurationMetrics(), tags));
 
@@ -75,13 +68,19 @@ public class MeteredEmbeddingProvider implements EmbeddingProvider {
     return result;
   }
 
+  /**
+   * Generates custom tags for metrics based on the command name, tenant ID, and the name of the
+   * embedding provider.
+   *
+   * @return a collection of {@link Tag} instances for use with metrics.
+   */
   private Tags getCustomTags() {
     Tag commandTag = Tag.of(jsonApiMetricsConfig.command(), commandName);
     Tag tenantTag =
         Tag.of(tenantConfig.tenantTag(), dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE));
     Tag embeddingProviderTag =
         Tag.of(
-            jsonApiMetricsConfig.embeddingProvider(), embeddingClient.getClass().getSimpleName());
+            jsonApiMetricsConfig.embeddingProvider(), embeddingProvider.getClass().getSimpleName());
     return Tags.of(commandTag, tenantTag, embeddingProviderTag);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -292,8 +292,7 @@ public class MeteredCommandProcessor {
             || id.getName().startsWith(jsonApiMetricsConfig.jsonBytesRead())
             || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsWritten())
             || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsRead())
-            || id.getName()
-                .startsWith(jsonApiMetricsConfig.vectorizeExternalCallDurationMetrics())) {
+            || id.getName().startsWith(jsonApiMetricsConfig.vectorizeCallDurationMetrics())) {
 
           return DistributionStatisticConfig.builder()
               .percentiles(0.5, 0.90, 0.95, 0.99) // median and 95th percentile, not aggregable

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -292,8 +292,9 @@ public class MeteredCommandProcessor {
             || id.getName().startsWith(jsonApiMetricsConfig.jsonBytesRead())
             || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsWritten())
             || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsRead())
-            || id.getName().startsWith(jsonApiMetricsConfig.vectorizeTimerMetrics())
-            || id.getName().startsWith(jsonApiMetricsConfig.vectorizeStringBytesMetrics())) {
+            || id.getName()
+                .startsWith(jsonApiMetricsConfig.vectorizeExternalCallDurationMetrics())) {
+
           return DistributionStatisticConfig.builder()
               .percentiles(0.5, 0.90, 0.95, 0.99) // median and 95th percentile, not aggregable
               .percentilesHistogram(true) // histogram buckets (e.g. prometheus histogram_quantile)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -291,7 +291,9 @@ public class MeteredCommandProcessor {
             || id.getName().startsWith(jsonApiMetricsConfig.jsonBytesWritten())
             || id.getName().startsWith(jsonApiMetricsConfig.jsonBytesRead())
             || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsWritten())
-            || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsRead())) {
+            || id.getName().startsWith(jsonApiMetricsConfig.jsonDocsRead())
+            || id.getName().startsWith(jsonApiMetricsConfig.vectorizeTimerMetrics())
+            || id.getName().startsWith(jsonApiMetricsConfig.vectorizeStringBytesMetrics())) {
           return DistributionStatisticConfig.builder()
               .percentiles(0.5, 0.90, 0.95, 0.99) // median and 95th percentile, not aggregable
               .percentilesHistogram(true) // histogram buckets (e.g. prometheus histogram_quantile)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -153,18 +153,18 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
 
       // verify the metrics
       String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
-      List<String> vectorizeExternalCallDurationMetrics =
+      List<String> vectorizeCallDurationMetrics =
           metrics
               .lines()
               .filter(
                   line ->
-                      line.startsWith("vectorize_external_call_duration_seconds")
-                          && !line.startsWith("vectorize_external_call_duration_seconds_bucket")
+                      line.startsWith("vectorize_call_duration_seconds")
+                          && !line.startsWith("vectorize_call_duration_seconds_bucket")
                           && !line.contains("quantile")
                           && line.contains("command=\"InsertOneCommand\""))
               .toList();
 
-      assertThat(vectorizeExternalCallDurationMetrics)
+      assertThat(vectorizeCallDurationMetrics)
           .satisfies(
               lines -> {
                 assertThat(lines.size()).isEqualTo(3);
@@ -390,18 +390,18 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
 
       // verify the metrics
       String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
-      List<String> vectorizeExternalCallDurationMetrics =
+      List<String> vectorizeCallDurationMetrics =
           metrics
               .lines()
               .filter(
                   line ->
-                      line.startsWith("vectorize_external_call_duration_seconds")
-                          && !line.startsWith("vectorize_external_call_duration_seconds_bucket")
+                      line.startsWith("vectorize_call_duration_seconds")
+                          && !line.startsWith("vectorize_call_duration_seconds_bucket")
                           && !line.contains("quantile")
                           && line.contains("command=\"InsertManyCommand\""))
               .toList();
 
-      assertThat(vectorizeExternalCallDurationMetrics)
+      assertThat(vectorizeCallDurationMetrics)
           .satisfies(
               lines -> {
                 lines.forEach(
@@ -1078,18 +1078,18 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
 
       // verify the metrics
       String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
-      List<String> vectorizeExternalCallDurationMetrics =
+      List<String> vectorizeCallDurationMetrics =
           metrics
               .lines()
               .filter(
                   line ->
-                      line.startsWith("vectorize_external_call_duration_seconds")
-                          && !line.startsWith("vectorize_external_call_duration_seconds_bucket")
+                      line.startsWith("vectorize_call_duration_seconds")
+                          && !line.startsWith("vectorize_call_duration_seconds_bucket")
                           && !line.contains("quantile")
                           && line.contains("command=\"FindOneAndReplaceCommand\""))
               .toList();
 
-      assertThat(vectorizeExternalCallDurationMetrics)
+      assertThat(vectorizeCallDurationMetrics)
           .satisfies(
               lines -> {
                 assertThat(lines.size()).isEqualTo(3);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -11,6 +12,7 @@ import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.test.CustomITEmbeddingProvider;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
@@ -148,6 +150,69 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .body("status.insertedIds[0]", is("1"))
           .body("data", is(nullValue()))
           .body("errors", is(nullValue()));
+
+      // verify the metrics
+      String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
+      List<String> vectorizeExternalCallDurationMetrics =
+          metrics
+              .lines()
+              .filter(
+                  line ->
+                      line.startsWith("vectorize_external_call_duration_seconds")
+                          && !line.startsWith("vectorize_external_call_duration_seconds_bucket")
+                          && !line.contains("quantile")
+                          && line.contains("command=\"InsertOneCommand\""))
+              .toList();
+
+      assertThat(vectorizeExternalCallDurationMetrics)
+          .satisfies(
+              lines -> {
+                assertThat(lines.size()).isEqualTo(3);
+                lines.forEach(
+                    line -> {
+                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("module=\"sgv2-jsonapi\"");
+                      assertThat(line).contains("tenant=\"unknown\"");
+
+                      if (line.contains("_count")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(1.0);
+                      }
+                    });
+              });
+
+      List<String> vectorizeInputBytesMetrics =
+          metrics.lines().filter(line -> line.startsWith("vectorize_input_bytes")).toList();
+      assertThat(vectorizeInputBytesMetrics)
+          .satisfies(
+              lines -> {
+                assertThat(lines.size()).isEqualTo(3);
+                lines.forEach(
+                    line -> {
+                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("module=\"sgv2-jsonapi\"");
+                      assertThat(line).contains("tenant=\"unknown\"");
+
+                      if (line.contains("_count")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(1.0);
+                      }
+
+                      if (line.contains("_sum")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(44.0);
+                      }
+                    });
+              });
 
       given()
           .headers(
@@ -322,6 +387,74 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .body("status.insertedIds[1]", is("3"))
           .body("data", is(nullValue()))
           .body("errors", is(nullValue()));
+
+      // verify the metrics
+      String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
+      List<String> vectorizeExternalCallDurationMetrics =
+          metrics
+              .lines()
+              .filter(
+                  line ->
+                      line.startsWith("vectorize_external_call_duration_seconds")
+                          && !line.startsWith("vectorize_external_call_duration_seconds_bucket")
+                          && !line.contains("quantile")
+                          && line.contains("command=\"InsertManyCommand\""))
+              .toList();
+
+      assertThat(vectorizeExternalCallDurationMetrics)
+          .satisfies(
+              lines -> {
+                lines.forEach(
+                    line -> {
+                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("module=\"sgv2-jsonapi\"");
+                      assertThat(line).contains("tenant=\"unknown\"");
+
+                      if (line.contains("_count")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(1.0);
+                      }
+                    });
+              });
+
+      List<String> vectorizeInputBytesMetrics =
+          metrics
+              .lines()
+              .filter(
+                  line ->
+                      line.startsWith("vectorize_input_bytes")
+                          && line.contains("command=\"InsertManyCommand\""))
+              .toList();
+      assertThat(vectorizeInputBytesMetrics)
+          .satisfies(
+              lines -> {
+                assertThat(lines.size()).isEqualTo(3);
+                lines.forEach(
+                    line -> {
+                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("module=\"sgv2-jsonapi\"");
+                      assertThat(line).contains("tenant=\"unknown\"");
+
+                      if (line.contains("_count")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(2.0);
+                      }
+
+                      if (line.contains("_sum")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(84.0);
+                      }
+                    });
+              });
 
       json =
           """
@@ -942,6 +1075,75 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(1))
           .body("errors", is(nullValue()));
+
+      // verify the metrics
+      String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
+      List<String> vectorizeExternalCallDurationMetrics =
+          metrics
+              .lines()
+              .filter(
+                  line ->
+                      line.startsWith("vectorize_external_call_duration_seconds")
+                          && !line.startsWith("vectorize_external_call_duration_seconds_bucket")
+                          && !line.contains("quantile")
+                          && line.contains("command=\"FindOneAndReplaceCommand\""))
+              .toList();
+
+      assertThat(vectorizeExternalCallDurationMetrics)
+          .satisfies(
+              lines -> {
+                assertThat(lines.size()).isEqualTo(3);
+                lines.forEach(
+                    line -> {
+                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("module=\"sgv2-jsonapi\"");
+                      assertThat(line).contains("tenant=\"unknown\"");
+
+                      if (line.contains("_count")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(2.0);
+                      }
+                    });
+              });
+
+      List<String> vectorizeInputBytesMetrics =
+          metrics
+              .lines()
+              .filter(
+                  line ->
+                      line.startsWith("vectorize_input_bytes")
+                          && line.contains("command=\"FindOneAndReplaceCommand\""))
+              .toList();
+      assertThat(vectorizeInputBytesMetrics)
+          .satisfies(
+              lines -> {
+                assertThat(lines.size()).isEqualTo(3);
+                lines.forEach(
+                    line -> {
+                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("module=\"sgv2-jsonapi\"");
+                      assertThat(line).contains("tenant=\"unknown\"");
+
+                      if (line.contains("_count")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(2.0);
+                      }
+
+                      if (line.contains("_sum")) {
+                        String[] parts = line.split(" ");
+                        String numericPart =
+                            parts[parts.length - 1]; // Get the last part which should be the number
+                        double value = Double.parseDouble(numericPart);
+                        assertThat(value).isEqualTo(61.0);
+                      }
+                    });
+              });
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -417,7 +417,6 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       assertThat(jsonDocsWrittenCountMetrics).hasSize(1);
       jsonDocsWrittenCountMetrics.forEach(
           line -> {
-            System.out.println(line);
             String[] parts = line.split(" ");
             String numericPart =
                 parts[parts.length - 1]; // Get the last part which should be the number


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add vectorize metrics :
1. number of calls
2. String size in bytes
3. timer/histogram for calls to NeMo or other third-party providers


**Which issue(s) this PR fixes**:
Fixes [Jira C2-3308](https://datastax.jira.com/browse/C2-3308)

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
