### PR TITLE
Fix #1042: increase `DEFAULT_MAX_DOCUMENT_INSERT_COUNT` to 100 (from 20)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
@@ -39,9 +39,9 @@ public interface OperationsConfig {
 
   /**
    * Defines the default maximum documents to insert setting for {@code InsertMany} command;
-   * defaults to 20
+   * defaults to 100
    */
-  public static final int DEFAULT_MAX_DOCUMENT_INSERT_COUNT = 20;
+  public static final int DEFAULT_MAX_DOCUMENT_INSERT_COUNT = 100;
 
   /** @return Defines the default document page size, defaults to <code>20</code>. */
   @Max(500)


### PR DESCRIPTION
**What this PR does**:

Allows bigger batches for `InsertMany`: up to 100 documents instead of former 20.

**Which issue(s) this PR fixes**:
Fixes #1042

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
