### PR TITLE
Pass DataAPIRequestInfo instead of injecting

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -160,7 +160,8 @@ public class CollectionResource {
           @Size(min = 1, max = 48)
           String collection) {
     return schemaCache
-        .getCollectionSettings(dataApiRequestInfo.getTenantId(), namespace, collection)
+        .getCollectionSettings(
+            dataApiRequestInfo, dataApiRequestInfo.getTenantId(), namespace, collection)
         .onItemOrFailure()
         .transformToUni(
             (collectionProperty, throwable) -> {
@@ -193,7 +194,8 @@ public class CollectionResource {
                         jsonProcessingMetricsReporter);
 
                 // call processor
-                return meteredCommandProcessor.processCommand(commandContext, command);
+                return meteredCommandProcessor.processCommand(
+                    dataApiRequestInfo, commandContext, command);
               }
             })
         .map(commandResult -> commandResult.map());

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
@@ -5,6 +5,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.GeneralCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateNamespaceCommand;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.config.constants.OpenApiConstants;
 import io.stargate.sgv2.jsonapi.service.processor.MeteredCommandProcessor;
 import jakarta.inject.Inject;
@@ -32,6 +33,8 @@ import org.jboss.resteasy.reactive.RestResponse;
 @SecurityRequirement(name = OpenApiConstants.SecuritySchemes.TOKEN)
 @Tag(ref = "General")
 public class GeneralResource {
+
+  @Inject private DataApiRequestInfo dataApiRequestInfo;
 
   public static final String BASE_PATH = "/v1";
 
@@ -72,7 +75,7 @@ public class GeneralResource {
   public Uni<RestResponse<CommandResult>> postCommand(@NotNull @Valid GeneralCommand command) {
     // call processor
     return meteredCommandProcessor
-        .processCommand(CommandContext.empty(), command)
+        .processCommand(dataApiRequestInfo, CommandContext.empty(), command)
         // map to 2xx unless overridden by error
         .map(commandResult -> commandResult.map());
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResource.java
@@ -93,7 +93,7 @@ public class NamespaceResource {
 
     //     call processor
     return meteredCommandProcessor
-        .processCommand(commandContext, command)
+        .processCommand(dataApiRequestInfo, commandContext, command)
         // map to 2xx unless overridden by error
         .map(commandResult -> commandResult.map());
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCache.java
@@ -5,6 +5,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.grpc.StatusRuntimeException;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.schema.model.JsonapiTableMatcher;
@@ -33,12 +34,13 @@ public class NamespaceCache {
     this.objectMapper = objectMapper;
   }
 
-  protected Uni<CollectionSettings> getCollectionProperties(String collectionName) {
+  protected Uni<CollectionSettings> getCollectionProperties(
+      DataApiRequestInfo dataApiRequestInfo, String collectionName) {
     CollectionSettings collectionProperty = vectorCache.getIfPresent(collectionName);
     if (null != collectionProperty) {
       return Uni.createFrom().item(collectionProperty);
     } else {
-      return getVectorProperties(collectionName)
+      return getVectorProperties(dataApiRequestInfo, collectionName)
           .onItemOrFailure()
           .transformToUni(
               (result, error) -> {
@@ -90,9 +92,10 @@ public class NamespaceCache {
     }
   }
 
-  private Uni<CollectionSettings> getVectorProperties(String collectionName) {
+  private Uni<CollectionSettings> getVectorProperties(
+      DataApiRequestInfo dataApiRequestInfo, String collectionName) {
     return queryExecutor
-        .getSchema(namespace, collectionName)
+        .getSchema(dataApiRequestInfo, namespace, collectionName)
         .onItem()
         .transform(
             table -> {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/QueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/QueryExecutor.java
@@ -9,6 +9,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.core.servererrors.TruncateException;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
@@ -29,10 +30,11 @@ public class QueryExecutor {
   private final OperationsConfig operationsConfig;
 
   /** CQLSession cache. */
-  @Inject CQLSessionCache cqlSessionCache;
+  private final CQLSessionCache cqlSessionCache;
 
   @Inject
-  public QueryExecutor(OperationsConfig operationsConfig) {
+  public QueryExecutor(CQLSessionCache cqlSessionCache, OperationsConfig operationsConfig) {
+    this.cqlSessionCache = cqlSessionCache;
     this.operationsConfig = operationsConfig;
   }
 
@@ -47,7 +49,10 @@ public class QueryExecutor {
    * @return AsyncResultSet
    */
   public Uni<AsyncResultSet> executeRead(
-      SimpleStatement simpleStatement, Optional<String> pagingState, int pageSize) {
+      DataApiRequestInfo dataApiRequestInfo,
+      SimpleStatement simpleStatement,
+      Optional<String> pagingState,
+      int pageSize) {
     simpleStatement =
         simpleStatement
             .setPageSize(pageSize)
@@ -57,7 +62,8 @@ public class QueryExecutor {
           simpleStatement.setPagingState(ByteBuffer.wrap(decodeBase64(pagingState.get())));
     }
     return Uni.createFrom()
-        .completionStage(cqlSessionCache.getSession().executeAsync(simpleStatement));
+        .completionStage(
+            cqlSessionCache.getSession(dataApiRequestInfo).executeAsync(simpleStatement));
   }
 
   /**
@@ -67,12 +73,13 @@ public class QueryExecutor {
    *     query must have keyspace prefixed.
    * @return AsyncResultSet
    */
-  public CompletionStage<AsyncResultSet> executeCount(SimpleStatement simpleStatement) {
+  public CompletionStage<AsyncResultSet> executeCount(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement simpleStatement) {
     simpleStatement =
         simpleStatement
             .setExecutionProfileName("count")
             .setConsistencyLevel(operationsConfig.queriesConfig().consistency().reads());
-    return cqlSessionCache.getSession().executeAsync(simpleStatement);
+    return cqlSessionCache.getSession(dataApiRequestInfo).executeAsync(simpleStatement);
   }
 
   /**
@@ -82,11 +89,12 @@ public class QueryExecutor {
    *     query must have keyspace prefixed.
    * @return AsyncResultSet
    */
-  public CompletionStage<AsyncResultSet> executeEstimatedCount(SimpleStatement simpleStatement) {
+  public CompletionStage<AsyncResultSet> executeEstimatedCount(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement simpleStatement) {
     simpleStatement =
         simpleStatement.setConsistencyLevel(operationsConfig.queriesConfig().consistency().reads());
 
-    return cqlSessionCache.getSession().executeAsync(simpleStatement);
+    return cqlSessionCache.getSession(dataApiRequestInfo).executeAsync(simpleStatement);
   }
   /**
    * Execute vector search query with bound statement.
@@ -99,7 +107,10 @@ public class QueryExecutor {
    * @return
    */
   public Uni<AsyncResultSet> executeVectorSearch(
-      SimpleStatement simpleStatement, Optional<String> pagingState, int pageSize) {
+      DataApiRequestInfo dataApiRequestInfo,
+      SimpleStatement simpleStatement,
+      Optional<String> pagingState,
+      int pageSize) {
     simpleStatement =
         simpleStatement
             .setPageSize(pageSize)
@@ -109,7 +120,8 @@ public class QueryExecutor {
           simpleStatement.setPagingState(ByteBuffer.wrap(decodeBase64(pagingState.get())));
     }
     return Uni.createFrom()
-        .completionStage(cqlSessionCache.getSession().executeAsync(simpleStatement));
+        .completionStage(
+            cqlSessionCache.getSession(dataApiRequestInfo).executeAsync(simpleStatement));
   }
 
   /**
@@ -119,11 +131,12 @@ public class QueryExecutor {
    *     must have keyspace prefixed.
    * @return AsyncResultSet
    */
-  public Uni<AsyncResultSet> executeWrite(SimpleStatement statement) {
+  public Uni<AsyncResultSet> executeWrite(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement statement) {
     return Uni.createFrom()
         .completionStage(
             cqlSessionCache
-                .getSession()
+                .getSession(dataApiRequestInfo)
                 .executeAsync(
                     statement
                         .setIdempotent(true)
@@ -140,8 +153,9 @@ public class QueryExecutor {
    *     query must have keyspace prefixed.
    * @return AsyncResultSet
    */
-  public Uni<AsyncResultSet> executeCreateSchemaChange(SimpleStatement boundStatement) {
-    return executeSchemaChange(boundStatement, "create");
+  public Uni<AsyncResultSet> executeCreateSchemaChange(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement boundStatement) {
+    return executeSchemaChange(dataApiRequestInfo, boundStatement, "create");
   }
 
   /**
@@ -151,8 +165,9 @@ public class QueryExecutor {
    *     query must have keyspace prefixed.
    * @return AsyncResultSet
    */
-  public Uni<AsyncResultSet> executeDropSchemaChange(SimpleStatement boundStatement) {
-    return executeSchemaChange(boundStatement, "drop");
+  public Uni<AsyncResultSet> executeDropSchemaChange(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement boundStatement) {
+    return executeSchemaChange(dataApiRequestInfo, boundStatement, "drop");
   }
 
   /**
@@ -162,15 +177,17 @@ public class QueryExecutor {
    *     query must have keyspace prefixed.
    * @return AsyncResultSet
    */
-  public Uni<AsyncResultSet> executeTruncateSchemaChange(SimpleStatement boundStatement) {
-    return executeSchemaChange(boundStatement, "truncate");
+  public Uni<AsyncResultSet> executeTruncateSchemaChange(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement boundStatement) {
+    return executeSchemaChange(dataApiRequestInfo, boundStatement, "truncate");
   }
 
-  private Uni<AsyncResultSet> executeSchemaChange(SimpleStatement boundStatement, String profile) {
+  private Uni<AsyncResultSet> executeSchemaChange(
+      DataApiRequestInfo dataApiRequestInfo, SimpleStatement boundStatement, String profile) {
     return Uni.createFrom()
         .completionStage(
             cqlSessionCache
-                .getSession()
+                .getSession(dataApiRequestInfo)
                 .executeAsync(
                     boundStatement
                         .setExecutionProfileName(profile)
@@ -200,7 +217,7 @@ public class QueryExecutor {
                           Uni.createFrom()
                               .completionStage(
                                   cqlSessionCache
-                                      .getSession()
+                                      .getSession(dataApiRequestInfo)
                                       .executeAsync(
                                           duplicate
                                               .setExecutionProfileName(profile)
@@ -228,12 +245,13 @@ public class QueryExecutor {
    * @param collectionName
    * @return
    */
-  protected Uni<Optional<TableMetadata>> getSchema(String namespace, String collectionName) {
+  protected Uni<Optional<TableMetadata>> getSchema(
+      DataApiRequestInfo dataApiRequestInfo, String namespace, String collectionName) {
     KeyspaceMetadata keyspaceMetadata;
     try {
       keyspaceMetadata =
           cqlSessionCache
-              .getSession()
+              .getSession(dataApiRequestInfo)
               .getMetadata()
               .getKeyspaces()
               .get(CqlIdentifier.fromInternal(namespace));
@@ -259,9 +277,11 @@ public class QueryExecutor {
    * @param collectionName - collection name
    * @return TableMetadata
    */
-  protected Uni<TableMetadata> getCollectionSchema(String namespace, String collectionName) {
+  protected Uni<TableMetadata> getCollectionSchema(
+      DataApiRequestInfo dataApiRequestInfo, String namespace, String collectionName) {
     Optional<KeyspaceMetadata> keyspaceMetadata;
-    if ((keyspaceMetadata = cqlSessionCache.getSession().getMetadata().getKeyspace(namespace))
+    if ((keyspaceMetadata =
+            cqlSessionCache.getSession(dataApiRequestInfo).getMetadata().getKeyspace(namespace))
         .isPresent()) {
       Optional<TableMetadata> tableMetadata = keyspaceMetadata.get().getTable(collectionName);
       if (tableMetadata.isPresent()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/SchemaCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/SchemaCache.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Optional;
@@ -20,10 +21,13 @@ public class SchemaCache {
       Caffeine.newBuilder().maximumSize(1000).build();
 
   public Uni<CollectionSettings> getCollectionSettings(
-      Optional<String> tenant, String namespace, String collectionName) {
+      DataApiRequestInfo dataApiRequestInfo,
+      Optional<String> tenant,
+      String namespace,
+      String collectionName) {
     final NamespaceCache namespaceCache =
         schemaCache.get(new CacheKey(tenant, namespace), this::addNamespaceCache);
-    return namespaceCache.getCollectionProperties(collectionName);
+    return namespaceCache.getCollectionProperties(dataApiRequestInfo, collectionName);
   }
 
   private NamespaceCache addNamespaceCache(CacheKey cacheKey) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/CountOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/CountOperation.java
@@ -6,6 +6,7 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.LogicalExpression;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cql.builder.BuiltCondition;
 import io.stargate.sgv2.jsonapi.service.cql.builder.Query;
 import io.stargate.sgv2.jsonapi.service.cql.builder.QueryBuilder;
@@ -24,11 +25,13 @@ public record CountOperation(
     implements ReadOperation {
 
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     SimpleStatement simpleStatement = buildSelectQuery();
     Uni<CountResponse> countResponse = null;
-    if (limit == -1) countResponse = countDocuments(queryExecutor, simpleStatement);
-    else countResponse = countDocumentsByKey(queryExecutor, simpleStatement);
+    if (limit == -1)
+      countResponse = countDocuments(dataApiRequestInfo, queryExecutor, simpleStatement);
+    else countResponse = countDocumentsByKey(dataApiRequestInfo, queryExecutor, simpleStatement);
 
     return countResponse
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/EstimatedDocumentCountOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/EstimatedDocumentCountOperation.java
@@ -6,6 +6,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.EstimatedCountResult;
 import java.util.function.Supplier;
@@ -15,9 +16,11 @@ public record EstimatedDocumentCountOperation(CommandContext commandContext)
     implements ReadOperation {
 
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     SimpleStatement simpleStatement = buildSelectQuery();
-    Uni<CountResponse> countResponse = estimateDocumentCount(queryExecutor, simpleStatement);
+    Uni<CountResponse> countResponse =
+        estimateDocumentCount(dataApiRequestInfo, queryExecutor, simpleStatement);
 
     return countResponse
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/Operation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/Operation.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model;
 
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import java.util.function.Supplier;
 
@@ -24,5 +25,6 @@ import java.util.function.Supplier;
  * OperationExecutor}
  */
 public interface Operation {
-  Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor);
+  Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor);
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateNamespaceOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateNamespaceOperation.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import java.util.function.Supplier;
@@ -22,12 +23,13 @@ public record CreateNamespaceOperation(String name, String replicationMap) imple
 
   /** {@inheritDoc} */
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     SimpleStatement createKeyspace =
         SimpleStatement.newInstance(String.format(CREATE_KEYSPACE_CQL, name, replicationMap));
     // execute
     return queryExecutor
-        .executeCreateSchemaChange(createKeyspace)
+        .executeCreateSchemaChange(dataApiRequestInfo, createKeyspace)
 
         // if we have a result always respond positively
         .map(any -> new SchemaChangeResult(any.wasApplied()));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteCollectionOperation.java
@@ -4,6 +4,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import java.util.function.Supplier;
@@ -22,13 +23,14 @@ public record DeleteCollectionOperation(CommandContext context, String name) imp
   private static final String DROP_TABLE_CQL = "DROP TABLE IF EXISTS \"%s\".\"%s\";";
 
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     logger.info("Executing DeleteCollectionOperation for {}", name);
     String cql = DROP_TABLE_CQL.formatted(context.namespace(), name);
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute
     return queryExecutor
-        .executeDropSchemaChange(query)
+        .executeDropSchemaChange(dataApiRequestInfo, query)
 
         // if we have a result always respond positively
         .map(any -> new SchemaChangeResult(any.wasApplied()));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DropNamespaceOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DropNamespaceOperation.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import java.util.function.Supplier;
@@ -19,12 +20,13 @@ public record DropNamespaceOperation(String name) implements Operation {
 
   /** {@inheritDoc} */
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     SimpleStatement deleteStatement =
         SimpleStatement.newInstance(DROP_KEYSPACE_CQL.formatted(name));
     // execute
     return queryExecutor
-        .executeDropSchemaChange(deleteStatement)
+        .executeDropSchemaChange(dataApiRequestInfo, deleteStatement)
 
         // if we have a result always respond positively
         .map(any -> new SchemaChangeResult(any.wasApplied()));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindCollectionsOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindCollectionsOperation.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateCollectionCommand;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
@@ -50,10 +51,11 @@ public record FindCollectionsOperation(
 
   /** {@inheritDoc} */
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     KeyspaceMetadata keyspaceMetadata =
         cqlSessionCache
-            .getSession()
+            .getSession(dataApiRequestInfo)
             .getMetadata()
             .getKeyspaces()
             .get(CqlIdentifier.fromInternal(commandContext.namespace()));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindEmbeddingProvidersOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindEmbeddingProvidersOperation.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.PropertyBasedEmbeddingProviderConfig;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
@@ -19,7 +20,8 @@ import java.util.stream.Collectors;
 public record FindEmbeddingProvidersOperation(PropertyBasedEmbeddingProviderConfig config)
     implements Operation {
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     return Uni.createFrom()
         .item(
             () -> {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindNamespacesOperations.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindNamespacesOperations.java
@@ -4,6 +4,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
@@ -21,14 +22,20 @@ public record FindNamespacesOperations(CQLSessionCache cqlSessionCache) implemen
 
   /** {@inheritDoc} */
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
 
     return Uni.createFrom()
         .item(
             () -> {
               // get all existing keyspaces
               List<String> keyspacesList =
-                  cqlSessionCache.getSession().getMetadata().getKeyspaces().keySet().stream()
+                  cqlSessionCache
+                      .getSession(dataApiRequestInfo)
+                      .getMetadata()
+                      .getKeyspaces()
+                      .keySet()
+                      .stream()
                       .map(CqlIdentifier::asInternal)
                       .toList();
               return new Result(keyspacesList);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -6,6 +6,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.cqldriver.serializer.CQLBindValues;
@@ -53,12 +54,14 @@ public record ReadAndUpdateOperation(
     implements ModifyOperation {
 
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     final AtomicReference pageStateReference = new AtomicReference();
     final AtomicInteger matchedCount = new AtomicInteger(0);
     final AtomicInteger modifiedCount = new AtomicInteger(0);
     Uni<ReadOperation.FindResponse> docsToUpdate =
-        findOperation().getDocuments(queryExecutor, findOperation().pageState(), null);
+        findOperation()
+            .getDocuments(dataApiRequestInfo, queryExecutor, findOperation().pageState(), null);
     return docsToUpdate
         .onItem()
         .transformToMulti(
@@ -75,7 +78,7 @@ public record ReadAndUpdateOperation(
         .onItem()
         .transformToUniAndConcatenate(
             readDocument ->
-                processUpdate(readDocument, queryExecutor, modifiedCount)
+                processUpdate(dataApiRequestInfo, readDocument, queryExecutor, modifiedCount)
                     .onFailure(LWTException.class)
                     .recoverWithUni(
                         () -> {
@@ -85,13 +88,17 @@ public record ReadAndUpdateOperation(
                               .flatMap(
                                   prevDoc -> {
                                     // read the document again
-                                    return readDocumentAgain(queryExecutor, prevDoc)
+                                    return readDocumentAgain(
+                                            dataApiRequestInfo, queryExecutor, prevDoc)
                                         .onItem()
                                         // Try updating the document
                                         .transformToUni(
                                             reReadDocument ->
                                                 processUpdate(
-                                                    reReadDocument, queryExecutor, modifiedCount));
+                                                    dataApiRequestInfo,
+                                                    reReadDocument,
+                                                    queryExecutor,
+                                                    modifiedCount));
                                   })
                               .onFailure(LWTException.class)
                               .retry()
@@ -128,7 +135,10 @@ public record ReadAndUpdateOperation(
   }
 
   private Uni<UpdatedDocument> processUpdate(
-      ReadDocument document, QueryExecutor queryExecutor, AtomicInteger modifiedCount) {
+      DataApiRequestInfo dataApiRequestInfo,
+      ReadDocument document,
+      QueryExecutor queryExecutor,
+      AtomicInteger modifiedCount) {
     return Uni.createFrom()
         .item(document)
 
@@ -171,7 +181,7 @@ public record ReadAndUpdateOperation(
               // Have to do this because shredder adds _id field to the document if it doesn't exist
               JsonNode updatedDocument = writableShreddedDocument.docJsonNode();
               // update the document
-              return updatedDocument(queryExecutor, writableShreddedDocument)
+              return updatedDocument(dataApiRequestInfo, queryExecutor, writableShreddedDocument)
 
                   // send result back depending on the input
                   .onItem()
@@ -199,14 +209,16 @@ public record ReadAndUpdateOperation(
   }
 
   private Uni<DocumentId> updatedDocument(
-      QueryExecutor queryExecutor, WritableShreddedDocument writableShreddedDocument) {
+      DataApiRequestInfo dataApiRequestInfo,
+      QueryExecutor queryExecutor,
+      WritableShreddedDocument writableShreddedDocument) {
     final SimpleStatement updateQuery =
         bindUpdateValues(
             buildUpdateQuery(commandContext().isVectorEnabled()),
             writableShreddedDocument,
             commandContext().isVectorEnabled());
     return queryExecutor
-        .executeWrite(updateQuery)
+        .executeWrite(dataApiRequestInfo, updateQuery)
         .onItem()
         .transformToUni(
             result -> {
@@ -304,9 +316,12 @@ public record ReadAndUpdateOperation(
    * @return
    */
   private Uni<ReadDocument> readDocumentAgain(
-      QueryExecutor queryExecutor, ReadDocument prevReadDoc) {
+      DataApiRequestInfo dataApiRequestInfo,
+      QueryExecutor queryExecutor,
+      ReadDocument prevReadDoc) {
     return findOperation()
         .getDocuments(
+            dataApiRequestInfo,
             queryExecutor,
             null,
             new DBFilterBase.IDFilter(DBFilterBase.IDFilter.Operator.EQ, prevReadDoc.id()))

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/TruncateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/TruncateCollectionOperation.java
@@ -4,6 +4,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import java.util.function.Supplier;
@@ -20,13 +21,14 @@ public record TruncateCollectionOperation(CommandContext context) implements Ope
   private static final String TRUNCATE_TABLE_CQL = "TRUNCATE TABLE \"%s\".\"%s\";";
 
   @Override
-  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+  public Uni<Supplier<CommandResult>> execute(
+      DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     logger.info("Executing TruncateCollectionOperation for {}", context.collection());
     String cql = TRUNCATE_TABLE_CQL.formatted(context.namespace(), context.collection());
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute
     return queryExecutor
-        .executeTruncateSchemaChange(query)
+        .executeTruncateSchemaChange(dataApiRequestInfo, query)
 
         // if we have a result always respond positively
         .map(any -> new DeleteOperationPage(null, false, false));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
@@ -4,6 +4,7 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.Command;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableCommandResultSupplier;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.QueryExecutor;
@@ -55,7 +56,7 @@ public class CommandProcessor {
    * @param <T> Type of the command.
    */
   public <T extends Command> Uni<CommandResult> processCommand(
-      CommandContext commandContext, T command) {
+      DataApiRequestInfo dataApiRequestInfo, CommandContext commandContext, T command) {
     // vectorize the data
     return dataVectorizerService
         .vectorize(commandContext, command)
@@ -77,7 +78,7 @@ public class CommandProcessor {
             })
 
         //  execute the operation
-        .flatMap(operation -> operation.execute(queryExecutor))
+        .flatMap(operation -> operation.execute(dataApiRequestInfo, queryExecutor))
 
         // handle failures here
         .onFailure()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -97,12 +97,12 @@ public class MeteredCommandProcessor {
    * @return Uni emitting the result of the command execution.
    */
   public <T extends Command> Uni<CommandResult> processCommand(
-      CommandContext commandContext, T command) {
+      DataApiRequestInfo dataApiRequestInfo, CommandContext commandContext, T command) {
     Timer.Sample sample = Timer.start(meterRegistry);
     MDC.put("tenantId", dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE));
     // start by resolving the command, get resolver
     return commandProcessor
-        .processCommand(commandContext, command)
+        .processCommand(dataApiRequestInfo, commandContext, command)
         .onItem()
         .invoke(
             result -> {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionCacheTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionCacheTests.java
@@ -61,11 +61,7 @@ public class CqlSessionCacheTests {
     DataApiRequestInfo dataApiRequestInfo = mock(DataApiRequestInfo.class);
     when(dataApiRequestInfo.getCassandraToken())
         .thenReturn(operationsConfig.databaseConfig().fixedToken());
-    Field dataApiRequestInfoField =
-        cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-    dataApiRequestInfoField.setAccessible(true);
-    dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
-    CqlSession cqlSession = cqlSessionCacheForTest.getSession();
+    CqlSession cqlSession = cqlSessionCacheForTest.getSession(dataApiRequestInfo);
     sessionsCreatedInTests.add(cqlSession);
     assertThat(
             ((DefaultDriverContext) cqlSession.getContext())
@@ -91,16 +87,12 @@ public class CqlSessionCacheTests {
     when(dataApiRequestInfo.getCassandraToken())
         .thenReturn(operationsConfig.databaseConfig().fixedToken());
     CQLSessionCache cqlSessionCacheForTest = new CQLSessionCache(operationsConfig, meterRegistry);
-    Field dataApiRequestInfoField =
-        cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-    dataApiRequestInfoField.setAccessible(true);
-    dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
     // set operation config
     Field operationsConfigField =
         cqlSessionCacheForTest.getClass().getDeclaredField("operationsConfig");
     operationsConfigField.setAccessible(true);
     operationsConfigField.set(cqlSessionCacheForTest, operationsConfig);
-    CqlSession cqlSession = cqlSessionCacheForTest.getSession();
+    CqlSession cqlSession = cqlSessionCacheForTest.getSession(dataApiRequestInfo);
     sessionsCreatedInTests.add(cqlSession);
     assertThat(
             ((DefaultDriverContext) cqlSession.getContext())
@@ -126,17 +118,13 @@ public class CqlSessionCacheTests {
     when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of(TENANT_ID_FOR_TEST));
     when(dataApiRequestInfo.getCassandraToken()).thenReturn(Optional.of("invalid_token"));
     CQLSessionCache cqlSessionCacheForTest = new CQLSessionCache(operationsConfig, meterRegistry);
-    Field dataApiRequestInfoField =
-        cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-    dataApiRequestInfoField.setAccessible(true);
-    dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
     // set operation config
     Field operationsConfigField =
         cqlSessionCacheForTest.getClass().getDeclaredField("operationsConfig");
     operationsConfigField.setAccessible(true);
     operationsConfigField.set(cqlSessionCacheForTest, operationsConfig);
     // Throwable
-    Throwable t = catchThrowable(cqlSessionCacheForTest::getSession);
+    Throwable t = catchThrowable(() -> cqlSessionCacheForTest.getSession(dataApiRequestInfo));
     assertThat(t)
         .isNotNull()
         .isInstanceOf(UnauthorizedException.class)
@@ -173,11 +161,7 @@ public class CqlSessionCacheTests {
       when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of(tenantId));
       when(dataApiRequestInfo.getCassandraToken())
           .thenReturn(operationsConfig.databaseConfig().fixedToken());
-      Field dataApiRequestInfoField =
-          cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-      dataApiRequestInfoField.setAccessible(true);
-      dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
-      CqlSession cqlSession = cqlSessionCacheForTest.getSession();
+      CqlSession cqlSession = cqlSessionCacheForTest.getSession(dataApiRequestInfo);
       sessionsCreatedInTests.add(cqlSession);
       assertThat(
               ((DefaultDriverContext) cqlSession.getContext())
@@ -220,11 +204,7 @@ public class CqlSessionCacheTests {
       when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of(tenantId));
       when(dataApiRequestInfo.getCassandraToken())
           .thenReturn(operationsConfig.databaseConfig().fixedToken());
-      Field dataApiRequestInfoField =
-          cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-      dataApiRequestInfoField.setAccessible(true);
-      dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
-      CqlSession cqlSession = cqlSessionCacheForTest.getSession();
+      CqlSession cqlSession = cqlSessionCacheForTest.getSession(dataApiRequestInfo);
       sessionsCreatedInTests.add(cqlSession);
       assertThat(
               ((DefaultDriverContext) cqlSession.getContext())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionCacheTimingTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionCacheTimingTests.java
@@ -16,7 +16,6 @@ import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import jakarta.inject.Inject;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -61,11 +60,7 @@ public class CqlSessionCacheTimingTests {
       when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of(tenantId));
       when(dataApiRequestInfo.getCassandraToken())
           .thenReturn(operationsConfig.databaseConfig().fixedToken());
-      Field dataApiRequestInfoField =
-          cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-      dataApiRequestInfoField.setAccessible(true);
-      dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
-      CqlSession cqlSession = cqlSessionCacheForTest.getSession();
+      CqlSession cqlSession = cqlSessionCacheForTest.getSession(dataApiRequestInfo);
       sessionsCreatedInTests.add(cqlSession);
       assertThat(
               ((DefaultDriverContext) cqlSession.getContext())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/InvalidCredentialsTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/InvalidCredentialsTests.java
@@ -64,17 +64,13 @@ public class InvalidCredentialsTests {
     when(dataApiRequestInfo.getCassandraToken())
         .thenReturn(operationsConfig.databaseConfig().fixedToken());
     CQLSessionCache cqlSessionCacheForTest = new CQLSessionCache(operationsConfig, meterRegistry);
-    Field dataApiRequestInfoField =
-        cqlSessionCacheForTest.getClass().getDeclaredField("dataApiRequestInfo");
-    dataApiRequestInfoField.setAccessible(true);
-    dataApiRequestInfoField.set(cqlSessionCacheForTest, dataApiRequestInfo);
     // set operation config
     Field operationsConfigField =
         cqlSessionCacheForTest.getClass().getDeclaredField("operationsConfig");
     operationsConfigField.setAccessible(true);
     operationsConfigField.set(cqlSessionCacheForTest, operationsConfig);
     // Throwable
-    Throwable t = catchThrowable(cqlSessionCacheForTest::getSession);
+    Throwable t = catchThrowable(() -> cqlSessionCacheForTest.getSession(dataApiRequestInfo));
     assertThat(t).isInstanceOf(AllNodesFailedException.class);
     CommandResult.Error error =
         ThrowableToErrorMapper.getMapperWithMessageFunction().apply(t, t.getMessage());

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCacheTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCacheTest.java
@@ -14,9 +14,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import jakarta.inject.Inject;
@@ -34,13 +36,15 @@ public class NamespaceCacheTest {
 
   @Inject ObjectMapper objectMapper;
 
+  @InjectMock protected DataApiRequestInfo dataApiRequestInfo;
+
   @Nested
   class Execute {
 
     @Test
     public void checkValidJsonApiTable() {
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.getSchema(any(), any()))
+      when(queryExecutor.getSchema(any(), any(), any()))
           .then(
               i -> {
                 List<ColumnMetadata> partitionColumn =
@@ -151,7 +155,7 @@ public class NamespaceCacheTest {
       NamespaceCache namespaceCache = new NamespaceCache("ks", queryExecutor, objectMapper);
       CollectionSettings collectionSettings =
           namespaceCache
-              .getCollectionProperties("table")
+              .getCollectionProperties(dataApiRequestInfo, "table")
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -168,7 +172,7 @@ public class NamespaceCacheTest {
     @Test
     public void checkValidJsonApiTableWithIndexing() {
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.getSchema(any(), any()))
+      when(queryExecutor.getSchema(any(), any(), any()))
           .then(
               i -> {
                 List<ColumnMetadata> partitionColumn =
@@ -281,7 +285,7 @@ public class NamespaceCacheTest {
       NamespaceCache namespaceCache = new NamespaceCache("ks", queryExecutor, objectMapper);
       CollectionSettings collectionSettings =
           namespaceCache
-              .getCollectionProperties("table")
+              .getCollectionProperties(dataApiRequestInfo, "table")
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -299,7 +303,7 @@ public class NamespaceCacheTest {
     @Test
     public void checkInvalidJsonApiTable() {
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.getSchema(any(), any()))
+      when(queryExecutor.getSchema(any(), any(), any()))
           .then(
               i -> {
                 List<ColumnMetadata> partitionColumn =
@@ -345,7 +349,7 @@ public class NamespaceCacheTest {
       NamespaceCache namespaceCache = new NamespaceCache("ks", queryExecutor, objectMapper);
       Throwable error =
           namespaceCache
-              .getCollectionProperties("table")
+              .getCollectionProperties(dataApiRequestInfo, "table")
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -55,7 +55,7 @@ public class CountOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(COUNT_RESULT_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -65,7 +65,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, LogicalExpression.and(), 100, -1);
       Supplier<CommandResult> execute =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -96,7 +96,7 @@ public class CountOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(COUNT_RESULT_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -115,7 +115,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd, 100, -1);
       Supplier<CommandResult> execute =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -146,7 +146,7 @@ public class CountOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(COUNT_RESULT_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -166,7 +166,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd, 100, -1);
       Supplier<CommandResult> execute =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -194,7 +194,7 @@ public class CountOperationTest extends OperationTestBase {
       SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -205,7 +205,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd, 100, -1);
       Throwable result =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()
@@ -239,7 +239,7 @@ public class CountOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(COUNT_RESULT_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -249,7 +249,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, LogicalExpression.and(), 100, 10);
       Supplier<CommandResult> execute =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -279,7 +279,7 @@ public class CountOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(COUNT_RESULT_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -298,7 +298,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd, 100, 10);
       Supplier<CommandResult> execute =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -328,7 +328,7 @@ public class CountOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(COUNT_RESULT_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -348,7 +348,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd, 100, 10);
       Supplier<CommandResult> execute =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -376,7 +376,7 @@ public class CountOperationTest extends OperationTestBase {
       SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCount(eq(stmt)))
+      when(queryExecutor.executeCount(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -387,7 +387,7 @@ public class CountOperationTest extends OperationTestBase {
       CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd, 100, 10);
       Throwable result =
           countOperation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +62,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(RESULT_COLUMNS, resultRows, null);
       final AtomicInteger schemaCounter = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCreateSchemaChange(any()))
+      when(queryExecutor.executeCreateSchemaChange(eq(dataApiRequestInfo), any()))
           .then(
               invocation -> {
                 schemaCounter.incrementAndGet();
@@ -70,7 +71,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       CQLSessionCache sessionCache = mock(CQLSessionCache.class);
       CqlSession session = mock(CqlSession.class);
-      when(sessionCache.getSession()).thenReturn(session);
+      when(sessionCache.getSession(dataApiRequestInfo)).thenReturn(session);
       Metadata metadata = mock(Metadata.class);
       when(session.getMetadata()).thenReturn(metadata);
       Map<CqlIdentifier, KeyspaceMetadata> allKeyspaces = new HashMap<>();
@@ -102,7 +103,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -119,7 +120,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(RESULT_COLUMNS, resultRows, null);
       final AtomicInteger schemaCounter = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCreateSchemaChange(any()))
+      when(queryExecutor.executeCreateSchemaChange(eq(dataApiRequestInfo), any()))
           .then(
               invocation -> {
                 schemaCounter.incrementAndGet();
@@ -128,7 +129,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       CQLSessionCache sessionCache = mock(CQLSessionCache.class);
       CqlSession session = mock(CqlSession.class);
-      when(sessionCache.getSession()).thenReturn(session);
+      when(sessionCache.getSession(dataApiRequestInfo)).thenReturn(session);
       Metadata metadata = mock(Metadata.class);
       when(session.getMetadata()).thenReturn(metadata);
       Map<CqlIdentifier, KeyspaceMetadata> allKeyspaces = new HashMap<>();
@@ -162,7 +163,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -179,7 +180,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(RESULT_COLUMNS, resultRows, null);
       final AtomicInteger schemaCounter = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCreateSchemaChange(any()))
+      when(queryExecutor.executeCreateSchemaChange(eq(dataApiRequestInfo), any()))
           .then(
               invocation -> {
                 schemaCounter.incrementAndGet();
@@ -188,7 +189,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       CQLSessionCache sessionCache = mock(CQLSessionCache.class);
       CqlSession session = mock(CqlSession.class);
-      when(sessionCache.getSession()).thenReturn(session);
+      when(sessionCache.getSession(dataApiRequestInfo)).thenReturn(session);
       Metadata metadata = mock(Metadata.class);
       when(session.getMetadata()).thenReturn(metadata);
       Map<CqlIdentifier, KeyspaceMetadata> allKeyspaces = new HashMap<>();
@@ -220,7 +221,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -237,7 +238,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(RESULT_COLUMNS, resultRows, null);
       final AtomicInteger schemaCounter = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeCreateSchemaChange(any()))
+      when(queryExecutor.executeCreateSchemaChange(eq(dataApiRequestInfo), any()))
           .then(
               invocation -> {
                 schemaCounter.incrementAndGet();
@@ -246,7 +247,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       CQLSessionCache sessionCache = mock(CQLSessionCache.class);
       CqlSession session = mock(CqlSession.class);
-      when(sessionCache.getSession()).thenReturn(session);
+      when(sessionCache.getSession(dataApiRequestInfo)).thenReturn(session);
       Metadata metadata = mock(Metadata.class);
       when(session.getMetadata()).thenReturn(metadata);
       Map<CqlIdentifier, KeyspaceMetadata> allKeyspaces = new HashMap<>();
@@ -280,7 +281,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -137,7 +137,7 @@ public class DeleteOperationTest extends OperationTestBase {
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -223,7 +223,7 @@ public class DeleteOperationTest extends OperationTestBase {
               commandContext, findOperation, 3, DocumentProjector.defaultProjector());
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -408,7 +408,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -531,7 +531,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -585,7 +585,7 @@ public class DeleteOperationTest extends OperationTestBase {
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -665,7 +665,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -786,7 +786,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -908,7 +908,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1011,7 +1011,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1113,7 +1113,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1170,7 +1170,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1312,7 +1312,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1507,7 +1507,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1647,7 +1647,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1801,7 +1801,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -93,7 +93,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -111,7 +111,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -175,7 +175,7 @@ public class DeleteOperationTest extends OperationTestBase {
           new MockAsyncResultSet(SELECT_WITH_JSON_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -193,7 +193,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -357,7 +357,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_SORT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -375,7 +375,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -480,7 +480,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_SORT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -498,7 +498,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -560,7 +560,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -621,7 +621,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -639,7 +639,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -703,7 +703,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -728,7 +728,7 @@ public class DeleteOperationTest extends OperationTestBase {
                   Arrays.asList(byteBufferFrom(keyValue), byteBufferFrom(tx_id2))));
 
       AsyncResultSet mockResults1 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -748,7 +748,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -761,7 +761,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults2 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -824,7 +824,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -849,7 +849,7 @@ public class DeleteOperationTest extends OperationTestBase {
                   Arrays.asList(byteBufferFrom(keyValue), byteBufferFrom(tx_id2))));
 
       AsyncResultSet mockResults1 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -869,7 +869,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -883,7 +883,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults2 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -945,7 +945,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -965,7 +965,7 @@ public class DeleteOperationTest extends OperationTestBase {
       rows = Arrays.asList();
 
       AsyncResultSet mockResults1 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -985,7 +985,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1053,7 +1053,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1071,7 +1071,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1084,7 +1084,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults1 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1143,7 +1143,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1212,7 +1212,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1236,7 +1236,7 @@ public class DeleteOperationTest extends OperationTestBase {
                   Arrays.asList(byteBufferFrom(keyValue1), byteBufferFrom(tx_id3))));
 
       AsyncResultSet mockResults2 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1255,7 +1255,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1268,7 +1268,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults1 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1282,7 +1282,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults2 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1369,7 +1369,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet mockResults = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       final AtomicInteger selectCallCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1394,7 +1394,7 @@ public class DeleteOperationTest extends OperationTestBase {
                   Arrays.asList(byteBufferFrom(keyValue1), byteBufferFrom(tx_id3))));
 
       AsyncResultSet mockResults1 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1415,7 +1415,7 @@ public class DeleteOperationTest extends OperationTestBase {
                   Arrays.asList(byteBufferFrom(keyValue2), byteBufferFrom(tx_id4))));
 
       AsyncResultSet mockResults2 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1434,7 +1434,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1448,7 +1448,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults2 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1462,7 +1462,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet deleteResults3 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1477,7 +1477,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults4 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
 
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1565,7 +1565,8 @@ public class DeleteOperationTest extends OperationTestBase {
           new MockAsyncResultSet(
               SELECT_RESULT_COLUMNS, rows, asyncResultSetCompletableFuture, executionInfo);
       final AtomicInteger selectCallCount = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt), eq(Optional.empty()), anyInt()))
+      when(queryExecutor.executeRead(
+              eq(dataApiRequestInfo), eq(stmt), eq(Optional.empty()), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1581,6 +1582,7 @@ public class DeleteOperationTest extends OperationTestBase {
 
       AsyncResultSet mockResults1 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       when(queryExecutor.executeRead(
+              eq(dataApiRequestInfo),
               eq(stmt),
               eq(Optional.of(Base64.getEncoder().encodeToString(pagingStateBB.array()))),
               anyInt()))
@@ -1602,7 +1604,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1616,7 +1618,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults2 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
 
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1695,7 +1697,8 @@ public class DeleteOperationTest extends OperationTestBase {
           new MockAsyncResultSet(
               SELECT_RESULT_COLUMNS, rows, asyncResultSetCompletableFuture, executionInfo);
       final AtomicInteger selectCallCount = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt), eq(Optional.empty()), anyInt()))
+      when(queryExecutor.executeRead(
+              eq(dataApiRequestInfo), eq(stmt), eq(Optional.empty()), anyInt()))
           .then(
               invocation -> {
                 selectCallCount.incrementAndGet();
@@ -1714,6 +1717,7 @@ public class DeleteOperationTest extends OperationTestBase {
           new MockAsyncResultSet(
               SELECT_RESULT_COLUMNS, rows, asyncResultSetCompletableFuture, executionInfo);
       when(queryExecutor.executeRead(
+              eq(dataApiRequestInfo),
               eq(stmt),
               eq(Optional.of(Base64.getEncoder().encodeToString(pagingStateBB.array()))),
               anyInt()))
@@ -1731,6 +1735,7 @@ public class DeleteOperationTest extends OperationTestBase {
                   Arrays.asList(byteBufferFrom(keyValue3), byteBufferFrom(tx_id3))));
       AsyncResultSet mockResults2 = new MockAsyncResultSet(SELECT_RESULT_COLUMNS, rows, null);
       when(queryExecutor.executeRead(
+              eq(dataApiRequestInfo),
               eq(stmt),
               eq(Optional.of(Base64.getEncoder().encodeToString(pagingStateBB2.array()))),
               anyInt()))
@@ -1752,7 +1757,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
       final AtomicInteger deleteCallCount = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();
@@ -1766,7 +1771,7 @@ public class DeleteOperationTest extends OperationTestBase {
       AsyncResultSet deleteResults2 =
           new MockAsyncResultSet(DELETE_RESULT_COLUMNS, deleteRows, null);
 
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 deleteCallCount.incrementAndGet();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -140,7 +140,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -285,7 +285,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -326,7 +326,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -415,7 +415,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -498,7 +498,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -559,7 +559,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -616,7 +616,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -677,7 +677,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -741,7 +741,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -805,7 +805,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -870,7 +870,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -935,7 +935,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -999,7 +999,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1064,7 +1064,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1125,7 +1125,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1187,7 +1187,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1258,7 +1258,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1329,7 +1329,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1396,7 +1396,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1465,7 +1465,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1533,7 +1533,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1600,7 +1600,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1667,7 +1667,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1725,7 +1725,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Throwable failure =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()
@@ -1894,7 +1894,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -2093,7 +2093,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -2273,7 +2273,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -2447,7 +2447,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -2576,7 +2576,7 @@ public class FindOperationTest extends OperationTestBase {
 
     Supplier<CommandResult> execute =
         operation
-            .execute(queryExecutor)
+            .execute(dataApiRequestInfo, queryExecutor)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
             .awaitItem()
@@ -2653,7 +2653,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -2718,7 +2718,7 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -2822,7 +2822,7 @@ public class FindOperationTest extends OperationTestBase {
       // Throwable
       Throwable failure =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -119,7 +119,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -250,13 +250,13 @@ public class FindOperationTest extends OperationTestBase {
       final AtomicInteger callCount1 = new AtomicInteger();
       final AtomicInteger callCount2 = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
                 return Uni.createFrom().item(results1);
               });
-      when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -373,13 +373,13 @@ public class FindOperationTest extends OperationTestBase {
       final AtomicInteger callCount1 = new AtomicInteger();
       final AtomicInteger callCount2 = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
                 return Uni.createFrom().item(results1);
               });
-      when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -463,13 +463,13 @@ public class FindOperationTest extends OperationTestBase {
       final AtomicInteger callCount1 = new AtomicInteger();
       final AtomicInteger callCount2 = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
                 return Uni.createFrom().item(results1);
               });
-      when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -535,7 +535,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -588,7 +588,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, Arrays.asList(), null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -652,7 +652,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -716,7 +716,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -780,7 +780,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -845,7 +845,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -910,7 +910,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -974,7 +974,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1039,7 +1039,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1102,7 +1102,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1165,7 +1165,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1228,7 +1228,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1299,7 +1299,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1368,7 +1368,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1437,7 +1437,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1505,7 +1505,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1572,7 +1572,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1639,7 +1639,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1700,7 +1700,7 @@ public class FindOperationTest extends OperationTestBase {
           SimpleStatement.newInstance(collectionReadCql, boundKeyForStatement("doc1"));
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -1870,7 +1870,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -2069,7 +2069,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -2249,7 +2249,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -2423,7 +2423,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -2552,7 +2552,7 @@ public class FindOperationTest extends OperationTestBase {
     AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
     final AtomicInteger callCount = new AtomicInteger();
     QueryExecutor queryExecutor = mock(QueryExecutor.class);
-    when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
         .then(
             invocation -> {
               callCount.incrementAndGet();
@@ -2631,7 +2631,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeVectorSearch(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeVectorSearch(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -2692,7 +2692,7 @@ public class FindOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeVectorSearch(eq(stmt), any(), anyInt()))
+      when(queryExecutor.executeVectorSearch(eq(dataApiRequestInfo), eq(stmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -2794,7 +2794,8 @@ public class FindOperationTest extends OperationTestBase {
       boolean dataPresent = false;
       Map<InetAddress, Integer> reasonMap = new HashMap<>();
       reasonMap.put(InetAddress.getByName("127.0.0.1"), 0x0000);
-      Mockito.when(queryExecutor.executeVectorSearch(any(), any(), anyInt()))
+      Mockito.when(
+              queryExecutor.executeVectorSearch(eq(dataApiRequestInfo), any(), any(), anyInt()))
           .thenThrow(
               new ReadFailureException(
                   coordinator,

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -119,7 +119,7 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -128,7 +128,7 @@ public class InsertOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           new InsertOperation(COMMAND_CONTEXT_NON_VECTOR, shredDocument)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -171,7 +171,7 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -180,7 +180,7 @@ public class InsertOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           new InsertOperation(COMMAND_CONTEXT_NON_VECTOR, shredDocument)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -247,13 +247,13 @@ public class InsertOperationTest extends OperationTestBase {
       final List<Integer> calls = new ArrayList<>();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt1)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt1)))
           .then(
               invocation -> {
                 calls.add(1);
                 return Uni.createFrom().item(results1);
               });
-      when(queryExecutor.executeWrite(eq(insertStmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt2)))
           .then(
               invocation -> {
                 calls.add(2);
@@ -264,7 +264,7 @@ public class InsertOperationTest extends OperationTestBase {
           createCommandContextWithCommandName("jsonDocsWrittenInsertManyCommand");
       Supplier<CommandResult> execute =
           new InsertOperation(commandContext, List.of(shredDocument1, shredDocument2), true)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -371,7 +371,7 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -380,7 +380,7 @@ public class InsertOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           new InsertOperation(COMMAND_CONTEXT_NON_VECTOR, shredDocument)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -439,13 +439,13 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt1)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt1)))
           .then(
               invocation -> {
                 callCount.addAndGet(1);
                 return Uni.createFrom().item(results1);
               });
-      when(queryExecutor.executeWrite(eq(insertStmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt2)))
           .then(
               invocation -> {
                 callCount.addAndGet(1);
@@ -455,7 +455,7 @@ public class InsertOperationTest extends OperationTestBase {
       Supplier<CommandResult> execute =
           new InsertOperation(
                   COMMAND_CONTEXT_NON_VECTOR, List.of(shredDocument1, shredDocument2), false)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -516,13 +516,13 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt1)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt1)))
           .then(
               invocation -> {
                 callCount.addAndGet(1);
                 return Uni.createFrom().failure(new RuntimeException("Test break #1"));
               });
-      when(queryExecutor.executeWrite(eq(insertStmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt2)))
           .then(
               invocation -> {
                 callCount.addAndGet(1);
@@ -532,7 +532,7 @@ public class InsertOperationTest extends OperationTestBase {
       Supplier<CommandResult> execute =
           new InsertOperation(
                   COMMAND_CONTEXT_NON_VECTOR, List.of(shredDocument1, shredDocument2), true)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -601,13 +601,13 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt1)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt1)))
           .then(
               invocation -> {
                 callCount.addAndGet(1);
                 return Uni.createFrom().item(resultOk);
               });
-      when(queryExecutor.executeWrite(eq(insertStmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt2)))
           .then(
               invocation -> {
                 callCount.addAndGet(1);
@@ -617,7 +617,7 @@ public class InsertOperationTest extends OperationTestBase {
       Supplier<CommandResult> execute =
           new InsertOperation(
                   COMMAND_CONTEXT_NON_VECTOR, List.of(shredDocument1, shredDocument2), true)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -687,13 +687,13 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount2 = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt1)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt1)))
           .then(
               invocation -> {
                 callCount1.addAndGet(1);
                 return Uni.createFrom().failure(new RuntimeException("Test break #1"));
               });
-      when(queryExecutor.executeWrite(eq(insertStmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt2)))
           .then(
               invocation -> {
                 callCount2.addAndGet(1);
@@ -703,7 +703,7 @@ public class InsertOperationTest extends OperationTestBase {
       Supplier<CommandResult> execute =
           new InsertOperation(
                   COMMAND_CONTEXT_NON_VECTOR, List.of(shredDocument1, shredDocument2), false)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -775,13 +775,13 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount2 = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt1)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt1)))
           .then(
               invocation -> {
                 callCount1.addAndGet(1);
                 return Uni.createFrom().failure(new RuntimeException("Insert 1 failed"));
               });
-      when(queryExecutor.executeWrite(eq(insertStmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt2)))
           .then(
               invocation -> {
                 callCount2.addAndGet(1);
@@ -791,7 +791,7 @@ public class InsertOperationTest extends OperationTestBase {
       Supplier<CommandResult> execute =
           new InsertOperation(
                   COMMAND_CONTEXT_NON_VECTOR, List.of(shredDocument1, shredDocument2), false)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -841,7 +841,7 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -850,7 +850,7 @@ public class InsertOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           new InsertOperation(COMMAND_CONTEXT_VECTOR, shredDocument)
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -892,7 +892,7 @@ public class InsertOperationTest extends OperationTestBase {
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      when(queryExecutor.executeWrite(eq(insertStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(insertStmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -901,7 +901,7 @@ public class InsertOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           new InsertOperation(COMMAND_CONTEXT_VECTOR, shredDocument)
-              .execute(queryExecutor)
+              .execute(eq(dataApiRequestInfo), queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -940,7 +940,8 @@ public class InsertOperationTest extends OperationTestBase {
       InsertOperation operation = new InsertOperation(COMMAND_CONTEXT_NON_VECTOR, shredDocument);
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
-      Throwable failure = catchThrowable(() -> operation.execute(queryExecutor));
+      Throwable failure =
+          catchThrowable(() -> operation.execute(dataApiRequestInfo, queryExecutor));
       assertThat(failure)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VECTOR_SEARCH_NOT_SUPPORTED);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -901,7 +901,7 @@ public class InsertOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           new InsertOperation(COMMAND_CONTEXT_VECTOR, shredDocument)
-              .execute(eq(dataApiRequestInfo), queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -147,7 +147,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", tx_id1, doc1));
     AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
     final AtomicInteger selectQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
         .then(
             invocation -> {
               selectQueryAssert.incrementAndGet();
@@ -167,7 +167,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows2 = Arrays.asList(resultRow(0, "doc1", tx_id2, doc1));
     AsyncResultSet results2 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows2, null);
     final AtomicInteger reReadQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
         .then(
             invocation -> {
               reReadQueryAssert.incrementAndGet();
@@ -189,7 +189,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger failedUpdateQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt3)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt3)))
         .then(
             invocation -> {
               failedUpdateQueryAssert.incrementAndGet();
@@ -200,7 +200,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt4)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt4)))
         .then(
             invocation -> {
               updateQueryAssert.incrementAndGet();
@@ -289,7 +289,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", tx_id1, doc1));
     AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
     final AtomicInteger selectQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
         .then(
             invocation -> {
               selectQueryAssert.incrementAndGet();
@@ -310,7 +310,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows2 = Arrays.asList(resultRow(0, "doc1", tx_id2, doc1));
     AsyncResultSet results2 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows2, null);
     final AtomicInteger reReadQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
         .then(
             invocation -> {
               reReadQueryAssert.incrementAndGet();
@@ -332,7 +332,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger updateFailedQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt3)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt3)))
         .then(
             invocation -> {
               updateFailedQueryAssert.incrementAndGet();
@@ -343,7 +343,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateRetryFailedQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt4)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt4)))
         .then(
             invocation -> {
               updateRetryFailedQueryAssert.incrementAndGet();
@@ -440,7 +440,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", tx_id1, doc1));
     AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
     final AtomicInteger selectQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
         .then(
             invocation -> {
               selectQueryAssert.incrementAndGet();
@@ -461,7 +461,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows2 = Arrays.asList(resultRow(0, "doc1", tx_id2, doc1));
     AsyncResultSet results2 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows2, null);
     final AtomicInteger reReadQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
         .then(
             invocation -> {
               reReadQueryAssert.incrementAndGet();
@@ -483,7 +483,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger updateFailedQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt3)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt3)))
         .then(
             invocation -> {
               updateFailedQueryAssert.incrementAndGet();
@@ -494,7 +494,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateRetryFailedQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt4)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt4)))
         .then(
             invocation -> {
               updateRetryFailedQueryAssert.incrementAndGet();
@@ -620,7 +620,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
         Arrays.asList(resultRow(0, "doc1", tx_id1, doc1), resultRow(0, "doc2", tx_id3, doc2));
     AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
     final AtomicInteger selectQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
         .then(
             invocation -> {
               selectQueryAssert.incrementAndGet();
@@ -639,7 +639,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows2 = Arrays.asList(resultRow(0, "doc1", tx_id2, doc1));
     AsyncResultSet results2 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows2, null);
     final AtomicInteger reReadFirstQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
         .then(
             invocation -> {
               reReadFirstQueryAssert.incrementAndGet();
@@ -652,7 +652,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger failedUpdateFirstQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt3)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt3)))
         .then(
             invocation -> {
               failedUpdateFirstQueryAssert.incrementAndGet();
@@ -663,7 +663,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger failedUpdateRetryFirstQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt4)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt4)))
         .then(
             invocation -> {
               failedUpdateRetryFirstQueryAssert.incrementAndGet();
@@ -677,7 +677,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows5 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
     AsyncResultSet results5 = new MockAsyncResultSet(COLUMNS_APPLIED, rows5, null);
     final AtomicInteger updateSecondQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt5)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt5)))
         .then(
             invocation -> {
               updateSecondQueryAssert.incrementAndGet();
@@ -807,7 +807,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
         Arrays.asList(resultRow(0, "doc1", tx_id1, doc1), resultRow(0, "doc2", tx_id3, doc2));
     AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
     final AtomicInteger selectQueryAssert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
         .then(
             invocation -> {
               selectQueryAssert.incrementAndGet();
@@ -824,7 +824,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows2 = Arrays.asList(resultRow(0, "doc1", tx_id2, doc1));
     AsyncResultSet results2 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows2, null);
     final AtomicInteger retrySelectQueryDoc1Assert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt2), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt2), any(), anyInt()))
         .then(
             invocation -> {
               retrySelectQueryDoc1Assert.incrementAndGet();
@@ -839,7 +839,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows3 = Arrays.asList(resultRow(0, "doc2", tx_id4, doc2));
     AsyncResultSet results3 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows3, null);
     final AtomicInteger retrySelectQueryDoc2Assert = new AtomicInteger();
-    when(queryExecutor.executeRead(eq(stmt3), any(), anyInt()))
+    when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt3), any(), anyInt()))
         .then(
             invocation -> {
               retrySelectQueryDoc2Assert.incrementAndGet();
@@ -852,7 +852,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateQueryDoc1Assert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt4)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt4)))
         .then(
             invocation -> {
               updateQueryDoc1Assert.incrementAndGet();
@@ -863,7 +863,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows5 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results5 = new MockAsyncResultSet(COLUMNS_APPLIED, rows5, null);
     final AtomicInteger updateRetryQueryDoc1Assert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt5)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt5)))
         .then(
             invocation -> {
               updateRetryQueryDoc1Assert.incrementAndGet();
@@ -877,7 +877,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows6 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results6 = new MockAsyncResultSet(COLUMNS_APPLIED, rows6, null);
     final AtomicInteger updateQueryDoc2Assert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt6)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt6)))
         .then(
             invocation -> {
               updateQueryDoc2Assert.incrementAndGet();
@@ -888,7 +888,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
     List<Row> rows7 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results7 = new MockAsyncResultSet(COLUMNS_APPLIED, rows7, null);
     final AtomicInteger updateRetryQueryDoc2Assert = new AtomicInteger();
-    when(queryExecutor.executeWrite(eq(stmt7)))
+    when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt7)))
         .then(
             invocation -> {
               updateRetryQueryDoc2Assert.incrementAndGet();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -242,7 +242,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
 
     Supplier<CommandResult> execute =
         operation
-            .execute(queryExecutor)
+            .execute(dataApiRequestInfo, queryExecutor)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
             .awaitItem()
@@ -385,7 +385,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
 
     Supplier<CommandResult> execute =
         operation
-            .execute(queryExecutor)
+            .execute(dataApiRequestInfo, queryExecutor)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
             .awaitItem()
@@ -536,7 +536,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
 
     Supplier<CommandResult> execute =
         operation
-            .execute(queryExecutor)
+            .execute(dataApiRequestInfo, queryExecutor)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
             .awaitItem()
@@ -722,7 +722,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
 
     Supplier<CommandResult> execute =
         operation
-            .execute(queryExecutor)
+            .execute(dataApiRequestInfo, queryExecutor)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
             .awaitItem()
@@ -932,7 +932,7 @@ public class ReadAndUpdateOperationRetryTest extends OperationTestBase {
 
     Supplier<CommandResult> execute =
         operation
-            .execute(queryExecutor)
+            .execute(dataApiRequestInfo, queryExecutor)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
             .awaitItem()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -197,7 +197,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", tx_id, doc1));
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -236,7 +236,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -304,7 +304,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", tx_id, doc1));
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -575,7 +575,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
                       null)));
       AsyncResultSet results1 = new MockAsyncResultSet(SELECT_SORT_RESULT_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -599,7 +599,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -809,7 +809,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", tx_id, doc1));
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -847,7 +847,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -917,7 +917,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList();
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -947,7 +947,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -1068,7 +1068,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
                       null)));
       AsyncResultSet results1 = new MockAsyncResultSet(SELECT_SORT_RESULT_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -1093,7 +1093,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -1236,7 +1236,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
                       null)));
       AsyncResultSet results1 = new MockAsyncResultSet(SELECT_SORT_RESULT_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -1260,7 +1260,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -1340,7 +1340,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList();
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -1378,7 +1378,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -1437,7 +1437,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList();
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -1558,7 +1558,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
           Arrays.asList(resultRow(0, "doc1", tx_id1, doc1), resultRow(0, "doc2", tx_id2, doc2));
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -1572,7 +1572,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -1585,7 +1585,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
       final AtomicInteger callCount3 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt3)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt3)))
           .then(
               invocation -> {
                 callCount3.incrementAndGet();
@@ -1662,7 +1662,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList();
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();
@@ -1683,7 +1683,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
       final AtomicInteger callCount2 = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(stmt2)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt2)))
           .then(
               invocation -> {
                 callCount2.incrementAndGet();
@@ -1761,7 +1761,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
       List<Row> rows1 = Arrays.asList();
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       final AtomicInteger callCount1 = new AtomicInteger();
-      when(queryExecutor.executeRead(eq(stmt1), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(stmt1), any(), anyInt()))
           .then(
               invocation -> {
                 callCount1.incrementAndGet();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -264,7 +264,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -350,7 +350,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -648,7 +648,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -877,7 +877,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -977,7 +977,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1145,7 +1145,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1307,7 +1307,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1404,7 +1404,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1480,7 +1480,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1629,7 +1629,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1727,7 +1727,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -1805,7 +1805,7 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -140,7 +140,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -211,7 +211,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       InsertOperation operation = new InsertOperation(COMMAND_CONTEXT, shredDocument);
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
@@ -354,7 +354,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor)
+              .execute(dataApiRequestInfo, queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -117,7 +117,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
-                SimpleStatement stmt = invocation.getArgument(0);
+                SimpleStatement stmt = invocation.getArgument(1);
                 callCountDelete.incrementAndGet();
                 return Uni.createFrom().item(deleteResults);
               });

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -99,7 +99,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       AsyncResultSet selectResults = new MockAsyncResultSet(keyAndTxtIdColumns, selectRows, null);
       final AtomicInteger callCountSelect = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(selectStmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(selectStmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCountSelect.incrementAndGet();
@@ -114,7 +114,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       List<Row> deleteRows = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, byteBufferFrom(true)));
       AsyncResultSet deleteResults = new MockAsyncResultSet(COLUMNS_APPLIED, deleteRows, null);
       final AtomicInteger callCountDelete = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(deleteStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(deleteStmt)))
           .then(
               invocation -> {
                 SimpleStatement stmt = invocation.getArgument(0);
@@ -201,7 +201,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       AsyncResultSet results = new MockAsyncResultSet(COLUMNS_APPLIED, resultRows, null);
       final AtomicInteger callCount = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeWrite(eq(stmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(stmt)))
           .then(
               invocation -> {
                 callCount.incrementAndGet();
@@ -257,7 +257,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       AsyncResultSet selectResults = new MockAsyncResultSet(keyTxIdDocColumns, selectRows, null);
       final AtomicInteger callCountSelect = new AtomicInteger();
       QueryExecutor queryExecutor = mock(QueryExecutor.class);
-      when(queryExecutor.executeRead(eq(selectStmt), any(), anyInt()))
+      when(queryExecutor.executeRead(eq(dataApiRequestInfo), eq(selectStmt), any(), anyInt()))
           .then(
               invocation -> {
                 callCountSelect.incrementAndGet();
@@ -312,7 +312,7 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
       List<Row> resultRows = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, byteBufferFrom(true)));
       AsyncResultSet updateResults = new MockAsyncResultSet(COLUMNS_APPLIED, resultRows, null);
       final AtomicInteger callCountUpdate = new AtomicInteger();
-      when(queryExecutor.executeWrite(eq(updateStmt)))
+      when(queryExecutor.executeWrite(eq(dataApiRequestInfo), eq(updateStmt)))
           .then(
               invocation -> {
                 callCountUpdate.incrementAndGet();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessorTest.java
@@ -51,11 +51,12 @@ public class MeteredCommandProcessorTest {
           objectMapper.readValue(json, CountDocumentsCommand.class);
       CommandContext commandContext = new CommandContext("namespace", "collection");
       CommandResult commandResult = new CommandResult(Collections.emptyList());
-      Mockito.when(commandProcessor.processCommand(commandContext, countCommand))
+      Mockito.when(
+              commandProcessor.processCommand(dataApiRequestInfo, commandContext, countCommand))
           .thenReturn(Uni.createFrom().item(commandResult));
       Mockito.when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of("test-tenant"));
       meteredCommandProcessor
-          .processCommand(commandContext, countCommand)
+          .processCommand(dataApiRequestInfo, commandContext, countCommand)
           .await()
           .atMost(Duration.ofMinutes(1));
       String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
@@ -103,11 +104,12 @@ public class MeteredCommandProcessorTest {
       CommandResult.Error error =
           new CommandResult.Error("message", fields, fields, Response.Status.OK);
       CommandResult commandResult = new CommandResult(Collections.singletonList(error));
-      Mockito.when(commandProcessor.processCommand(commandContext, countCommand))
+      Mockito.when(
+              commandProcessor.processCommand(dataApiRequestInfo, commandContext, countCommand))
           .thenReturn(Uni.createFrom().item(commandResult));
       Mockito.when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of("test-tenant"));
       meteredCommandProcessor
-          .processCommand(commandContext, countCommand)
+          .processCommand(dataApiRequestInfo, commandContext, countCommand)
           .await()
           .atMost(Duration.ofMinutes(1));
       String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
@@ -160,11 +162,12 @@ public class MeteredCommandProcessorTest {
       CommandResult.Error error =
           new CommandResult.Error("message", fields, fields, Response.Status.OK);
       CommandResult commandResult = new CommandResult(Collections.singletonList(error));
-      Mockito.when(commandProcessor.processCommand(commandContext, countCommand))
+      Mockito.when(
+              commandProcessor.processCommand(dataApiRequestInfo, commandContext, countCommand))
           .thenReturn(Uni.createFrom().item(commandResult));
       Mockito.when(dataApiRequestInfo.getTenantId()).thenReturn(Optional.of("test-tenant"));
       meteredCommandProcessor
-          .processCommand(commandContext, countCommand)
+          .processCommand(dataApiRequestInfo, commandContext, countCommand)
           .await()
           .atMost(Duration.ofMinutes(1));
       String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();


### PR DESCRIPTION
**What this PR does**:
Changes to pass the DataAPIRequestInfo object through out the flow for each request instead of injecting it in the `CqlSessionCache.java`. This enables this code base to be used as a library and execute commands in a Java application.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
