### PR TITLE
Refactor DocumentProjector by splitting out IndexingProjector

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
@@ -3,7 +3,7 @@ package io.stargate.sgv2.jsonapi.api.model.command;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonProcessingMetricsReporter;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 
 /**
  * Defines the context in which to execute the command.
@@ -58,7 +58,7 @@ public record CommandContext(
     return collectionSettings.vectorConfig().vectorEnabled();
   }
 
-  public DocumentProjector indexingProjector() {
+  public IndexingProjector indexingProjector() {
     return collectionSettings.indexingProjector();
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
@@ -6,7 +6,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.deserializers.FilterClauseDese
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -21,7 +21,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
               """)
 public record FilterClause(LogicalExpression logicalExpression) {
   public void validate(CommandContext commandContext) {
-    DocumentProjector indexingProjector = commandContext.indexingProjector();
+    IndexingProjector indexingProjector = commandContext.indexingProjector();
     // If nothing specified, everything indexed
     if (indexingProjector.isIdentityProjection()) {
       return;
@@ -30,7 +30,7 @@ public record FilterClause(LogicalExpression logicalExpression) {
   }
 
   public void validateLogicalExpression(
-      LogicalExpression logicalExpression, DocumentProjector indexingProjector) {
+      LogicalExpression logicalExpression, IndexingProjector indexingProjector) {
     for (LogicalExpression subLogicalExpression : logicalExpression.logicalExpressions) {
       validateLogicalExpression(subLogicalExpression, indexingProjector);
     }
@@ -40,7 +40,7 @@ public record FilterClause(LogicalExpression logicalExpression) {
   }
 
   public void validateComparisonExpression(
-      ComparisonExpression comparisonExpression, DocumentProjector indexingProjector) {
+      ComparisonExpression comparisonExpression, IndexingProjector indexingProjector) {
     String path = comparisonExpression.getPath();
     boolean isPathIndexed =
         !indexingProjector.isIndexingDenyAll() && indexingProjector.isPathIncluded(path);
@@ -82,7 +82,7 @@ public record FilterClause(LogicalExpression logicalExpression) {
     }
   }
 
-  private void validateMap(DocumentProjector indexingProjector, Map<?, ?> map, String currentPath) {
+  private void validateMap(IndexingProjector indexingProjector, Map<?, ?> map, String currentPath) {
     for (Map.Entry<?, ?> entry : map.entrySet()) {
       String incrementalPath = currentPath + "." + entry.getKey();
       if (!indexingProjector.isPathIncluded(incrementalPath)) {
@@ -100,7 +100,7 @@ public record FilterClause(LogicalExpression logicalExpression) {
     }
   }
 
-  private void validateList(DocumentProjector indexingProjector, List<?> list, String currentPath) {
+  private void validateList(IndexingProjector indexingProjector, List<?> list, String currentPath) {
     for (Object element : list) {
       if (element instanceof Map<?, ?> map) {
         validateMap(indexingProjector, map, currentPath);

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/sort/SortClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/sort/SortClause.java
@@ -5,7 +5,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.deserializers.SortClauseDeserializer;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +42,7 @@ public record SortClause(@Valid List<SortExpression> sortExpressions) {
   }
 
   public void validate(CommandContext commandContext) {
-    DocumentProjector indexingProjector = commandContext.indexingProjector();
+    IndexingProjector indexingProjector = commandContext.indexingProjector();
     // If nothing specified, everything indexed
     if (indexingProjector.isIdentityProjection()) {
       return;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
@@ -15,7 +15,7 @@ import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.config.constants.TableCommentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -56,25 +56,25 @@ public record CollectionSettings(
     }
   }
 
-  public DocumentProjector indexingProjector() {
+  public IndexingProjector indexingProjector() {
     // IndexingConfig null if no indexing definitions: default, index all:
     if (indexingConfig == null) {
-      return DocumentProjector.identityProjector();
+      return IndexingProjector.identityProjector();
     }
     // otherwise get lazily initialized indexing projector from config
     return indexingConfig.indexingProjector();
   }
 
   public record IndexingConfig(
-      Set<String> allowed, Set<String> denied, Supplier<DocumentProjector> indexedProject) {
+      Set<String> allowed, Set<String> denied, Supplier<IndexingProjector> indexedProject) {
     public IndexingConfig(Set<String> allowed, Set<String> denied) {
       this(
           allowed,
           denied,
-          Suppliers.memoize(() -> DocumentProjector.createForIndexing(allowed, denied)));
+          Suppliers.memoize(() -> IndexingProjector.createForIndexing(allowed, denied)));
     }
 
-    public DocumentProjector indexingProjector() {
+    public IndexingProjector indexingProjector() {
       return indexedProject.get();
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -102,38 +102,14 @@ public class DocumentProjector {
     }
   }
 
-  /**
-   * Method to call to check if given path (dotted path, that is, dot-separated segments) would be
-   * included by this Projection. That is, either
-   *
-   * <ul>
-   *   <li>This is inclusion projection, and path is covered by an inclusion path
-   *   <li>This is exclusion projection, and path is NOT covered by any exclusion path
-   * </ul>
-   *
-   * @param path Dotted path (possibly nested) to check
-   * @return {@code true} if path is included; {@code false} if not.
-   */
-  public boolean isPathIncluded(String path) {
-    // First: if we have no layers, we are identity projector and include everything
-    if (rootLayer == null) {
-      return true;
-    }
-    // Otherwise need to split path, evaluate; but note reversal wrt include/exclude
-    // projections
-    if (inclusion) {
-      return rootLayer.isPathIncluded(path);
-    } else {
-      return !rootLayer.isPathIncluded(path);
-    }
-  }
-
   // Mostly for deserialization tests
   @Override
   public boolean equals(Object o) {
     if (o instanceof DocumentProjector) {
       DocumentProjector other = (DocumentProjector) o;
-      return (this.inclusion == other.inclusion) && Objects.equals(this.rootLayer, other.rootLayer);
+      return (this.inclusion == other.inclusion)
+          && (this.includeSimilarityScore == other.includeSimilarityScore)
+          && Objects.equals(this.rootLayer, other.rootLayer);
     }
     return false;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -20,10 +20,10 @@ public class DocumentProjector {
    * exclusions" is conceptually what happens ("no inclusions" would drop all content)
    */
   private static final DocumentProjector IDENTITY_PROJECTOR =
-      new DocumentProjector(null, false, false, false);
+      new DocumentProjector(null, false, false);
 
   private static final DocumentProjector IDENTITY_PROJECTOR_WITH_SIMILARITY =
-      new DocumentProjector(null, false, true, false);
+      new DocumentProjector(null, false, true);
 
   private final ProjectionLayer rootLayer;
 
@@ -33,22 +33,11 @@ public class DocumentProjector {
   /** Whether to include the similarity score in the projection. */
   private final boolean includeSimilarityScore;
 
-  /** An override flag set when indexing option is deny all */
-  private final boolean indexingDenyAll;
-
   private DocumentProjector(
-      ProjectionLayer rootLayer,
-      boolean inclusion,
-      boolean includeSimilarityScore,
-      boolean indexingDenyAll) {
+      ProjectionLayer rootLayer, boolean inclusion, boolean includeSimilarityScore) {
     this.rootLayer = rootLayer;
     this.inclusion = inclusion;
     this.includeSimilarityScore = includeSimilarityScore;
-    this.indexingDenyAll = indexingDenyAll;
-  }
-
-  public boolean isIndexingDenyAll() {
-    return indexingDenyAll;
   }
 
   public static DocumentProjector createFromDefinition(JsonNode projectionDefinition) {
@@ -76,10 +65,6 @@ public class DocumentProjector {
 
   public static DocumentProjector identityProjector() {
     return IDENTITY_PROJECTOR;
-  }
-
-  public boolean isIdentityProjection() {
-    return rootLayer == null && !inclusion;
   }
 
   public static DocumentProjector identityProjectorWithSimilarity() {
@@ -194,15 +179,13 @@ public class DocumentProjector {
         return new DocumentProjector(
             ProjectionLayer.buildLayersNoOverlap(paths, slices, !Boolean.FALSE.equals(idInclusion)),
             true,
-            includeSimilarityScore,
-            false);
+            includeSimilarityScore);
       } else { // exclusion-based
         // doc-id excluded only if explicitly excluded
         return new DocumentProjector(
             ProjectionLayer.buildLayersNoOverlap(paths, slices, Boolean.FALSE.equals(idInclusion)),
             false,
-            includeSimilarityScore,
-            false);
+            includeSimilarityScore);
       }
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -13,6 +13,9 @@ import java.util.Objects;
 /**
  * Helper class that implements functionality needed to support projections on documents fetched via
  * various {@code find} commands.
+ *
+ * <p>Note that this is not used for "No Index" handling: see {@link IndexingProjector} for that use
+ * case
  */
 public class DocumentProjector {
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/IndexingProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/IndexingProjector.java
@@ -2,12 +2,7 @@ package io.stargate.sgv2.jsonapi.service.projection;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
-import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -125,9 +120,8 @@ public class IndexingProjector {
     // projections
     if (inclusion) {
       return rootLayer.isPathIncluded(path);
-    } else {
-      return !rootLayer.isPathIncluded(path);
     }
+    return !rootLayer.isPathIncluded(path);
   }
 
   // Mostly for deserialization tests
@@ -135,7 +129,9 @@ public class IndexingProjector {
   public boolean equals(Object o) {
     if (o instanceof IndexingProjector) {
       IndexingProjector other = (IndexingProjector) o;
-      return (this.inclusion == other.inclusion) && Objects.equals(this.rootLayer, other.rootLayer);
+      return (this.inclusion == other.inclusion)
+          && (this.indexingDenyAll == other.indexingDenyAll)
+          && Objects.equals(this.rootLayer, other.rootLayer);
     }
     return false;
   }
@@ -143,200 +139,5 @@ public class IndexingProjector {
   @Override
   public int hashCode() {
     return rootLayer.hashCode();
-  }
-
-  /**
-   * Helper object used to traverse and collection inclusion/exclusion path definitions and verify
-   * that there are only one or the other (except for doc id). Does not build data structures for
-   * actual matching.
-   */
-  private static class PathCollector {
-    private List<String> paths = new ArrayList<>();
-
-    private List<ProjectionLayer.SliceDef> slices = new ArrayList<>();
-
-    private int exclusions, inclusions;
-
-    private Boolean idInclusion = null;
-
-    private PathCollector() {}
-
-    static PathCollector collectPaths(JsonNode def) {
-      return new PathCollector().collectFromObject(def, null);
-    }
-
-    public IndexingProjector buildProjector() {
-      if (isIdentityProjection()) {
-        return identityProjector();
-      }
-
-      // One more thing: do we need to add document id?
-      if (inclusions > 0) { // inclusion-based projection
-        // doc-id included unless explicitly excluded
-        return new IndexingProjector(
-            ProjectionLayer.buildLayersNoOverlap(paths, slices, !Boolean.FALSE.equals(idInclusion)),
-            true,
-            false);
-      } else { // exclusion-based
-        // doc-id excluded only if explicitly excluded
-        return new IndexingProjector(
-            ProjectionLayer.buildLayersNoOverlap(paths, slices, Boolean.FALSE.equals(idInclusion)),
-            false,
-            false);
-      }
-    }
-
-    /**
-     * Accessor to use for checking if collected paths indicate "empty" (no-operation) projection:
-     * if so, caller can avoid actual construction or evaluation.
-     */
-    boolean isIdentityProjection() {
-      // Only the case if we have no non-doc-id inclusions/exclusions AND
-      // doc-id is included (by default or explicitly)
-      return paths.isEmpty() && slices.isEmpty() && !Boolean.FALSE.equals(idInclusion);
-    }
-
-    PathCollector collectFromObject(JsonNode ob, String parentPath) {
-      var it = ob.fields();
-      while (it.hasNext()) {
-        var entry = it.next();
-        String path = entry.getKey();
-
-        if (path.isEmpty()) {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                  + ": empty paths (and path segments) not allowed");
-        }
-        if (path.charAt(0) == '$'
-            && !(path.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)
-                || DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(path))) {
-          // First: no operators allowed at root level
-          if (parentPath == null) {
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-                ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                    + ": path cannot start with '$' (no root-level operators)");
-          }
-
-          // Second: we only support one operator for now
-          if (!"$slice".equals(path)) {
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-                ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                    + ": unrecognized/unsupported projection operator '"
-                    + path
-                    + "' (only '$slice' supported)");
-          }
-
-          addSlice(parentPath, entry.getValue());
-          continue;
-        }
-
-        if (parentPath != null) {
-          path = parentPath + "." + path;
-        }
-        JsonNode value = entry.getValue();
-        if (value.isNumber()) {
-          // "0" means exclude (like false); any other number include
-          if (BigDecimal.ZERO.equals(value.decimalValue())) {
-            addExclusion(path);
-          } else {
-            addInclusion(path);
-          }
-        } else if (value.isBoolean()) {
-          if (value.booleanValue()) {
-            addInclusion(path);
-          } else {
-            addExclusion(path);
-          }
-        } else if (value.isObject()) {
-          // Nested definitions allowed, too
-          collectFromObject(value, path);
-        } else {
-          // Unknown JSON node type; error
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                  + ": path ('"
-                  + path
-                  + "') value must be NUMBER, BOOLEAN or OBJECT, was "
-                  + value.getNodeType());
-        }
-      }
-      return this;
-    }
-
-    private void addSlice(String path, JsonNode sliceDef) {
-      if (sliceDef.isArray()) {
-        if (sliceDef.size() == 2
-            && sliceDef.get(0).isIntegralNumber()
-            && sliceDef.get(1).isIntegralNumber()) {
-          int skip = sliceDef.get(0).intValue();
-          int count = sliceDef.get(1).intValue();
-          if (count < 0) { // negative values not allowed
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-                ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                    + ": path ('"
-                    + path
-                    + "') has unsupported parameter for '$slice' ("
-                    + sliceDef.getNodeType()
-                    + "): second NUMBER (entries to return) MUST be positive");
-          }
-          slices.add(
-              new ProjectionLayer.SliceDef(path, ProjectionLayer.constructSlicer(skip, count)));
-          return;
-        }
-      } else if (sliceDef.isIntegralNumber()) {
-        int count = sliceDef.intValue();
-        slices.add(new ProjectionLayer.SliceDef(path, ProjectionLayer.constructSlicer(count)));
-        return;
-      }
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-          ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-              + ": path ('"
-              + path
-              + "') has unsupported parameter for '$slice' ("
-              + sliceDef.getNodeType()
-              + "): only NUMBER or ARRAY with 2 NUMBERs accepted");
-    }
-
-    private void addExclusion(String path) {
-      if (DocumentConstants.Fields.DOC_ID.equals(path)) {
-        idInclusion = false;
-      } else {
-        // Must not mix exclusions and inclusions
-        if (inclusions > 0) {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                  + ": cannot exclude '"
-                  + path
-                  + "' on inclusion projection");
-        }
-        ++exclusions;
-        paths.add(path);
-      }
-    }
-
-    private void addInclusion(String path) {
-      if (DocumentConstants.Fields.DOC_ID.equals(path)) {
-        idInclusion = true;
-      } else {
-        // Must not mix exclusions and inclusions
-        if (exclusions > 0) {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-              ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                  + ": cannot include '"
-                  + path
-                  + "' on exclusion projection");
-        }
-        ++inclusions;
-        paths.add(path);
-      }
-    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
@@ -5,7 +5,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertManyCommand;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.InsertOperation;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -33,7 +33,7 @@ public class InsertManyCommandResolver implements CommandResolver<InsertManyComm
 
   @Override
   public Operation resolveCommand(CommandContext ctx, InsertManyCommand command) {
-    final DocumentProjector projection = ctx.indexingProjector();
+    final IndexingProjector projection = ctx.indexingProjector();
     final List<WritableShreddedDocument> shreddedDocuments =
         command.documents().stream().map(doc -> shredder.shred(ctx, doc, null)).toList();
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -14,7 +14,7 @@ import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.JsonExtensionType;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -75,7 +75,7 @@ public class Shredder {
     return shred(
         doc,
         txId,
-        DocumentProjector.identityProjector(),
+        IndexingProjector.identityProjector(),
         "testCommand",
         CollectionSettings.empty());
   }
@@ -87,7 +87,7 @@ public class Shredder {
   public WritableShreddedDocument shred(
       JsonNode doc,
       UUID txId,
-      DocumentProjector indexProjector,
+      IndexingProjector indexProjector,
       String commandName,
       CollectionSettings collectionSettings) {
     // Although we could otherwise allow non-Object documents, requirement

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSettingsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSettingsTest.java
@@ -7,7 +7,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import java.util.Arrays;
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class CollectionSettingsTest {
             CollectionSettings.IdConfig.defaultIdConfig(),
             CollectionSettings.VectorConfig.notEnabledVectorConfig(),
             indexingConfig);
-    DocumentProjector indexingProj = settings.indexingProjector();
+    IndexingProjector indexingProj = settings.indexingProjector();
     assertThat(indexingProj)
         .isNotNull()
         // Should get the same instance second time due to memoization

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
@@ -180,37 +180,37 @@ public class DocumentProjectorForIndexingTest {
   class PathInclusion {
     @Test
     public void testPathInclusion() {
-      DocumentProjector rootProj = createAllowProjection(Arrays.asList("a", "c"));
+      IndexingProjector rootProj = createAllowProjection(Arrays.asList("a", "c"));
       assertIsIncluded(rootProj, "a", "a.x", "a.b.c.d");
       assertIsIncluded(rootProj, "c", "c.a", "c.x.y.z");
       assertIsNotIncluded(rootProj, "b", "d", "b.a", "abc", "cef", "_id");
 
-      DocumentProjector nestedProj = createAllowProjection(Arrays.asList("a.b"));
+      IndexingProjector nestedProj = createAllowProjection(Arrays.asList("a.b"));
       assertIsIncluded(nestedProj, "a.b", "a.b.c", "a.b.longer.path.for.sure");
       assertIsNotIncluded(nestedProj, "a", "b", "c", "a.c", "a.x", "a.x.y.z", "_id");
 
       // Let's also check overlapping (redundant) case; most generic used (specific ignored)
       // same as just "c":
-      DocumentProjector overlapProj = createAllowProjection(Arrays.asList("c", "c.x"));
+      IndexingProjector overlapProj = createAllowProjection(Arrays.asList("c", "c.x"));
       assertIsIncluded(overlapProj, "c", "c.abc", "c.d.e.f");
       assertIsNotIncluded(overlapProj, "a", "b", "d", "a.c", "a.x.y.z", "_id");
     }
 
     @Test
     public void testPathExclusion() {
-      DocumentProjector rootProj = createDenyProjection(Arrays.asList("a", "c"));
+      IndexingProjector rootProj = createDenyProjection(Arrays.asList("a", "c"));
       assertIsNotIncluded(rootProj, "a", "a.x", "a.b.c.d");
       assertIsNotIncluded(rootProj, "c", "c.a", "c.x.y.z");
       assertIsIncluded(rootProj, "b", "d", "b.a", "abc", "cef", "_id");
 
-      DocumentProjector nestedProj = createDenyProjection(Arrays.asList("a.b", "a.noindex"));
+      IndexingProjector nestedProj = createDenyProjection(Arrays.asList("a.b", "a.noindex"));
       assertIsNotIncluded(
           nestedProj, "a.b", "a.b.c", "a.b.longer.path.for.sure", "a.noindex", "a.noindex.x");
       assertIsIncluded(nestedProj, "a", "b", "_id", "a.c", "a.x", "a.x.y.z");
 
       // Let's also check overlapping (redundant) case; most generic used (specific ignored)
       // same as just "c":
-      DocumentProjector overlapProj = createDenyProjection(Arrays.asList("c", "c.x"));
+      IndexingProjector overlapProj = createDenyProjection(Arrays.asList("c", "c.x"));
       assertIsNotIncluded(overlapProj, "c", "c.abc", "c.d.e.f");
       assertIsIncluded(overlapProj, "a", "b", "d", "a.c", "a.x.y.z", "_id");
     }
@@ -218,7 +218,7 @@ public class DocumentProjectorForIndexingTest {
 
   private void assertAllowProjection(
       Collection<String> allows, String inputDoc, String expectedDoc) {
-    DocumentProjector projector = createAllowProjection(allows);
+    IndexingProjector projector = createAllowProjection(allows);
     try {
       JsonNode input = objectMapper.readTree(inputDoc);
       projector.applyProjection(input);
@@ -230,7 +230,7 @@ public class DocumentProjectorForIndexingTest {
 
   private void assertDenyProjection(
       Collection<String> denies, String inputDoc, String expectedDoc) {
-    DocumentProjector projector = createDenyProjection(denies);
+    IndexingProjector projector = createDenyProjection(denies);
     try {
       JsonNode input = objectMapper.readTree(inputDoc);
       projector.applyProjection(input);
@@ -240,15 +240,15 @@ public class DocumentProjectorForIndexingTest {
     }
   }
 
-  private DocumentProjector createAllowProjection(Collection<String> allows) {
-    return DocumentProjector.createForIndexing(new LinkedHashSet<>(allows), null);
+  private IndexingProjector createAllowProjection(Collection<String> allows) {
+    return IndexingProjector.createForIndexing(new LinkedHashSet<>(allows), null);
   }
 
-  private DocumentProjector createDenyProjection(Collection<String> denies) {
-    return DocumentProjector.createForIndexing(null, new LinkedHashSet<>(denies));
+  private IndexingProjector createDenyProjection(Collection<String> denies) {
+    return IndexingProjector.createForIndexing(null, new LinkedHashSet<>(denies));
   }
 
-  private void assertIsIncluded(DocumentProjector proj, String... paths) {
+  private void assertIsIncluded(IndexingProjector proj, String... paths) {
     for (String path : paths) {
       assertThat(proj.isPathIncluded(path))
           .withFailMessage("Path '%s' should be included", path)
@@ -256,7 +256,7 @@ public class DocumentProjectorForIndexingTest {
     }
   }
 
-  private void assertIsNotIncluded(DocumentProjector proj, String... paths) {
+  private void assertIsNotIncluded(IndexingProjector proj, String... paths) {
     for (String path : paths) {
       assertThat(proj.isPathIncluded(path))
           .withFailMessage("Path '%s' should NOT be included", path)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/IndexingProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/IndexingProjectorTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
-public class DocumentProjectorForIndexingTest {
+public class IndexingProjectorTest {
   final ObjectMapper objectMapper = new ObjectMapper();
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -17,7 +17,7 @@ import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import jakarta.inject.Inject;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -133,8 +133,8 @@ public class ShredderDocLimitsTest {
     public void allowDocWithHugeObjectNoIndex() {
       // Max allowed 1000 normally, but if Object not-indexed, not limited
       final ObjectNode doc = docWithNProps("no_index", docLimits.maxObjectProperties() + 100);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(null, Collections.singleton("no_index"));
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(null, Collections.singleton("no_index"));
       assertThat(
               shredder.shred(doc, null, indexProjector, "testCommand", CollectionSettings.empty()))
           .isNotNull();
@@ -213,8 +213,8 @@ public class ShredderDocLimitsTest {
     public void allowDocWithHugeArrayNoIndex() {
       // Max allowed 1000 normally, but if array not-indexed, not limited
       final ObjectNode doc = docWithNArrayElems("no_index", docLimits.maxArrayLength() + 100);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(null, Collections.singleton("no_index"));
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(null, Collections.singleton("no_index"));
       assertThat(
               shredder.shred(doc, null, indexProjector, "testCommand", CollectionSettings.empty()))
           .isNotNull();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -14,7 +14,7 @@ import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -365,8 +365,8 @@ public class ShredderTest {
                           }
                           """;
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(
               new HashSet<>(Arrays.asList("name", "metadata")), null);
       WritableShreddedDocument doc =
           shredder.shred(inputDoc, null, indexProjector, "testCommand", CollectionSettings.empty());
@@ -433,8 +433,8 @@ public class ShredderTest {
                               """
               .formatted(str);
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(
               new HashSet<>(Arrays.asList("name", "metadata")), null);
       WritableShreddedDocument doc =
           shredder.shred(inputDoc, null, indexProjector, "testCommand", CollectionSettings.empty());
@@ -495,8 +495,8 @@ public class ShredderTest {
                 }
                 """;
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(
               new HashSet<>(Arrays.asList("name", "metadata")), null);
       WritableShreddedDocument doc =
           shredder.shred(inputDoc, null, indexProjector, "testCommand", CollectionSettings.empty());
@@ -553,8 +553,8 @@ public class ShredderTest {
               }
               """;
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(null, new HashSet<>(Arrays.asList("name", "values")));
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(null, new HashSet<>(Arrays.asList("name", "values")));
       WritableShreddedDocument doc =
           shredder.shred(inputDoc, null, indexProjector, "testCommand", CollectionSettings.empty());
       assertThat(doc.id()).isEqualTo(DocumentId.fromNumber(BigDecimal.valueOf(123)));
@@ -615,8 +615,8 @@ public class ShredderTest {
                   }
                   """;
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(null, new HashSet<>(Arrays.asList("*")));
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(null, new HashSet<>(Arrays.asList("*")));
       WritableShreddedDocument doc =
           shredder.shred(inputDoc, null, indexProjector, "testCommand", CollectionSettings.empty());
       assertThat(doc.id()).isEqualTo(DocumentId.fromNumber(BigDecimal.valueOf(123)));
@@ -658,8 +658,8 @@ public class ShredderTest {
               .formatted(hugeString);
 
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      DocumentProjector indexProjector =
-          DocumentProjector.createForIndexing(null, new HashSet<>(Arrays.asList("blob")));
+      IndexingProjector indexProjector =
+          IndexingProjector.createForIndexing(null, new HashSet<>(Arrays.asList("blob")));
       WritableShreddedDocument doc =
           shredder.shred(inputDoc, null, indexProjector, "testCommand", CollectionSettings.empty());
       assertThat(doc.id()).isEqualTo(DocumentId.fromNumber(BigDecimal.valueOf(1)));
@@ -699,7 +699,7 @@ public class ShredderTest {
       shredder.shred(
           inputDoc,
           null,
-          DocumentProjector.identityProjector(),
+          IndexingProjector.identityProjector(),
           "jsonBytesWriteCommand",
           CollectionSettings.empty());
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderWithExtendedTypesTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderWithExtendedTypesTest.java
@@ -14,7 +14,7 @@ import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.JsonExtensionType;
@@ -203,7 +203,7 @@ public class ShredderWithExtendedTypesTest {
           shredder.shred(
               inputDoc,
               null,
-              DocumentProjector.identityProjector(),
+              IndexingProjector.identityProjector(),
               "test",
               CollectionSettings.empty().withIdType(CollectionSettings.IdType.UNDEFINED));
 
@@ -242,7 +242,7 @@ public class ShredderWithExtendedTypesTest {
           shredder.shred(
               inputDoc,
               null,
-              DocumentProjector.identityProjector(),
+              IndexingProjector.identityProjector(),
               "test",
               CollectionSettings.empty().withIdType(CollectionSettings.IdType.OBJECT_ID));
 
@@ -297,7 +297,7 @@ public class ShredderWithExtendedTypesTest {
           shredder.shred(
               inputDoc,
               null,
-              DocumentProjector.identityProjector(),
+              IndexingProjector.identityProjector(),
               "test",
               CollectionSettings.empty().withIdType(idType));
 


### PR DESCRIPTION
**What this PR does**:

Splits existing `DocumentProjector` into 2 classes, new one `IndexingProject`, to help serve separate use cases more cleanly

**Which issue(s) this PR fixes**:
Fixes #1006

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
