### PR TITLE
Wire command name to MeteredEmbeddingProvider

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -186,7 +186,8 @@ public class CollectionResource {
                           vectorizeConfig.provider(),
                           vectorizeConfig.modelName(),
                           collectionProperty.vectorConfig().vectorSize(),
-                          vectorizeConfig.vectorizeServiceParameter());
+                          vectorizeConfig.vectorizeServiceParameter(),
+                          command.getClass().getSimpleName());
                 }
 
                 CommandContext commandContext =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
@@ -59,7 +59,6 @@ public class DataVectorizerService {
                         meterRegistry,
                         jsonApiMetricsConfig,
                         dataApiRequestInfo,
-                        metricsConfig,
                         provider,
                         command.getClass().getSimpleName()))
             .orElse(null);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/gateway/EmbeddingGatewayClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/gateway/EmbeddingGatewayClient.java
@@ -31,8 +31,8 @@ public class EmbeddingGatewayClient implements EmbeddingProvider {
   private String modelName;
   private String baseUrl;
   private EmbeddingService embeddingService;
-
   private Map<String, Object> vectorizeServiceParameter;
+  private String commandName;
 
   /**
    * @param requestProperties
@@ -52,7 +52,8 @@ public class EmbeddingGatewayClient implements EmbeddingProvider {
       String baseUrl,
       String modelName,
       EmbeddingService embeddingService,
-      Map<String, Object> vectorizeServiceParameter) {
+      Map<String, Object> vectorizeServiceParameter,
+      String commandName) {
     this.requestProperties = requestProperties;
     this.provider = provider;
     this.dimension = dimension;
@@ -61,6 +62,7 @@ public class EmbeddingGatewayClient implements EmbeddingProvider {
     this.baseUrl = baseUrl;
     this.embeddingService = embeddingService;
     this.vectorizeServiceParameter = vectorizeServiceParameter;
+    this.commandName = commandName;
   }
 
   /**
@@ -111,6 +113,7 @@ public class EmbeddingGatewayClient implements EmbeddingProvider {
         EmbeddingGateway.ProviderEmbedRequest.EmbeddingRequest.newBuilder()
             .setModelName(modelName)
             .setDimensions(dimension)
+            .setCommandName(commandName)
             .putAllParameters(grpcVectorizeServiceParameter)
             .setInputType(
                 embeddingRequestType == EmbeddingRequestType.INDEX

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactory.java
@@ -47,8 +47,10 @@ public class EmbeddingProviderFactory {
       String serviceName,
       String modelName,
       int dimension,
-      Map<String, Object> vectorizeServiceParameter) {
-    return addService(tenant, serviceName, modelName, dimension, vectorizeServiceParameter);
+      Map<String, Object> vectorizeServiceParameter,
+      String commandName) {
+    return addService(
+        tenant, serviceName, modelName, dimension, vectorizeServiceParameter, commandName);
   }
 
   private synchronized EmbeddingProvider addService(
@@ -56,7 +58,8 @@ public class EmbeddingProviderFactory {
       String serviceName,
       String modelName,
       int dimension,
-      Map<String, Object> vectorizeServiceParameter) {
+      Map<String, Object> vectorizeServiceParameter,
+      String commandName) {
     final EmbeddingProviderConfigStore.ServiceConfig configuration =
         embeddingProviderConfigStore.get().getConfiguration(tenant, serviceName);
     if (config.enableEmbeddingGateway()) {
@@ -68,7 +71,8 @@ public class EmbeddingProviderFactory {
           configuration.baseUrl(),
           modelName,
           embeddingService,
-          vectorizeServiceParameter);
+          vectorizeServiceParameter,
+          commandName);
     }
 
     if (configuration.serviceProvider().equals(ProviderConstants.CUSTOM)) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -2,7 +2,6 @@ package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
 import io.micrometer.core.instrument.*;
 import io.smallrye.mutiny.Uni;
-import io.stargate.sgv2.api.common.config.MetricsConfig;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import java.util.List;
@@ -19,7 +18,6 @@ public class MeteredEmbeddingProvider implements EmbeddingProvider {
   private final JsonApiMetricsConfig jsonApiMetricsConfig;
   private final DataApiRequestInfo dataApiRequestInfo;
   private static final String UNKNOWN_VALUE = "unknown";
-  private final MetricsConfig.TenantRequestCounterConfig tenantConfig;
   private final EmbeddingProvider embeddingProvider;
   private final String commandName;
 
@@ -27,13 +25,11 @@ public class MeteredEmbeddingProvider implements EmbeddingProvider {
       MeterRegistry meterRegistry,
       JsonApiMetricsConfig jsonApiMetricsConfig,
       DataApiRequestInfo dataApiRequestInfo,
-      MetricsConfig metricsConfig,
       EmbeddingProvider embeddingProvider,
       String commandName) {
     this.meterRegistry = meterRegistry;
     this.jsonApiMetricsConfig = jsonApiMetricsConfig;
     this.dataApiRequestInfo = dataApiRequestInfo;
-    tenantConfig = metricsConfig.tenantRequestCounter();
     this.embeddingProvider = embeddingProvider;
     this.commandName = commandName;
   }
@@ -79,8 +75,7 @@ public class MeteredEmbeddingProvider implements EmbeddingProvider {
    */
   private Tags getCustomTags() {
     Tag commandTag = Tag.of(jsonApiMetricsConfig.command(), commandName);
-    Tag tenantTag =
-        Tag.of(tenantConfig.tenantTag(), dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE));
+    Tag tenantTag = Tag.of("tenant", dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE));
     Tag embeddingProviderTag =
         Tag.of(
             jsonApiMetricsConfig.embeddingProvider(), embeddingProvider.getClass().getSimpleName());

--- a/src/main/proto/embedding_gateway.proto
+++ b/src/main/proto/embedding_gateway.proto
@@ -27,6 +27,8 @@ message ProviderEmbedRequest {
     InputType 					  input_type = 4;
     // The input data that needs to be vectorized
     repeated string 			inputs = 5;
+    // The command contains vectorize
+    string command_name = 6;
 
     // The parameter value, used when provided needs user specified parameters
     message ParameterValue {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingGatewayClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingGatewayClientTest.java
@@ -25,6 +25,9 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 public class EmbeddingGatewayClientTest {
+
+  public static final String TESTING_COMMAND_NAME = "test_command";
+
   @Test
   void handleValidResponse() throws ExecutionException, InterruptedException {
     EmbeddingService embeddingService = mock(EmbeddingService.class);
@@ -52,7 +55,8 @@ public class EmbeddingGatewayClientTest {
             "https://api.openai.com/v1/",
             "text-embedding-3-small",
             embeddingService,
-            Map.of());
+            Map.of(),
+            TESTING_COMMAND_NAME);
 
     final List<float[]> response =
         embeddingGatewayClient
@@ -95,7 +99,8 @@ public class EmbeddingGatewayClientTest {
             "https://api.openai.com/v1/",
             "text-embedding-3-small",
             embeddingService,
-            Map.of());
+            Map.of(),
+            TESTING_COMMAND_NAME);
 
     Throwable result =
         embeddingGatewayClient


### PR DESCRIPTION
This is for adding command name as tag in Embedding-Gateway metrics.


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
