### PR TITLE
Add support for default exclusion of $vector and $vectorize

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -31,7 +31,7 @@ public interface DocumentConstants {
     String VECTOR_INDEX_FUNCTION_NAME = "similarity_function";
 
     /** Field name used in projection clause to get similarity score in response. */
-    String VECTOR_FUNCTION_PROJECTION_FIELD = "$similarity";
+    String VECTOR_FUNCTION_SIMILARITY_FIELD = "$similarity";
 
     // Current definition of valid JSON API names: note that this only validates
     // characters, not length limits (nor empty nor "too long" allowed but validated

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -188,7 +188,9 @@ public record ReadAndUpdateOperation(
                               returnUpdatedDocument ? updatedDocument : originalDocument;
                           // Some operations (findOneAndUpdate) define projection to apply to
                           // result:
-                          resultProjection.applyProjection(documentToReturn);
+                          if (documentToReturn != null) { // null for some Operation tests
+                            resultProjection.applyProjection(documentToReturn);
+                          }
                         }
                         return new UpdatedDocument(
                             writableShreddedDocument.id(), upsert, documentToReturn, null);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -55,6 +55,10 @@ public class DocumentProjector {
     return DefaultProjectorWrapper.defaultProjector();
   }
 
+  public static DocumentProjector includeAllProjector() {
+    return INCLUDE_ALL_PROJECTOR;
+  }
+
   DocumentProjector withIncludeSimilarity(boolean includeSimilarityScore) {
     if (this.includeSimilarityScore == includeSimilarityScore) {
       return this;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -140,7 +140,7 @@ public class DocumentProjector {
       // In either case, we may need to add similarity score if present
       if (includeSimilarityScore && similarityScore != null) {
         ((ObjectNode) document)
-            .put(DocumentConstants.Fields.VECTOR_FUNCTION_PROJECTION_FIELD, similarityScore);
+            .put(DocumentConstants.Fields.VECTOR_FUNCTION_SIMILARITY_FIELD, similarityScore);
       }
       return;
     }
@@ -151,7 +151,7 @@ public class DocumentProjector {
     }
     if (includeSimilarityScore && similarityScore != null) {
       ((ObjectNode) document)
-          .put(DocumentConstants.Fields.VECTOR_FUNCTION_PROJECTION_FIELD, similarityScore);
+          .put(DocumentConstants.Fields.VECTOR_FUNCTION_SIMILARITY_FIELD, similarityScore);
     }
   }
 
@@ -178,8 +178,8 @@ public class DocumentProjector {
    */
   static class DefaultProjectorWrapper {
     /**
-     * Default projector that drops $vector but otherwise leaves document as-is. Constructed from
-     * empty definition (no inclusions/exclusions).
+     * Default projector that drops $vector and $vectorize fields but otherwise leaves document
+     * as-is. Constructed from empty definition (no inclusions/exclusions).
      */
     private static final DocumentProjector DEFAULT_PROJECTOR;
 
@@ -212,9 +212,11 @@ public class DocumentProjector {
 
     private int exclusions, inclusions;
 
-    private Boolean idInclusion = null;
+    private Boolean idInclusion;
 
-    private Boolean $vectorInclusion = null;
+    private Boolean $vectorInclusion;
+
+    private Boolean $vectorizeInclusion;
 
     /** Whether similarity score is needed. */
     private final boolean includeSimilarityScore;
@@ -237,7 +239,9 @@ public class DocumentProjector {
                 // doc-id included unless explicitly excluded
                 !Boolean.FALSE.equals(idInclusion),
                 // $vector only included if explicitly included
-                Boolean.TRUE.equals($vectorInclusion)),
+                Boolean.TRUE.equals($vectorInclusion),
+                // $vectorize only included if explicitly included
+                Boolean.TRUE.equals($vectorizeInclusion)),
             true,
             includeSimilarityScore);
       } else { // exclusion-based
@@ -248,7 +252,9 @@ public class DocumentProjector {
                 // doc-id excluded only if explicitly excluded
                 Boolean.FALSE.equals(idInclusion),
                 // $vector excluded unless explicitly included
-                !Boolean.TRUE.equals($vectorInclusion)),
+                !Boolean.TRUE.equals($vectorInclusion),
+                // $vectorize excluded unless explicitly included
+                !Boolean.TRUE.equals($vectorizeInclusion)),
             false,
             includeSimilarityScore);
       }
