### PR TITLE
(WIP) Increase maximum doc size to 16MB

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Positive;
 @ConfigMapping(prefix = "stargate.jsonapi.document.limits")
 public interface DocumentLimitsConfig {
   /** Defines the default maximum document size. */
-  int DEFAULT_MAX_DOCUMENT_SIZE = 4_000_000;
+  int DEFAULT_MAX_DOCUMENT_SIZE = 16_000_000;
 
   /** Defines the default maximum document (nesting) depth */
   int DEFAULT_MAX_DOCUMENT_DEPTH = 16;
@@ -57,7 +57,7 @@ public interface DocumentLimitsConfig {
   int DEFAULT_MAX_VECTOR_EMBEDDING_LENGTH = 4096;
 
   /**
-   * @return Defines the maximum document size, defaults to {@code 4 meg} (4 million characters).
+   * @return Defines the maximum document size, defaults to {@code 16 meg} (16 million characters).
    */
   @Positive
   @WithDefault("" + DEFAULT_MAX_DOCUMENT_SIZE)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,9 +60,9 @@ quarkus:
 
     limits:
       # Let's limit low-level maximum HTTP request size to 20 megs: stricter
-      # limit (16 meg per document) is applied at the JSON API level.
+      # limit (16 meg per document) is applied at the Data API level.
       # Low-level limits may result in EPIPE/413 errors
-      # whereas at higher level we can use regular JSON API error responses
+      # whereas at higher level we can use regular Data API error responses
       max-body-size: 20M
 
     port: 8181

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,7 +60,7 @@ quarkus:
 
     limits:
       # Let's limit low-level maximum HTTP request size to 20 megs: stricter
-      # limit (4 meg per document) is applied at the JSON API level.
+      # limit (16 meg per document) is applied at the JSON API level.
       # Low-level limits may result in EPIPE/413 errors
       # whereas at higher level we can use regular JSON API error responses
       max-body-size: 20M

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -56,9 +56,9 @@ public class ShredderDocLimitsTest {
 
     @Test
     public void catchTooBigDoc() {
-      // Let's construct document above 4 meg limit (but otherwise legal), with
-      // (12x45) x 7.5k String values, divided in 12 sub documents of 45 properties
-      final ObjectNode bigDoc = createBigDoc(12, 45);
+      // Let's construct document above 16 meg limit (but otherwise legal), with
+      // (47x45) x 7.5k String values, divided in 48 sub documents of 45 properties
+      final ObjectNode bigDoc = createBigDoc(48, 45);
 
       Exception e = catchException(() -> shredder.shred(bigDoc));
       assertThat(e)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -57,7 +57,7 @@ public class ShredderDocLimitsTest {
     @Test
     public void catchTooBigDoc() {
       // Let's construct document above 16 meg limit (but otherwise legal), with
-      // (47x45) x 7.5k String values, divided in 48 sub documents of 45 properties
+      // (48x45) x 7.5k String values, divided in 48 sub documents of 45 properties
       final ObjectNode bigDoc = createBigDoc(48, 45);
 
       Exception e = catchException(() -> shredder.shred(bigDoc));


### PR DESCRIPTION
Increase Data API Maximum doc size from 4MB to 16MB

**Which issue(s) this PR fixes**:
Fixes [Jira](https://datastax.jira.com/jira/software/c/projects/C2/boards/525?assignee=712020%3Afe33438e-80b4-4c42-89f5-4f9383ed25cb&selectedIssue=C2-3427)

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
