### PR TITLE
Fix #983: prevent serialization of "empty" defaultId in CollectionSet…

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
@@ -362,7 +362,6 @@ public record CollectionSettings(
 
   public static CreateCollectionCommand collectionSettingToCreateCollectionCommand(
       CollectionSettings collectionSetting) {
-    CreateCollectionCommand.Options options = null;
     CreateCollectionCommand.Options.VectorSearchConfig vectorSearchConfig = null;
     CreateCollectionCommand.Options.IndexingConfig indexingConfig = null;
     // construct the CreateCollectionCommand.options.vectorSearchConfig
@@ -412,13 +411,17 @@ public record CollectionSettings(
               Lists.newArrayList(collectionSetting.indexingConfig().allowed()),
               Lists.newArrayList(collectionSetting.indexingConfig().denied()));
     }
-    // construct the CreateCollectionCommand.options.idConfig
+    // construct the CreateCollectionCommand.options.idConfig -- but only if non-default IdType
+    final IdType idType = collectionSetting.idConfig().idType();
     CreateCollectionCommand.Options.IdConfig idConfig =
-        new CreateCollectionCommand.Options.IdConfig(collectionSetting.idConfig.idType.toString());
+        (idType == null || idType == IdType.UNDEFINED)
+            ? null
+            : new CreateCollectionCommand.Options.IdConfig(idType.toString());
 
-    options = new CreateCollectionCommand.Options(idConfig, vectorSearchConfig, indexingConfig);
     // CreateCollectionCommand object is created for convenience to generate json
     // response. The code is not creating a collection here.
-    return new CreateCollectionCommand(collectionSetting.collectionName(), options);
+    return new CreateCollectionCommand(
+        collectionSetting.collectionName(),
+        new CreateCollectionCommand.Options(idConfig, vectorSearchConfig, indexingConfig));
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
@@ -110,9 +110,6 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
                   {
                     "name": "%s",
                     "options": {
-                        "defaultId":{
-                          "type" : ""
-                      }
                     }
                   }
                     """
@@ -122,9 +119,6 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
               {
                   "name": "%s",
                   "options": {
-                      "defaultId":{
-                          "type" : ""
-                      },
                     "vector": {
                       "dimension": 5,
                       "metric": "cosine"
@@ -349,17 +343,15 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
           .statusCode(200)
           .body("status.ok", is(1));
 
-      String expected1 =
-          """
-      {"name":"TableName","options":{"defaultId" : {"type" : ""}}}
+      String expected1 = """
+      {"name":"TableName","options":{}}
       """;
-      String expected2 =
-          """
-              {"name":"collection1", "options":{"defaultId" : {"type" : ""}}}
+      String expected2 = """
+              {"name":"collection1", "options":{}}
               """;
       String expected3 =
           """
-      {"name":"collection2", "options": {"defaultId" : {"type" : ""}, "vector": {"dimension":5, "metric":"cosine"}, "indexing":{"deny":["comment"]}}}
+      {"name":"collection2", "options": {"vector": {"dimension":5, "metric":"cosine"}, "indexing":{"deny":["comment"]}}}
       """;
       String expected4 =
           """


### PR DESCRIPTION
**What this PR does**:

Filters out "empty" value for `defaultId`, for cases where user did not provide mechanism (backwards compatible)

**Which issue(s) this PR fixes**:
Fixes #983

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