@@ -373,6 +379,8 @@ public class DocumentProjector {
         idInclusion = false;
       } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(path)) {
         $vectorInclusion = false;
+      } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(path)) {
+        $vectorizeInclusion = false;
       } else {
         // Must not mix exclusions and inclusions
         if (inclusions > 0) {
@@ -393,6 +401,8 @@ public class DocumentProjector {
         idInclusion = true;
       } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(path)) {
         $vectorInclusion = true;
+      } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(path)) {
+        $vectorizeInclusion = true;
       } else {
         // Must not mix exclusions and inclusions
         if (exclusions > 0) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -179,6 +179,8 @@ public class DocumentProjector {
 
     private Boolean idInclusion = null;
 
+    private Boolean $vectorInclusion = null;
+
     /** Whether similarity score is needed. */
     private final boolean includeSimilarityScore;
 
@@ -197,17 +199,25 @@ public class DocumentProjector {
 
       // One more thing: do we need to add document id?
       if (inclusions > 0) { // inclusion-based projection
-        // doc-id included unless explicitly excluded
         return new DocumentProjector(
             ProjectionLayer.buildLayersForProjection(
-                paths, slices, !Boolean.FALSE.equals(idInclusion)),
+                paths,
+                slices,
+                // doc-id included unless explicitly excluded
+                !Boolean.FALSE.equals(idInclusion),
+                // $vector only included if explicitly included
+                Boolean.TRUE.equals($vectorInclusion)),
             true,
             includeSimilarityScore);
       } else { // exclusion-based
-        // doc-id excluded only if explicitly excluded
         return new DocumentProjector(
             ProjectionLayer.buildLayersForProjection(
-                paths, slices, Boolean.FALSE.equals(idInclusion)),
+                paths,
+                slices,
+                // doc-id excluded only if explicitly excluded
+                Boolean.FALSE.equals(idInclusion),
+                // $vector excluded unless explicitly included
+                !Boolean.TRUE.equals($vectorInclusion)),
             false,
             includeSimilarityScore);
       }
@@ -340,6 +350,8 @@ public class DocumentProjector {
     private void addExclusion(String path) {
       if (DocumentConstants.Fields.DOC_ID.equals(path)) {
         idInclusion = false;
+      } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(path)) {
+        $vectorInclusion = false;
       } else {
         // Must not mix exclusions and inclusions
         if (inclusions > 0) {
@@ -358,6 +370,8 @@ public class DocumentProjector {
     private void addInclusion(String path) {
       if (DocumentConstants.Fields.DOC_ID.equals(path)) {
         idInclusion = true;
+      } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(path)) {
+        $vectorInclusion = true;
       } else {
         // Must not mix exclusions and inclusions
         if (exclusions > 0) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -199,13 +199,15 @@ public class DocumentProjector {
       if (inclusions > 0) { // inclusion-based projection
         // doc-id included unless explicitly excluded
         return new DocumentProjector(
-            ProjectionLayer.buildLayersNoOverlap(paths, slices, !Boolean.FALSE.equals(idInclusion)),
+            ProjectionLayer.buildLayersForProjection(
+                paths, slices, !Boolean.FALSE.equals(idInclusion)),
             true,
             includeSimilarityScore);
       } else { // exclusion-based
         // doc-id excluded only if explicitly excluded
         return new DocumentProjector(
-            ProjectionLayer.buildLayersNoOverlap(paths, slices, Boolean.FALSE.equals(idInclusion)),
+            ProjectionLayer.buildLayersForProjection(
+                paths, slices, Boolean.FALSE.equals(idInclusion)),
             false,
             includeSimilarityScore);
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -229,8 +229,11 @@ public class DocumentProjector {
      */
     boolean isDefaultProjection() {
       // Only the case if we have no non-doc-id inclusions/exclusions AND
-      // doc-id is included (by default or explicitly)
-      return paths.isEmpty() && slices.isEmpty() && !Boolean.FALSE.equals(idInclusion);
+      // neither doc-id nor $vector has explicit overrides
+      return paths.isEmpty()
+          && slices.isEmpty()
+          && (idInclusion == null)
+          && ($vectorInclusion == null);
     }
 
     PathCollector collectFromObject(JsonNode ob, String parentPath) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -131,6 +131,7 @@ public class DocumentProjector {
   }
 
   public void applyProjection(JsonNode document, Float similarityScore) {
+    Objects.requireNonNull(document, "Document to call 'applyProjection()' on must not be null");
     // null -> either include-add or exclude-all; but logic may seem counter-intuitive
     if (rootLayer == null) {
       if (inclusion) { // exclude-all

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/IndexingProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/IndexingProjector.java
@@ -60,7 +60,7 @@ public class IndexingProjector {
       if (!allowed.contains(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
         allowed.add(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD);
       }
-      return new IndexingProjector(ProjectionLayer.buildLayersOverlapOk(allowed), true, false);
+      return new IndexingProjector(ProjectionLayer.buildLayersForIndexing(allowed), true, false);
     }
     if (denied != null && !denied.isEmpty()) {
       // (special) Case 4:
@@ -71,10 +71,10 @@ public class IndexingProjector {
         overrideFields.add(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD);
         overrideFields.add(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD);
         return new IndexingProjector(
-            ProjectionLayer.buildLayersOverlapOk(overrideFields), true, true);
+            ProjectionLayer.buildLayersForIndexing(overrideFields), true, true);
       }
       // Case 2: exclusion-based projection
-      return new IndexingProjector(ProjectionLayer.buildLayersOverlapOk(denied), false, false);
+      return new IndexingProjector(ProjectionLayer.buildLayersForIndexing(denied), false, false);
     }
     // Case 3: include-all (identity) projection
     return identityProjector();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -51,16 +51,20 @@ class ProjectionLayer {
   }
 
   public static ProjectionLayer buildLayersForProjection(
-      Collection<String> dotPaths, List<SliceDef> slices, boolean addDocId) {
-    return buildLayers(dotPaths, slices, true, addDocId);
+      Collection<String> dotPaths, List<SliceDef> slices, boolean addDocId, boolean add$vector) {
+    return buildLayers(dotPaths, slices, true, addDocId, add$vector);
   }
 
   public static ProjectionLayer buildLayersForIndexing(Collection<String> dotPaths) {
-    return buildLayers(dotPaths, Collections.emptyList(), false, false);
+    return buildLayers(dotPaths, Collections.emptyList(), false, false, false);
   }
 
   private static ProjectionLayer buildLayers(
-      Collection<String> dotPaths, List<SliceDef> slices, boolean failOnOverlap, boolean addDocId) {
+      Collection<String> dotPaths,
+      List<SliceDef> slices,
+      boolean failOnOverlap,
+      boolean addDocId,
+      boolean add$vector) {
     // Root is always branch (not terminal):
     ProjectionLayer root = new ProjectionLayer("", false);
     for (String fullPath : dotPaths) {
@@ -82,6 +86,13 @@ class ProjectionLayer {
           DocumentConstants.Fields.DOC_ID,
           root,
           new String[] {DocumentConstants.Fields.DOC_ID});
+    }
+    if (add$vector) {
+      buildPath(
+          failOnOverlap,
+          DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD,
+          root,
+          new String[] {DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD});
     }
     return root;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -51,12 +51,16 @@ class ProjectionLayer {
   }
 
   public static ProjectionLayer buildLayersForProjection(
-      Collection<String> dotPaths, List<SliceDef> slices, boolean addDocId, boolean add$vector) {
-    return buildLayers(dotPaths, slices, true, addDocId, add$vector);
+      Collection<String> dotPaths,
+      List<SliceDef> slices,
+      boolean addDocId,
+      boolean add$vector,
+      boolean add$vectorize) {
+    return buildLayers(dotPaths, slices, true, addDocId, add$vector, add$vectorize);
   }
 
   public static ProjectionLayer buildLayersForIndexing(Collection<String> dotPaths) {
-    return buildLayers(dotPaths, Collections.emptyList(), false, false, false);
+    return buildLayers(dotPaths, Collections.emptyList(), false, false, false, false);
   }
 
   private static ProjectionLayer buildLayers(
@@ -64,7 +68,8 @@ class ProjectionLayer {
       List<SliceDef> slices,
       boolean failOnOverlap,
       boolean addDocId,
-      boolean add$vector) {
+      boolean add$vector,
+      boolean add$vectorize) {
     // Root is always branch (not terminal):
     ProjectionLayer root = new ProjectionLayer("", false);
     for (String fullPath : dotPaths) {
@@ -93,6 +98,13 @@ class ProjectionLayer {
           DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD,
           root,
           new String[] {DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD});
+    }
+    if (add$vectorize) {
+      buildPath(
+          failOnOverlap,
+          DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD,
+          root,
+          new String[] {DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD});
     }
     return root;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -50,17 +50,17 @@ class ProjectionLayer {
     nextLayers = null;
   }
 
-  public static ProjectionLayer buildLayersNoOverlap(
+  public static ProjectionLayer buildLayersForProjection(
       Collection<String> dotPaths, List<SliceDef> slices, boolean addDocId) {
-    return buildLayers(dotPaths, slices, addDocId, true);
+    return buildLayers(dotPaths, slices, true, addDocId);
   }
 
-  public static ProjectionLayer buildLayersOverlapOk(Collection<String> dotPaths) {
+  public static ProjectionLayer buildLayersForIndexing(Collection<String> dotPaths) {
     return buildLayers(dotPaths, Collections.emptyList(), false, false);
   }
 
   private static ProjectionLayer buildLayers(
-      Collection<String> dotPaths, List<SliceDef> slices, boolean addDocId, boolean failOnOverlap) {
+      Collection<String> dotPaths, List<SliceDef> slices, boolean failOnOverlap, boolean addDocId) {
     // Root is always branch (not terminal):
     ProjectionLayer root = new ProjectionLayer("", false);
     for (String fullPath : dotPaths) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolver.java
@@ -59,7 +59,7 @@ public class DeleteManyCommandResolver extends FilterableResolver<DeleteManyComm
     return FindOperation.unsorted(
         commandContext,
         logicalExpression,
-        DocumentProjector.defaultProjector(),
+        DocumentProjector.includeAllProjector(),
         null,
         operationsConfig.maxDocumentDeleteCount() + 1,
         operationsConfig.defaultPageSize(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
@@ -62,7 +62,7 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
       return FindOperation.vsearchSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.KEY,
           objectMapper,
           vector);
@@ -74,7 +74,7 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
       return FindOperation.sortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
           operationsConfig.defaultSortPageSize(),
           ReadType.SORTED_DOCUMENT,
@@ -88,7 +88,7 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
       return FindOperation.unsortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.KEY,
           objectMapper);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
@@ -66,7 +66,7 @@ public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneA
       return FindOperation.vsearchSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper,
           vector);
@@ -78,7 +78,7 @@ public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneA
       return FindOperation.sortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
           operationsConfig.defaultSortPageSize(),
           ReadType.SORTED_DOCUMENT,
@@ -92,7 +92,7 @@ public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneA
       return FindOperation.unsortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
@@ -84,7 +84,7 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
       return FindOperation.vsearchSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper,
           vector);
@@ -96,7 +96,7 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
       return FindOperation.sortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
           operationsConfig.defaultSortPageSize(),
           ReadType.SORTED_DOCUMENT,
@@ -110,7 +110,7 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
       return FindOperation.unsortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -86,7 +86,7 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
       return FindOperation.vsearchSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper,
           vector);
@@ -99,8 +99,8 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
           commandContext,
           logicalExpression,
           // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
-          // read path, hence pass identity projector.
-          DocumentProjector.defaultProjector(),
+          // read path:
+          DocumentProjector.includeAllProjector(),
           // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
           operationsConfig.defaultSortPageSize(),
           ReadType.SORTED_DOCUMENT,
@@ -115,8 +115,8 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
           commandContext,
           logicalExpression,
           // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
-          // read path, hence pass identity projector.
-          DocumentProjector.defaultProjector(),
+          // read path:
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolver.java
@@ -58,7 +58,7 @@ public class UpdateManyCommandResolver extends FilterableResolver<UpdateManyComm
         false,
         upsert,
         shredder,
-        DocumentProjector.defaultProjector(),
+        DocumentProjector.includeAllProjector(),
         operationsConfig.maxDocumentUpdateCount(),
         operationsConfig.lwt().retries());
   }
@@ -68,7 +68,7 @@ public class UpdateManyCommandResolver extends FilterableResolver<UpdateManyComm
     return FindOperation.unsorted(
         commandContext,
         logicalExpression,
-        DocumentProjector.defaultProjector(),
+        DocumentProjector.includeAllProjector(),
         null != command.options() ? command.options().pageState() : null,
         Integer.MAX_VALUE,
         operationsConfig.defaultPageSize(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
@@ -61,7 +61,7 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
         false,
         upsert,
         shredder,
-        DocumentProjector.defaultProjector(),
+        DocumentProjector.includeAllProjector(),
         1,
         operationsConfig.lwt().retries());
   }
@@ -81,7 +81,7 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
       return FindOperation.vsearchSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper,
           vector);
@@ -93,7 +93,7 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
       return FindOperation.sortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
           operationsConfig.defaultSortPageSize(),
           ReadType.SORTED_DOCUMENT,
@@ -107,7 +107,7 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
       return FindOperation.unsortedSingle(
           commandContext,
           logicalExpression,
-          DocumentProjector.defaultProjector(),
+          DocumentProjector.includeAllProjector(),
           ReadType.DOCUMENT,
           objectMapper);
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -126,8 +126,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
                         "name": "Joe",
                         "age": 42,
                         "enabled": true,
-                        "value": -1,
-                        "$vector" : [ 0.5, -0.25 ]
+                        "value": -1
                       }
                       """))
           .body("status.matchedCount", is(1))
@@ -144,7 +143,6 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
                 "name": "Bob",
                 "age": 77,
                 "enabled": true,
-                "$vector" : [ 0.5, -0.25 ],
                 "value": 3
               }
               """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -1408,7 +1408,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               """
           {
             "find": {
-              "filter" : {"_id" : "bigVectorForFindReplace"}
+              "filter" : {"_id" : "bigVectorForFindReplace"},
+              "projection": { "*": 1 }
             }
           }
           """)
@@ -1428,6 +1429,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                     {
                       "findOneAndReplace": {
                         "filter" : {"_id" : "bigVectorForFindReplace"},
+                        "projection": { "*": 1 },
                         "replacement" : {"_id" : "bigVectorForFindReplace", "$vector" : [ %s ]},
                         "options" : {"returnDocument" : "after"}
                       }
@@ -1458,7 +1460,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               """
                       {
                         "find": {
-                          "filter" : {"_id" : "bigVectorForFindReplace"}
+                          "filter" : {"_id" : "bigVectorForFindReplace"},
+                          "projection": { "*": 1 }
                         }
                       }
                       """)
@@ -1481,7 +1484,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
             {
               "findOneAndDelete": {
-                "projection": { "$vector": 1 },
+                "projection": { "*": 1 },
                 "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
               }
             }
@@ -1498,8 +1501,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("errors", is(nullValue()))
           .body("status.deletedCount", is(1))
           .body("data.document._id", is("3"))
-          .body("data.document.$vector", is(notNullValue()))
-          .body("data.document.name", is("Vision Vector Frame"));
+          .body("data.document.name", is("Vision Vector Frame"))
+          .body("data.document.$vector", is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -202,7 +202,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
         {
           "find": {
-            "filter" : {"_id" : "1"}
+            "filter" : {"_id" : "1"},
+            "projection": { "$vector": 1 }
           }
         }
         """;
@@ -224,8 +225,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.documents[0]", jsonEquals(expected))
-          .body("errors", is(nullValue()));
+          .body("errors", is(nullValue()))
+          .body("data.documents[0]", jsonEquals(expected));
     }
 
     // Test to verify vector embedding size can exceed general Array length limit
@@ -243,7 +244,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               """
             {
               "find": {
-                "filter" : {"_id" : "bigVector1"}
+                "filter" : {"_id" : "bigVector1"},
+                "projection": { "$vector": 1 }
               }
             }
             """)
@@ -455,7 +457,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
                       {
                         "find": {
-                          "filter" : {"_id" : "2"}
+                          "filter" : {"_id" : "2"},
+                          "projection": { "$vector": 1 }
                         }
                       }
                       """;
@@ -477,8 +480,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.documents[0]", jsonEquals(expected))
-          .body("errors", is(nullValue()));
+          .body("errors", is(nullValue()))
+          .body("data.documents[0]", jsonEquals(expected));
     }
   }
 
@@ -1054,6 +1057,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"_id": "2"},
+                          "projection": { "$vector": 1 },
                           "update" : {"$set" : {"$vector" : [0.25, 0.25, 0.25, 0.25, 0.25]}},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1083,6 +1087,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"name": "Coded Cleats"},
+                          "projection": { "$vector": 1 },
                           "update" : {"$unset" : {"$vector" : null}},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1112,6 +1117,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"_id": "11"},
+                          "projection": { "$vector": 1 },
                           "update" : {"$setOnInsert" : {"$vector": [0.11, 0.22, 0.33, 0.44, 0.55]}},
                           "options" : {"returnDocument" : "after", "upsert": true}
                         }
@@ -1176,12 +1182,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .contentType(ContentType.JSON)
           .body(
               """
-                                      {
-                                        "find": {
-                                          "filter" : {"_id" : "bigVectorForSet"}
-                                        }
-                                      }
-                                      """)
+                {
+                  "find": {
+                    "filter" : {"_id" : "bigVectorForSet"},
+                    "projection": { "$vector": 1 }
+                  }
+                }
+                """)
           .when()
           .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
           .then()
@@ -1198,6 +1205,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"_id": "bigVectorForSet"},
+                          "projection": { "$vector": 1 },
                           "update" : {"$set" : {"$vector" : [ %s ]}},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1228,7 +1236,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               """
                         {
                           "find": {
-                            "filter" : {"_id" : "bigVectorForSet"}
+                            "filter" : {"_id" : "bigVectorForSet"},
+                            "projection": { "$vector": 1 }
                           }
                         }
                         """)
@@ -1332,6 +1341,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndReplace": {
                           "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                          "projection": { "$vector": 1 },
                           "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1472,6 +1482,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
             {
               "findOneAndDelete": {
+                "projection": { "$vector": 1 },
                 "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
               }
             }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -203,7 +203,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
         {
           "find": {
             "filter" : {"_id" : "1"},
-            "projection": { "$vector": 1 }
+            "projection": { "*": 1 }
           }
         }
         """;
@@ -245,7 +245,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
             {
               "find": {
                 "filter" : {"_id" : "bigVector1"},
-                "projection": { "$vector": 1 }
+                "projection": { "*": 1 }
               }
             }
             """)
@@ -458,7 +458,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "find": {
                           "filter" : {"_id" : "2"},
-                          "projection": { "$vector": 1 }
+                          "projection": { "*": 1 }
                         }
                       }
                       """;
@@ -1057,7 +1057,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"_id": "2"},
-                          "projection": { "$vector": 1 },
+                          "projection": { "*": 1 },
                           "update" : {"$set" : {"$vector" : [0.25, 0.25, 0.25, 0.25, 0.25]}},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1116,7 +1116,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"_id": "11"},
-                          "projection": { "$vector": 1 },
+                          "projection": { "*": 1 },
                           "update" : {"$setOnInsert" : {"$vector": [0.11, 0.22, 0.33, 0.44, 0.55]}},
                           "options" : {"returnDocument" : "after", "upsert": true}
                         }
@@ -1184,7 +1184,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                 {
                   "find": {
                     "filter" : {"_id" : "bigVectorForSet"},
-                    "projection": { "$vector": 1 }
+                    "projection": { "*": 1 }
                   }
                 }
                 """)
@@ -1204,7 +1204,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"_id": "bigVectorForSet"},
-                          "projection": { "$vector": 1 },
+                          "projection": { "*": 1 },
                           "update" : {"$set" : {"$vector" : [ %s ]}},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1236,7 +1236,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                         {
                           "find": {
                             "filter" : {"_id" : "bigVectorForSet"},
-                            "projection": { "$vector": 1 }
+                            "projection": { "*": 1 }
                           }
                         }
                         """)
@@ -1340,7 +1340,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndReplace": {
                           "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-                          "projection": { "$vector": 1 },
+                          "projection": { "*": 1 },
                           "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
                           "options" : {"returnDocument" : "after"}
                         }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -1072,11 +1072,11 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.document._id", is("2"))
