### PR TITLE
Stop tagging CQL metrics by session id

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CustomTaggingMetricIdGenerator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CustomTaggingMetricIdGenerator.java
@@ -52,8 +52,7 @@ public class CustomTaggingMetricIdGenerator implements MetricIdGenerator {
   @Override
   public MetricId sessionMetricId(@NonNull SessionMetric metric) {
     return new DefaultMetricId(
-        sessionPrefix + metric.getPath(),
-        ImmutableMap.of("session", sessionName, "tenant", tenantId));
+        sessionPrefix + metric.getPath(), ImmutableMap.of("tenant", tenantId));
   }
 
   @NonNull
@@ -61,7 +60,6 @@ public class CustomTaggingMetricIdGenerator implements MetricIdGenerator {
   public MetricId nodeMetricId(@NonNull Node node, @NonNull NodeMetric metric) {
     return new DefaultMetricId(
         nodePrefix + metric.getPath(),
-        ImmutableMap.of(
-            "session", sessionName, "node", node.getEndPoint().toString(), "tenant", tenantId));
+        ImmutableMap.of("node", node.getEndPoint().toString(), "tenant", tenantId));
   }
 }


### PR DESCRIPTION
When deployed in a multi tenant environment with lots of sessions being created, tagging the CQL driver metrics by session ID can lead to an explosion in metric cardinality, making it difficult to scrape metrics. 


