### PR TITLE
Fixed change log for v1.0.6 manually.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,7 @@
 
 ## [v1.0.6](https://github.com/stargate/data-api/tree/v1.0.6) (2024-04-17)
 
-[Full Changelog](https://github.com/stargate/data-api/compare/file_loader_changes...v1.0.6)
-
-**Merged pull requests:**
-
-- Pass DataAPIRequestInfo instead of injecting [\#1036](https://github.com/stargate/data-api/pull/1036) ([kathirsvn](https://github.com/kathirsvn))
-- Use Stargate v2.1.0-BETA-11 [\#1035](https://github.com/stargate/data-api/pull/1035) ([github-actions[bot]](https://github.com/apps/github-actions))
-- Fixes \#1031: partially revert change \#1005, making default Projection go back to "include all" [\#1033](https://github.com/stargate/data-api/pull/1033) ([tatu-at-datastax](https://github.com/tatu-at-datastax))
-- Fix DSE Integration, Username/Password credential based token [\#1030](https://github.com/stargate/data-api/pull/1030) ([Yuqi-Du](https://github.com/Yuqi-Du))
-- Add tenantId to driver logs [\#1027](https://github.com/stargate/data-api/pull/1027) ([Yuqi-Du](https://github.com/Yuqi-Du))
-- Add test to show \#1000 no longer applies [\#1026](https://github.com/stargate/data-api/pull/1026) ([tatu-at-datastax](https://github.com/tatu-at-datastax))
-
-## [file_loader_changes](https://github.com/stargate/data-api/tree/file_loader_changes) (2024-04-17)
-
-[Full Changelog](https://github.com/stargate/data-api/compare/v1.0.5...file_loader_changes)
+[Full Changelog](https://github.com/stargate/data-api/compare/v1.0.5...v1.0.6)
 
 **Implemented enhancements:**
 
@@ -43,7 +30,12 @@
 - Define acceptable consistency levels set globally [\#94](https://github.com/stargate/data-api/issues/94)
 
 **Merged pull requests:**
-
+- Pass DataAPIRequestInfo instead of injecting [\#1036](https://github.com/stargate/data-api/pull/1036) ([kathirsvn](https://github.com/kathirsvn))
+- Use Stargate v2.1.0-BETA-11 [\#1035](https://github.com/stargate/data-api/pull/1035) ([github-actions[bot]](https://github.com/apps/github-actions))
+- Fixes \#1031: partially revert change \#1005, making default Projection go back to "include all" [\#1033](https://github.com/stargate/data-api/pull/1033) ([tatu-at-datastax](https://github.com/tatu-at-datastax))
+- Fix DSE Integration, Username/Password credential based token [\#1030](https://github.com/stargate/data-api/pull/1030) ([Yuqi-Du](https://github.com/Yuqi-Du))
+- Add tenantId to driver logs [\#1027](https://github.com/stargate/data-api/pull/1027) ([Yuqi-Du](https://github.com/Yuqi-Du))
+- Add test to show \#1000 no longer applies [\#1026](https://github.com/stargate/data-api/pull/1026) ([tatu-at-datastax](https://github.com/tatu-at-datastax))
 - Quarkus Common Removal: Separate tenant resolver, token resolver, hea… [\#1024](https://github.com/stargate/data-api/pull/1024) ([Yuqi-Du](https://github.com/Yuqi-Du))
 - Username/Password credential based token format [\#1023](https://github.com/stargate/data-api/pull/1023) ([maheshrajamani](https://github.com/maheshrajamani))
 - Quarkus Common Removal: Data API queryBuilder [\#1022](https://github.com/stargate/data-api/pull/1022) ([Yuqi-Du](https://github.com/Yuqi-Du))


### PR DESCRIPTION
**What this PR does**:
The change log for v1.0.6 is not clean because of an intermediate tag that got created. This PR addresses that.

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