-          .body("data.document.$vector", contains(0.25f, 0.25f, 0.25f, 0.25f, 0.25f))
+          .body("errors", is(nullValue()))
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(1))
-          .body("errors", is(nullValue()));
+          .body("data.document._id", is("2"))
+          .body("data.document.$vector", contains(0.25f, 0.25f, 0.25f, 0.25f, 0.25f));
     }
 
     @Test
@@ -1087,7 +1087,6 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                       {
                         "findOneAndUpdate": {
                           "filter" : {"name": "Coded Cleats"},
-                          "projection": { "$vector": 1 },
                           "update" : {"$unset" : {"$vector" : null}},
                           "options" : {"returnDocument" : "after"}
                         }
@@ -1102,11 +1101,11 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.document._id", is("1"))
-          .body("data.document.$vector", is(nullValue()))
+          .body("errors", is(nullValue()))
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(1))
-          .body("errors", is(nullValue()));
+          .body("data.document._id", is("1"))
+          .body("data.document.$vector", is(nullValue()));
     }
 
     @Test
@@ -1444,12 +1443,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
           .then()
           .statusCode(200)
+          .body("errors", is(nullValue()))
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(1))
           .body("data.document._id", is("bigVectorForFindReplace"))
           .body("data.document.$vector", is(notNullValue()))
