### PR TITLE
Enable Dependabot update for Github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
**What this PR does**:

Enables Dependabot updates for GH Actions: will create PRs to update versions of GH Actions we use

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ]  Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
