### PR TITLE
Change CI to always runs for pull request, not just for specified changes

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -10,10 +10,6 @@ on:
 
   pull_request:
     branches: [ "main", "feature/*" ]
-    paths:
-      - 'src/**'
-      - 'pom.xml'
-      - '.github/workflows/continuous-integration.yaml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
**What this PR does**:

Changes triggering criteria for pull requests: removes filtering to not run for non-code changes.
This is needed because PRs require passing CI and without running that cannot happen.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