-          .body("data.document.$vector", hasSize(BIG_VECTOR_SIZE))
-          .body("errors", is(nullValue()));
+          .body("data.document.$vector", hasSize(BIG_VECTOR_SIZE));
 
       // and verify it was set to value with expected size
       given()
@@ -1496,11 +1495,11 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("status.deletedCount", is(1))
           .body("data.document._id", is("3"))
           .body("data.document.$vector", is(notNullValue()))
-          .body("data.document.name", is("Vision Vector Frame"))
-          .body("status.deletedCount", is(1))
-          .body("errors", is(nullValue()));
+          .body("data.document.name", is("Vision Vector Frame"));
     }
 
     @Test
@@ -1525,9 +1524,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", is(nullValue()))
           .body("status.deletedCount", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
+          .body("data", is(nullValue()));
 
       // ensure find does not find the document
       json =
@@ -1547,9 +1546,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.document", is(nullValue()))
+          .body("errors", is(nullValue()))
           .body("status", is(nullValue()))
-          .body("errors", is(nullValue()));
+          .body("data.document", is(nullValue()));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -235,7 +235,8 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           """
             {
               "find": {
-                "filter" : {"_id" : "1"}
+                "filter" : {"_id" : "1"},
+                "projection": { "$vector": 1 }
               }
             }
             """;
@@ -253,10 +254,10 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", is(nullValue()))
           .body("data.documents[0]._id", is("1"))
           .body("data.documents[0].$vector", is(notNullValue()))
-          .body("data.documents[0].$vector", contains(0.1f, 0.15f, 0.3f, 0.12f, 0.05f))
-          .body("errors", is(nullValue()));
+          .body("data.documents[0].$vector", contains(0.1f, 0.15f, 0.3f, 0.12f, 0.05f));
     }
 
     @Test
