### PR TITLE
update workflows to publish jar

### DIFF
--- a/.github/workflows/jar-publish.yaml
+++ b/.github/workflows/jar-publish.yaml
@@ -2,7 +2,10 @@ name: JAR Publish
 
 # runs on
 # * manual trigger
+# * push to main branch (updates SNAPSHOT version)
 on:
+  push:
+    branches: [ "main" ]
   workflow_dispatch:
 
 # global env vars, available in all jobs and steps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -347,3 +347,19 @@ jobs:
           branch-suffix: "short-commit-hash"
           base: "main"
 
+  # dispatch release event
+  dispatch:
+    name: Dispatch release event
+    needs: [ 'resolve-tag', 'publish-jar', 'publish-image-dockerhub', 'publish-image-ecr']
+    if: ${{ always() }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.STARGATE_GH_RELEASE }}
+          repository: riptano/embedding-gateway
+          event-type: data-api-release
+          client-payload: '{"version": "${{ needs.resolve-tag.outputs.release-tag}}"}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ on:
 # global env vars, available in all jobs and steps
 env:
   MAVEN_OPTS: '-Xmx4g'
+  DS_ARTIFACTORY_USERNAME: ${{ secrets.DS_ARTIFACTORY_USERNAME }}
+  DS_ARTIFACTORY_PASSWORD: ${{ secrets.DS_ARTIFACTORY_PASSWORD }}
 
 jobs:
 
@@ -65,6 +67,69 @@ jobs:
           release_name: Release ${{needs.resolve-tag.outputs.release-tag}}
           draft: false
           prerelease: false
+
+  # builds and publishes the jar
+  publish-jar:
+    name: Build and Publish Jar
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Setup Maven
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>stargate-central</id>
+                <username>${DS_ARTIFACTORY_USERNAME}</username>
+                <password>${DS_ARTIFACTORY_PASSWORD}</password>
+              </server>
+              <server>
+                <id>stargate-snapshots</id>
+                <username>${DS_ARTIFACTORY_USERNAME}</username>
+                <password>${DS_ARTIFACTORY_PASSWORD}</password>
+             </server>
+              <server>
+                <id>artifactory</id>
+                <username>${DS_ARTIFACTORY_USERNAME}</username>
+                <password>${DS_ARTIFACTORY_PASSWORD}</password>
+              </server>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${DS_ARTIFACTORY_USERNAME}</username>
+                <password>${DS_ARTIFACTORY_PASSWORD}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${DS_ARTIFACTORY_USERNAME}</username>
+                <password>${DS_ARTIFACTORY_PASSWORD}</password>
+             </server>
+           </servers>
+          </settings>
+          EOF
+
+      # only set version here
+      - name: Install
+        run: |
+          ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
+
+      - name: Build
+        run: |
+          ./mvnw -B -ntp clean package -P offline
+
+      - name: Publish JAR
+        run: |
+          ./mvnw -B -ntp clean deploy -DskipTests -P offline
 
   # publishes the docker image to docker hub
   publish-image-dockerhub:


### PR DESCRIPTION
Update workflows that publish Data API as jar:

- update Publish Jar workflow to run on every commit to main (this will update SNAPSHOT versions)
- update Release workflow to publish non-SNAPSHOT versions

(also added event dispatch to release workflow)

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
