### PR TITLE
fix $not with $size 0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,14 +108,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push (Docker Hub)
+      - name: Build data-api image and push (Docker Hub)
         if: ${{ !inputs.skipPublish }}
         run: |
-          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 ${{ matrix.profile }}
-          docker push stargateio/data-api:${{needs.resolve-tag.outputs.release-tag}}
-          docker push stargateio/jsonapi:${{needs.resolve-tag.outputs.release-tag}}
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true  -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}} -Dquarkus.container-image.name=data-api ${{ matrix.profile }}
 
-     
+      - name: Build jsonapi image and push (Docker Hub)
+        if: ${{ !inputs.skipPublish }}
+        run: |
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true  -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}} -Dquarkus.container-image.name=jsonapi ${{ matrix.profile }}
 
   # publishes the docker image to ecr
   publish-image-ecr:

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpression.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpression.java
@@ -37,10 +37,10 @@ public class ComparisonExpression {
   public void flip() {
     List<FilterOperation<?>> filterOperations = new ArrayList<>(this.filterOperations.size());
     for (FilterOperation<?> filterOperation : this.filterOperations) {
-      final FilterOperator flipedOperator = filterOperation.operator().flip();
+      final FilterOperator flippedOperator = filterOperation.operator().flip();
       JsonLiteral<?> operand =
           getFlippedOperandValue(filterOperation.operator(), filterOperation.operand());
-      filterOperations.add(new ValueComparisonOperation<>(flipedOperator, operand));
+      filterOperations.add(new ValueComparisonOperation<>(flippedOperator, operand));
     }
     this.filterOperations = filterOperations;
   }
@@ -52,6 +52,10 @@ public class ComparisonExpression {
     if (operator == ElementComparisonOperator.EXISTS) {
       return new JsonLiteral<Boolean>(!((Boolean) operand.value()), operand.type());
     } else if (operator == ArrayComparisonOperator.SIZE) {
+      // for negating 0, will set BigDecimal -1.5 as flag
+      if (((BigDecimal) operand.value()).equals(BigDecimal.ZERO)) {
+        return new JsonLiteral<BigDecimal>(JsonLiteral.NEGATE_ZERO, operand.type());
+      }
       return new JsonLiteral<BigDecimal>(((BigDecimal) operand.value()).negate(), operand.type());
     } else {
       return operand;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpression.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpression.java
@@ -52,9 +52,10 @@ public class ComparisonExpression {
     if (operator == ElementComparisonOperator.EXISTS) {
       return new JsonLiteral<Boolean>(!((Boolean) operand.value()), operand.type());
     } else if (operator == ArrayComparisonOperator.SIZE) {
-      // for negating 0, will set BigDecimal -1.5 as flag
       if (((BigDecimal) operand.value()).equals(BigDecimal.ZERO)) {
-        return new JsonLiteral<BigDecimal>(JsonLiteral.NEGATE_ZERO, operand.type());
+        // This is the special case, e.g. {"$not":{"ages":{"$size":0}}}
+        // A boolean value here means this is to negate size 0
+        return new JsonLiteral<Boolean>(true, operand.type());
       }
       return new JsonLiteral<BigDecimal>(((BigDecimal) operand.value()).negate(), operand.type());
     } else {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonLiteral.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonLiteral.java
@@ -1,17 +1,9 @@
 package io.stargate.sgv2.jsonapi.api.model.command.clause.filter;
 
 // Literal value to use as RHS operand in the query
-
-import java.math.BigDecimal;
-
 /**
  * @param value Literal value to use as RHS operand in the query
  * @param type Literal value type of the RHS operand in the query
  * @param <T> Data type of the object
  */
-public record JsonLiteral<T>(T value, JsonType type) {
-
-  // for negating 0, will set BigDecimal -0.5 as flag
-  // this is used when pushing down "$not" to {"$size":0}
-  public static final BigDecimal NEGATE_ZERO = new BigDecimal("-1.5");
-}
+public record JsonLiteral<T>(T value, JsonType type) {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonLiteral.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonLiteral.java
@@ -2,9 +2,16 @@ package io.stargate.sgv2.jsonapi.api.model.command.clause.filter;
 
 // Literal value to use as RHS operand in the query
 
+import java.math.BigDecimal;
+
 /**
  * @param value Literal value to use as RHS operand in the query
  * @param type Literal value type of the RHS operand in the query
  * @param <T> Data type of the object
  */
-public record JsonLiteral<T>(T value, JsonType type) {}
+public record JsonLiteral<T>(T value, JsonType type) {
+
+  // for negating 0, will set BigDecimal -0.5 as flag
+  // this is used when pushing down "$not" to {"$size":0}
+  public static final BigDecimal NEGATE_ZERO = new BigDecimal("-1.5");
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
@@ -230,6 +230,11 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
                   ErrorCode.INVALID_FILTER_EXPRESSION,
                   "$size operator must have integer value >= 0");
             }
+            // Check if the value is an integer by comparing its scale.
+            if (i.stripTrailingZeros().scale() > 0) {
+              throw new JsonApiException(
+                  ErrorCode.INVALID_FILTER_EXPRESSION, "$size operator must have an integer value");
+            }
           } else {
             throw new JsonApiException(
                 ErrorCode.INVALID_FILTER_EXPRESSION, "$size operator must have integer");

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
@@ -317,6 +317,10 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
           operator = DBFilterBase.MapFilterBase.Operator.MAP_EQUALS;
         } else {
           operator = DBFilterBase.MapFilterBase.Operator.MAP_NOT_EQUALS;
+          // special case for negating 0, reset size as 0 from -1.5, array_size[?] != 0
+          if (bigDecimal.equals(JsonLiteral.NEGATE_ZERO)) {
+            size = 0;
+          }
         }
         filters.add(
             new DBFilterBase.SizeFilter(captureExpression.path(), operator, Math.abs(size)));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
@@ -308,22 +308,25 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
       }
 
       if (captureExpression.marker() == SIZE_GROUP) {
-        BigDecimal bigDecimal = (BigDecimal) filterOperation.operand().value();
-        // Flipping size operator will multiply the value by -1
-        // Negative means check array_size[?] != ?
-        int size = bigDecimal.intValue();
-        DBFilterBase.MapFilterBase.Operator operator;
-        if (size >= 0) {
-          operator = DBFilterBase.MapFilterBase.Operator.MAP_EQUALS;
+        if (filterOperation.operand().value() instanceof Boolean) {
+          // This is the special case, e.g. {"$not":{"ages":{"$size":0}}}
+          filters.add(
+              new DBFilterBase.SizeFilter(
+                  captureExpression.path(), DBFilterBase.MapFilterBase.Operator.MAP_NOT_EQUALS, 0));
         } else {
-          operator = DBFilterBase.MapFilterBase.Operator.MAP_NOT_EQUALS;
-          // special case for negating 0, reset size as 0 from -1.5, array_size[?] != 0
-          if (bigDecimal.equals(JsonLiteral.NEGATE_ZERO)) {
-            size = 0;
+          BigDecimal bigDecimal = (BigDecimal) filterOperation.operand().value();
+          // Flipping size operator will multiply the value by -1
+          // Negative means check array_size[?] != ?
+          int size = bigDecimal.intValue();
+          DBFilterBase.MapFilterBase.Operator operator;
+          if (size >= 0) {
+            operator = DBFilterBase.MapFilterBase.Operator.MAP_EQUALS;
+          } else {
+            operator = DBFilterBase.MapFilterBase.Operator.MAP_NOT_EQUALS;
           }
+          filters.add(
+              new DBFilterBase.SizeFilter(captureExpression.path(), operator, Math.abs(size)));
         }
-        filters.add(
-            new DBFilterBase.SizeFilter(captureExpression.path(), operator, Math.abs(size)));
       }
 
       if (captureExpression.marker() == ARRAY_EQUALS) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -430,12 +430,82 @@ public class FilterClauseDeserializerTest {
     }
 
     @Test
+    public void mustHandleIntegerWithTrailingZeroSize() throws Exception {
+      String json = """
+          {"sizePath" : {"$size": 0.0}}
+        """;
+      final ComparisonExpression expectedResult =
+          new ComparisonExpression(
+              "sizePath",
+              List.of(
+                  new ValueComparisonOperation(
+                      ArrayComparisonOperator.SIZE,
+                      new JsonLiteral(new BigDecimal(0), JsonType.NUMBER))),
+              null);
+      FilterClause filterClause = objectMapper.readValue(json, FilterClause.class);
+      assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
+      assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(1);
+      assertThat(
+              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
+          .isEqualTo(expectedResult.getFilterOperations());
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
+          .isEqualTo(expectedResult.getPath());
+
+      String json1 = """
+          {"sizePath" : {"$size": 5.0}}
+        """;
+      final ComparisonExpression expectedResult1 =
+          new ComparisonExpression(
+              "sizePath",
+              List.of(
+                  new ValueComparisonOperation(
+                      ArrayComparisonOperator.SIZE,
+                      new JsonLiteral(new BigDecimal(5), JsonType.NUMBER))),
+              null);
+      FilterClause filterClause1 = objectMapper.readValue(json, FilterClause.class);
+      assertThat(filterClause1.logicalExpression().logicalExpressions).hasSize(0);
+      assertThat(filterClause1.logicalExpression().comparisonExpressions).hasSize(1);
+      assertThat(
+              filterClause1.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
+          .isEqualTo(expectedResult.getFilterOperations());
+      assertThat(filterClause1.logicalExpression().comparisonExpressions.get(0).getPath())
+          .isEqualTo(expectedResult.getPath());
+    }
+
+    @Test
     public void mustHandleSizeNonNumber() throws Exception {
       String json = """
           {"sizePath" : {"$size": "2"}}
         """;
       Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, FilterClause.class));
       assertThat(throwable)
+          .isInstanceOf(JsonApiException.class)
+          .satisfies(
+              t -> {
+                assertThat(t.getMessage()).isEqualTo("$size operator must have integer");
+              });
+    }
+
+    // Notice, 0.0, -0.0, 5.0, etc are still considered as Integer
+    @Test
+    public void mustHandleSizeNonInteger() throws Exception {
+      String json = """
+          {"sizePath" : {"$size": "1.1"}}
+        """;
+      Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, FilterClause.class));
+      assertThat(throwable)
+          .isInstanceOf(JsonApiException.class)
+          .satisfies(
+              t -> {
+                assertThat(t.getMessage()).isEqualTo("$size operator must have integer");
+              });
+
+      String json1 = """
+          {"sizePath" : {"$size": "5.4"}}
+        """;
+      Throwable throwable1 =
+          catchThrowable(() -> objectMapper.readValue(json1, FilterClause.class));
+      assertThat(throwable1)
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -930,6 +930,37 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
     }
 
     @Test
+    public void withSizeOperatorNotZero() {
+      String json =
+          """
+                  {
+                      "find": {
+                          "filter": {
+                              "$not": {
+                                  "tags": {
+                                      "$size": 0
+                                  }
+                              }
+                          }
+                      }
+                  }
+                      """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("errors", is(nullValue()))
+          // should have all the documents
+          .body("data.documents", hasSize(6));
+    }
+
+    @Test
     public void withEqOperatorArray() {
       String json =
           """


### PR DESCRIPTION
This filter should find all the documents with ages array size is not 0, or simply do not have ages array.

```
{
    "find": {
        "filter": {
            "$not": {
                "ages": {
                    "$size": 0
                }
            }
        }
    }
}
```
since we pushed down the $not logic by negating the size number, so, 0 * -1 still -1
FilterableResolver can not know the intention of doing a map_not_equal.

Methodology here, is to add validation first, that $size value should be integer.
Then, since we want to push down the $not info to the FilterableResolver, we need a flag to say this is negating 0.
I choose -1.5 as the flag, since 
- it is a negative number, meaning we have $not logic in it.
- it is not an integer, so will never be user's input, and we can reserve it as a flag indicating negating 0


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