@@ -460,7 +461,8 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           """
         {
           "find": {
-            "filter" : {"_id" : "2"}
+            "filter" : {"_id" : "2"},
+            "projection": { "$vector": 1 }
           }
         }
         """;
@@ -473,9 +475,9 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", is(nullValue()))
           .body("data.documents[0]._id", is("2"))
-          .body("data.documents[0].$vector", is(notNullValue()))
-          .body("errors", is(nullValue()));
+          .body("data.documents[0].$vector", is(notNullValue()));
     }
   }
 
@@ -675,6 +677,7 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           """
             {
               "find": {
+                "projection": { "$vector": 1 },
                 "sort" : {"$vectorize" : "ChatGPT integrated sneakers that talk to you"}
               }
             }
@@ -817,6 +820,7 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
         {
           "findOneAndUpdate": {
             "filter" : {"_id": "2"},
+            "projection": { "$vector": 1 },
             "update" : {"$set" : {"description" : "ChatGPT upgraded", "$vectorize" : "ChatGPT upgraded"}},
             "options" : {"returnDocument" : "after"}
           }
@@ -881,6 +885,7 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           {
             "findOneAndUpdate": {
               "filter" : {"_id": "11"},
+              "projection": { "$vector": 1 },
               "update" : {"$setOnInsert" : {"$vectorize": "New data updated"}},
               "options" : {"returnDocument" : "after", "upsert": true}
             }
@@ -1006,6 +1011,7 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           """
           {
             "findOneAndReplace": {
+              "projection": { "$vector": 1 },
               "sort" : {"$vectorize" : "ChatGPT integrated sneakers that talk to you"},
               "replacement" : {"_id" : "1", "username": "user1", "status" : false, "description" : "Updating new data", "$vectorize" : "Updating new data"},
               "options" : {"returnDocument" : "after"}
@@ -1079,7 +1085,8 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           """
                 {
                   "findOneAndDelete": {
-                    "sort" : {"$vectorize" : "ChatGPT integrated sneakers that talk to you"}
+                    "sort" : {"$vectorize" : "ChatGPT integrated sneakers that talk to you"},
+                    "projection": { "$vector": 1 }
                   }
                 }
                 """;
@@ -1097,11 +1104,11 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("status.deletedCount", is(1))
           .body("data.document._id", is("1"))
           .body("data.document.$vector", is(notNullValue()))
-          .body("data.document.name", is("Coded Cleats"))
-          .body("status.deletedCount", is(1))
-          .body("errors", is(nullValue()));
+          .body("data.document.name", is("Coded Cleats"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -665,9 +665,9 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .then()
           .statusCode(200)
           .body("errors", hasSize(1))
-          .body("errors[0].message", startsWith("$vectorize search clause needs to be text value"))
           .body("errors[0].errorCode", is("SHRED_BAD_VECTORIZE_VALUE"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].message", startsWith("$vectorize search clause needs to be text value"));
     }
 
     @Test
@@ -677,7 +677,7 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           """
             {
               "find": {
-                "projection": { "$vector": 1 },
+                "projection": { "$vector": 1, "$vectorize" : 1 },
                 "sort" : {"$vectorize" : "ChatGPT integrated sneakers that talk to you"}
               }
             }
@@ -699,8 +699,8 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .body("data.documents", hasSize(1))
           .body("data.documents[0]._id", is("1"))
           .body("data.documents[0].$vector", is(notNullValue()))
-          .body("data.documents[0].$vectorize", is(notNullValue()))
-          .body("data.documents[0].$vector", contains(0.1f, 0.15f, 0.3f, 0.12f, 0.05f));
+          .body("data.documents[0].$vector", contains(0.1f, 0.15f, 0.3f, 0.12f, 0.05f))
+          .body("data.documents[0].$vectorize", is(notNullValue()));
     }
   }
 
@@ -739,8 +739,8 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.document._id", is("1"))
-          .body("errors", is(nullValue()));
+          .body("errors", is(nullValue()))
+          .body("data.document._id", is("1"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -1086,7 +1086,7 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
                 {
                   "findOneAndDelete": {
                     "sort" : {"$vectorize" : "ChatGPT integrated sneakers that talk to you"},
-                    "projection": { "$vector": 1 }
+                    "projection": { "*": 1 }
                   }
                 }
                 """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -1107,8 +1107,8 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .body("errors", is(nullValue()))
           .body("status.deletedCount", is(1))
           .body("data.document._id", is("1"))
-          .body("data.document.$vector", is(notNullValue()))
-          .body("data.document.name", is("Coded Cleats"));
+          .body("data.document.name", is("Coded Cleats"))
+          .body("data.document.$vector", is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -2643,7 +2643,7 @@ public class FindOperationTest extends OperationTestBase {
           FindOperation.vsearch(
               VECTOR_COMMAND_CONTEXT,
               implicitAnd,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               null,
               2,
               2,
@@ -2711,7 +2711,7 @@ public class FindOperationTest extends OperationTestBase {
           FindOperation.vsearchSingle(
               VECTOR_COMMAND_CONTEXT,
               implicitAnd,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               ReadType.DOCUMENT,
               objectMapper,
               new float[] {0.25f, 0.25f, 0.25f, 0.25f});

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -936,7 +936,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
           FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               implicitAnd,
-              DocumentProjector.includeAllProjector(),
+              DocumentProjector.defaultProjector(),
               ReadType.DOCUMENT,
               objectMapper);
 
@@ -971,7 +971,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
               false,
               true,
               shredder,
-              DocumentProjector.includeAllProjector(),
+              DocumentProjector.defaultProjector(),
               1,
               3);
 
@@ -1398,7 +1398,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
               false,
               true,
               shredder,
-              DocumentProjector.includeAllProjector(),
+              DocumentProjector.defaultProjector(),
               1,
               3);
 
@@ -1702,7 +1702,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
           FindOperation.unsorted(
               COMMAND_CONTEXT,
               implicitAnd,
-              DocumentProjector.includeAllProjector(),
+              DocumentProjector.defaultProjector(),
               null,
               21,
               20,

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -936,7 +936,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
           FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               implicitAnd,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               ReadType.DOCUMENT,
               objectMapper);
 
@@ -971,7 +971,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
               false,
               true,
               shredder,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               1,
               3);
 
@@ -1398,7 +1398,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
               false,
               true,
               shredder,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               1,
               3);
 
@@ -1702,7 +1702,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
           FindOperation.unsorted(
               COMMAND_CONTEXT,
               implicitAnd,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               null,
               21,
               20,
@@ -1721,7 +1721,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
               false,
               true,
               shredder,
-              DocumentProjector.defaultProjector(),
+              DocumentProjector.includeAllProjector(),
               20,
               3);
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -753,6 +753,72 @@ public class DocumentProjectorTest {
               }
               """));
     }
+
+    @Test
+    void includeIdExcludeVector() throws Exception {
+      final String docJson =
+          """
+                      {
+                        "_id": "id",
+                        "$vector": [0.25, 0.5],
+                        "value": 42
+                      }
+                      """;
+
+      // First with filter starting with _id:
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                                      { "_id": 1, "$vector": 0 }
+                                      """));
+      // exclusion by default since no regular fields specified
+      assertThat(projection.isInclusion()).isFalse();
+      JsonNode doc = objectMapper.readTree(docJson);
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+                                      {
+                                        "_id": "id",
+                                        "value": 42
+                                      }
+                                      """));
+    }
+
+    @Test
+    void excludeIdIncludeVector() throws Exception {
+      final String docJson =
+          """
+                          {
+                            "_id": "id",
+                            "$vector": [0.25, 0.5],
+                            "value": 42
+                          }
+                          """;
+
+      // First with filter starting with _id:
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                                      { "_id": 0, "$vector": 1 }
+                                      """));
+      // exclusion by default since no regular fields specified
+      assertThat(projection.isInclusion()).isFalse();
+      JsonNode doc = objectMapper.readTree(docJson);
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+                                      {
+                                        "$vector": [0.25, 0.5],
+                                        "value": 42
+                                      }
+                                      """));
+    }
   }
 
   // Special case of [data-api#1001]: include-all / exclude-all

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -37,12 +37,12 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-              { "root" :
-                { "branch" :
-                  { "": 1 }
-                }
-              }
-              """);
+                              { "root" :
+                                { "branch" :
+                                  { "": 1 }
+                                }
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -56,11 +56,11 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-              { "excludeMe" : 0,
-                "excludeMeToo" : 0,
-                "include.me" : 1
-              }
-              """);
+                              { "excludeMe" : 0,
+                                "excludeMeToo" : 0,
+                                "include.me" : 1
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -74,11 +74,11 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-                      { "branch" : 1,
-                        "branch.x.leaf" : 1,
-                        "include.me" : 1
-                      }
-                      """);
+                              { "branch" : 1,
+                                "branch.x.leaf" : 1,
+                                "include.me" : 1
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -90,11 +90,11 @@ public class DocumentProjectorTest {
       JsonNode def2 =
           objectMapper.readTree(
               """
-                      { "a.y.leaf" : 1,
-                        "a" : 1,
-                        "value" : 1
-                      }
-                      """);
+                              { "a.y.leaf" : 1,
+                                "a" : 1,
+                                "value" : 1
+                              }
+                              """);
       Throwable t2 = catchThrowable(() -> DocumentProjector.createFromDefinition(def2));
       assertThat(t2)
           .isInstanceOf(JsonApiException.class)
@@ -108,16 +108,16 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-              { "includeMe" : 1,
-                "misc" : {
-                   "nested": {
-                     "do" : true,
-                     "dont" : false
-                    }
-                },
-                "includeMe2" : 1
-              }
-              """);
+                              { "includeMe" : 1,
+                                "misc" : {
+                                   "nested": {
+                                     "do" : true,
+                                     "dont" : false
+                                    }
+                                },
+                                "includeMe2" : 1
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -157,10 +157,10 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-                      { "_id": 1,
-                        "$similarity": 1
-                      }
-                      """);
+                              { "_id": 1,
+                                "$similarity": 1
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -177,11 +177,11 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-                      { "include" : {
-                           "$set" : 1
-                         }
-                      }
-                      """);
+                              { "include" : {
+                                   "$set" : 1
+                                 }
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -230,12 +230,12 @@ public class DocumentProjectorTest {
       JsonNode def =
           objectMapper.readTree(
               """
-                      {
-                        "include" : {
-                           "$slice" : "text-not-accepted"
-                        }
-                      }
-                      """);
+                              {
+                                "include" : {
+                                   "$slice" : "text-not-accepted"
+                                }
+                              }
+                              """);
       Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
@@ -290,48 +290,48 @@ public class DocumentProjectorTest {
       final JsonNode doc =
           objectMapper.readTree(
               """
-                      { "_id" : 1,
-                         "value1" : true,
-                         "value2" : false,
-                         "nested" : {
-                            "x": 3,
-                            "y": 4,
-                            "z": -1
-                         },
-                         "nested2" : {
-                            "z": 5
-                         },
-                         "$vector" : [0.11, 0.22, 0.33, 0.44]
-                      }
-                      """);
+                              { "_id" : 1,
+                                 "value1" : true,
+                                 "value2" : false,
+                                 "nested" : {
+                                    "x": 3,
+                                    "y": 4,
+                                    "z": -1
+                                 },
+                                 "nested2" : {
+                                    "z": 5
+                                 },
+                                 "$vector" : [0.11, 0.22, 0.33, 0.44]
+                              }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree(
                   """
-                      { "value2" : 1,
-                        "nested" : {
-                           "x": 1
-                        },
-                        "nested.z": 1,
-                        "nosuchprop": 1,
-                        "$vector": 1
-                      }
-                      """));
+                                      { "value2" : 1,
+                                        "nested" : {
+                                           "x": 1
+                                        },
+                                        "nested.z": 1,
+                                        "nosuchprop": 1,
+                                        "$vector": 1
+                                      }
+                                      """));
       assertThat(projection.isInclusion()).isTrue();
       projection.applyProjection(doc);
       assertThat(doc)
           .isEqualTo(
               objectMapper.readTree(
                   """
-              { "_id" : 1,
-                 "value2" : false,
-                 "nested" : {
-                    "x": 3,
-                    "z": -1
-                 },
-                 "$vector" : [0.11, 0.22, 0.33, 0.44]
-              }
-                      """));
+                                      { "_id" : 1,
+                                         "value2" : false,
+                                         "nested" : {
+                                            "x": 3,
+                                            "z": -1
+                                         },
+                                         "$vector" : [0.11, 0.22, 0.33, 0.44]
+                                      }
+                                              """));
     }
 
     @Test
@@ -339,28 +339,28 @@ public class DocumentProjectorTest {
       final JsonNode doc =
           objectMapper.readTree(
               """
-            { "_id" : 1,
-               "value1" : true,
-               "value2" : false,
-               "nested" : {
-                  "x": 3,
-                  "y": 4,
-                  "z": -1
-               },
-               "nested2" : {
-                  "z": 5
-               },
-               "$vector" : [0.11, 0.22, 0.33, 0.44]
-            }
-            """);
+                              { "_id" : 1,
+                                 "value1" : true,
+                                 "value2" : false,
+                                 "nested" : {
+                                    "x": 3,
+                                    "y": 4,
+                                    "z": -1
+                                 },
+                                 "nested2" : {
+                                    "z": 5
+                                 },
+                                 "$vector" : [0.11, 0.22, 0.33, 0.44]
+                              }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree(
                   """
-                { "value2" : 1,
-                  "$vector": 1
-                }
-                """),
+                                      { "value2" : 1,
+                                        "$vector": 1
+                                      }
+                                      """),
               true);
       assertThat(projection.isInclusion()).isTrue();
       projection.applyProjection(doc, 0.25f);
