### PR TITLE
Adjust CQL execution profile timeouts

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -48,9 +48,6 @@ datastax-java-driver {
   }
   basic.request.timeout = 20 seconds
   profiles {
-    slow {
-      basic.request.timeout = 30 seconds
-    }
 
     create {
       basic.request.timeout = 10 seconds
@@ -65,7 +62,7 @@ datastax-java-driver {
     }
 
     count {
-      basic.request.timeout = 60 seconds
+      basic.request.timeout = 10 seconds
     }
   }
 }


### PR DESCRIPTION
Making a couple of adjustments to our default timeout settings for CQL execution profiles

- The timeout for count operations was set to 60 seconds, which is too long now that we have count limited to 1000 by default.
- Removing the `slow` execution profile as it is not used anywhere.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