@@ -374,43 +374,43 @@ public class DocumentProjectorTest {
       final JsonNode doc =
           objectMapper.readTree(
               """
-                      { "_id" : 1,
-                         "value1" : true,
-                         "nested" : {
-                            "x": 3,
-                            "z": -1
-                         },
-                         "nested2" : {
-                            "z": 5
-                         }
-                      }
-                      """);
+                              { "_id" : 1,
+                                 "value1" : true,
+                                 "nested" : {
+                                    "x": 3,
+                                    "z": -1
+                                 },
+                                 "nested2" : {
+                                    "z": 5
+                                 }
+                              }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree(
                   """
-                      { "value1" : 1,
-                        "nested" : {
-                           "x": 1
-                        },
-                        "_id": 0,
-                        "nested2.unknown": 1
-                      }
-                      """));
+                                      { "value1" : 1,
+                                        "nested" : {
+                                           "x": 1
+                                        },
+                                        "_id": 0,
+                                        "nested2.unknown": 1
+                                      }
+                                      """));
       assertThat(projection.isInclusion()).isTrue();
       projection.applyProjection(doc);
       assertThat(doc)
           .isEqualTo(
               objectMapper.readTree(
                   """
-              {
-                 "value1": true,
-                 "nested" : {
-                    "x": 3
-                 },
-                 "nested2" : { }
-              }
-              """));
+                                      {
+                                         "value1": true,
+                                         "nested" : {
+                                            "x": 3
+                                         },
+                                         "nested2" : { }
+                                      }
+                                      """));
     }
 
     @Test
@@ -418,17 +418,17 @@ public class DocumentProjectorTest {
       final JsonNode doc =
           objectMapper.readTree(
               """
-                      { "values" : [ {
-                           "x": 1,
-                           "y": 2
-                        }, {
-                           "y": false,
-                           "z": true
-                        } ],
-                        "array2": [1, 2],
-                        "array3": [2, 3]
-                      }
-              """);
+                                      { "values" : [ {
+                                           "x": 1,
+                                           "y": 2
+                                        }, {
+                                           "y": false,
+                                           "z": true
+                                        } ],
+                                        "array2": [1, 2],
+                                        "array3": [2, 3]
+                                      }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree("{ \"values.y\": 1, \"values.z\":1, \"array3\":1}"));
@@ -438,15 +438,15 @@ public class DocumentProjectorTest {
           .isEqualTo(
               objectMapper.readTree(
                   """
-                      { "values" : [ {
-                           "y": 2
-                        }, {
-                           "y": false,
-                           "z": true
-                        } ],
-                        "array3": [2, 3]
-                      }
-                      """));
+                                      { "values" : [ {
+                                           "y": 2
+                                        }, {
+                                           "y": false,
+                                           "z": true
+                                        } ],
+                                        "array3": [2, 3]
+                                      }
+                                      """));
     }
   }
 
@@ -457,51 +457,51 @@ public class DocumentProjectorTest {
       final JsonNode doc =
           objectMapper.readTree(
               """
-                      {  "_id" : 123,
-                         "value1" : true,
-                         "value2" : false,
-                         "nested" : {
-                            "x": 3,
-                            "y": 4,
-                            "z": -1
-                         },
-                         "nested2" : {
-                            "z": 5
-                         },
-                         "$vector" : [0.11, 0.22, 0.33, 0.44]
-                      }
-                      """);
+                              {  "_id" : 123,
+                                 "value1" : true,
+                                 "value2" : false,
+                                 "nested" : {
+                                    "x": 3,
+                                    "y": 4,
+                                    "z": -1
+                                 },
+                                 "nested2" : {
+                                    "z": 5
+                                 },
+                                 "$vector" : [0.11, 0.22, 0.33, 0.44]
+                              }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree(
                   """
-                                  {
-                                    "value1" : 0,
-                                    "nested" : {
-                                       "x": 0
-                                    },
-                                    "nested.z": 0,
-                                    "nosuchprop": 0,
-                                    "$vector": 0
-                                  }
-                                  """));
+                                      {
+                                        "value1" : 0,
+                                        "nested" : {
+                                           "x": 0
+                                        },
+                                        "nested.z": 0,
+                                        "nosuchprop": 0,
+                                        "$vector": 0
+                                      }
+                                      """));
       assertThat(projection.isInclusion()).isFalse();
       projection.applyProjection(doc);
       assertThat(doc)
           .isEqualTo(
               objectMapper.readTree(
                   """
-                          {
-                             "_id" : 123,
-                             "value2" : false,
-                             "nested" : {
-                                "y": 4
-                             },
-                             "nested2" : {
-                               "z": 5
-                             }
-                          }
-                                  """));
+                                      {
+                                         "_id" : 123,
+                                         "value2" : false,
+                                         "nested" : {
+                                            "y": 4
+                                         },
+                                         "nested2" : {
+                                           "z": 5
+                                         }
+                                      }
+                                              """));
     }
 
     @Test
@@ -509,45 +509,45 @@ public class DocumentProjectorTest {
       final JsonNode doc =
           objectMapper.readTree(
               """
-                      { "_id" : 123,
-                         "value1" : true,
-                         "nested" : {
-                            "x": 3,
-                            "z": -1
-                         },
-                         "nested2" : {
-                            "z": 5
-                         }
-                      }
-                      """);
+                              { "_id" : 123,
+                                 "value1" : true,
+                                 "nested" : {
+                                    "x": 3,
+                                    "z": -1
+                                 },
+                                 "nested2" : {
+                                    "z": 5
+                                 }
+                              }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree(
                   """
-                                  {
-                                    "_id": 0,
-                                    "value1" : 0,
-                                    "nested" : {
-                                       "x": 0
-                                    },
-                                    "nested2.unknown": 0
-                                  }
-                                  """));
+                                      {
+                                        "_id": 0,
+                                        "value1" : 0,
+                                        "nested" : {
+                                           "x": 0
+                                        },
+                                        "nested2.unknown": 0
+                                      }
+                                      """));
       assertThat(projection.isInclusion()).isFalse();
       projection.applyProjection(doc);
       assertThat(doc)
           .isEqualTo(
               objectMapper.readTree(
                   """
-                          {
-                             "nested" : {
-                                "z": -1
-                             },
-                             "nested2" : {
-                               "z" : 5
-                             }
-                          }
-                          """));
+                                      {
+                                         "nested" : {
+                                            "z": -1
+                                         },
+                                         "nested2" : {
+                                           "z" : 5
+                                         }
+                                      }
+                                      """));
     }
 
     @Test
@@ -555,17 +555,17 @@ public class DocumentProjectorTest {
       JsonNode doc =
           objectMapper.readTree(
               """
-                              { "values" : [ {
-                                   "x": 1,
-                                   "y": 2
-                                }, {
-                                   "y": false,
-                                   "z": true
-                                } ],
-                                "array2": [2, 3],
-                                "array3": [2, 3]
-                              }
-                      """);
+                                      { "values" : [ {
+                                           "x": 1,
+                                           "y": 2
+                                        }, {
+                                           "y": false,
+                                           "z": true
+                                        } ],
+                                        "array2": [2, 3],
+                                        "array3": [2, 3]
+                                      }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(
               objectMapper.readTree("{ \"values.y\": 0, \"values.z\":0,\"array3\":0}"));
@@ -575,13 +575,13 @@ public class DocumentProjectorTest {
           .isEqualTo(
               objectMapper.readTree(
                   """
-                                  { "values" : [ {
-                                       "x": 1
-                                    }, {
-                                    } ],
-                                    "array2": [2, 3]
-                                  }
-                                  """));
+                                      { "values" : [ {
+                                           "x": 1
+                                        }, {
+                                        } ],
+                                        "array2": [2, 3]
+                                      }
+                                      """));
     }
 
     @Test
@@ -589,18 +589,18 @@ public class DocumentProjectorTest {
       JsonNode doc =
           objectMapper.readTree(
               """
-                      {
-                        "_id": "doc5",
-                        "username": "user5",
-                        "sub_doc" : {
-                          "a": 5,
-                          "b": {
-                            "c": "v1",
-                            "d": false
-                          }
-                        }
-                      }
-                      """);
+                              {
+                                "_id": "doc5",
+                                "username": "user5",
+                                "sub_doc" : {
+                                  "a": 5,
+                                  "b": {
+                                    "c": "v1",
+                                    "d": false
+                                  }
+                                }
+                              }
+                              """);
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(objectMapper.readTree("{ \"sub_doc.b\": 0 }"));
       assertThat(projection.isInclusion()).isFalse();
@@ -609,14 +609,14 @@ public class DocumentProjectorTest {
           .isEqualTo(
               objectMapper.readTree(
                   """
-                              {
-                                "_id": "doc5",
-                                "username": "user5",
-                                "sub_doc" : {
-                                  "a": 5
-                                }
-                              }
-                              """));
+                                      {
+                                        "_id": "doc5",
+                                        "username": "user5",
+                                        "sub_doc" : {
+                                          "a": 5
+                                        }
+                                      }
+                                      """));
     }
 
     // "Empty" Projection is not really inclusion or exclusion, but technically
@@ -637,6 +637,121 @@ public class DocumentProjectorTest {
       assertThat(projection.isInclusion()).isFalse();
       projection.applyProjection(doc);
       assertThat(doc).isEqualTo(objectMapper.readTree(docJson));
+    }
+  }
+
+  // Tests to see that specific handling of _id works with various
+  // configurations
+  @Nested
+  class ProjectorApplyIdExcludeInclude {
+    @Test
+    void includeIdExcludeProperty() throws Exception {
+      final String docJson =
+          """
+              {
+                "_id": "id",
+                "value1": 1,
+                "value2": 2,
+                "value3": 3
+              }
+              """;
+
+      // First with filter starting with _id:
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                      { "_id": 1, "value2": 0 }
+                      """));
+      // exclusion since we have explicit exclusion for non-id field
+      assertThat(projection.isInclusion()).isFalse();
+      JsonNode doc = objectMapper.readTree(docJson);
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+              {
+                "_id": "id",
+                "value1": 1,
+                "value3": 3
+              }
+              """));
+
+      // Then the other way around
+      projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                      { "value2": 0, "_id": 1 }
+                      """));
+      // exclusion since we have explicit exclusion for non-id field
+      assertThat(projection.isInclusion()).isFalse();
+      doc = objectMapper.readTree(docJson);
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+              {
+                "_id": "id",
+                "value1": 1,
+                "value3": 3
+              }
+              """));
+    }
+
+    @Test
+    void excludeIdIncludeProperty() throws Exception {
+      final String docJson =
+          """
+              {
+                "_id": "id",
+                "value1": 1,
+                "value2": 2,
+                "value3": 3
+              }
+              """;
+
+      // First with filter starting with _id:
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                      { "_id": 0, "value2": 1 }
+                      """));
+      // inclusion since we have explicit inclusion for non-id field
+      assertThat(projection.isInclusion()).isTrue();
+      JsonNode doc = objectMapper.readTree(docJson);
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+              {
+                "value2": 2
+              }
+              """));
+
+      // then reverse order for filter
+      projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                      { "value2": 1, "_id": 0 }
+                      """));
+      // inclusion since we have explicit inclusion for non-id field
+      assertThat(projection.isInclusion()).isTrue();
+      doc = objectMapper.readTree(docJson);
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+              {
+                "value2": 2
+              }
+              """));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -265,25 +265,58 @@ public class DocumentProjectorTest {
   }
 
   @Nested
-  class ProjectorApplyInclusions {
+  class ProjectorApplyDefaultProjection {
     // [json-api#634]: empty Object same as "include all"
     @Test
-    public void testIncludeWithEmptyProject() throws Exception {
-      final JsonNode doc =
-          objectMapper.readTree(
-              """
-                              {
-                                 "_id" : 1,
-                                 "value1": 42
-                              }
-                              """);
+    public void defaultProjectionRegularFieldsOnly() throws Exception {
+      final String docJson =
+          """
+                          {
+                             "_id" : 1,
+                             "value1": 42
+                          }
+                          """;
       DocumentProjector projection =
           DocumentProjector.createFromDefinition(objectMapper.readTree("{ }"));
+      final JsonNode doc = objectMapper.readTree(docJson);
       // Technically considered "Exclusion" but one that excludes nothing
       assertThat(projection.isInclusion()).isFalse();
       projection.applyProjection(doc);
-      assertThat(doc).isEqualTo(doc);
+      assertThat(doc).isEqualTo(objectMapper.readTree(docJson));
     }
+
+    @Test
+    public void defaultProjectionMixAll() throws Exception {
+      final String docJson =
+          """
+                                      {
+                                         "_id" : 1,
+                                         "value1": 42,
+                                         "$vector": [0.0, 1.0],
+                                         "value2": -3
+                                      }
+                                      """;
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(objectMapper.readTree("{ }"));
+      final JsonNode doc = objectMapper.readTree(docJson);
+
+      assertThat(projection.isInclusion()).isFalse();
+      projection.applyProjection(doc);
+      assertThat(doc)
+          .isEqualTo(
+              objectMapper.readTree(
+                  """
+                      {
+                         "_id" : 1,
+                         "value1": 42,
+                         "value2": -3
+                      }
+                      """));
+    }
+  }
+
+  @Nested
+  class ProjectorApplyInclusions {
 
     @Test
     public void testSimpleIncludeWithId() throws Exception {


### PR DESCRIPTION
**What this PR does**:

Will change default projection inclusion to exclude `$vector` and `$vectorize`, needing explicit inclusion.

**Which issue(s) this PR fixes**:
Fixes #1005

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
