### PR TITLE
Fix #1088: handle `null` valued service params

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactory.java
@@ -23,7 +23,7 @@ public class EmbeddingProviderFactory {
   @GrpcClient("embedding")
   EmbeddingService embeddingService;
 
-  private interface ProviderConstructor {
+  interface ProviderConstructor {
     EmbeddingProvider create(
         EmbeddingProviderConfigStore.RequestProperties requestProperties,
         String baseUrl,
@@ -55,6 +55,9 @@ public class EmbeddingProviderFactory {
       Map<String, Object> vectorizeServiceParameters,
       Map<String, String> authentication,
       String commandName) {
+    if (vectorizeServiceParameters == null) {
+      vectorizeServiceParameters = Map.of();
+    }
     return addService(
         tenant,
         authToken,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingClient.java
@@ -33,18 +33,17 @@ public class VertexAIEmbeddingClient implements EmbeddingProvider {
 
   private static final String PROJECT_ID = "projectId";
 
-  private Map<String, Object> vectorizeServiceParameters;
-
   public VertexAIEmbeddingClient(
       EmbeddingProviderConfigStore.RequestProperties requestProperties,
       String baseUrl,
       String modelName,
       int dimension,
-      Map<String, Object> vectorizeServiceParameters) {
+      Map<String, Object> serviceParameters) {
     this.requestProperties = requestProperties;
     this.modelName = modelName;
-    this.vectorizeServiceParameters = vectorizeServiceParameters;
-    baseUrl = baseUrl.replace(PROJECT_ID, vectorizeServiceParameters.get(PROJECT_ID).toString());
+    String projectId =
+        (serviceParameters == null) ? "" : String.valueOf(serviceParameters.get(PROJECT_ID));
+    baseUrl = baseUrl.replace(PROJECT_ID, projectId);
     embeddingProvider =
         QuarkusRestClientBuilder.newBuilder()
             .baseUri(URI.create(baseUrl))

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingClient.java
@@ -38,13 +38,13 @@ public class VoyageAIEmbeddingClient implements EmbeddingProvider {
       String baseUrl,
       String modelName,
       int dimension,
-      Map<String, Object> vectorizeServiceParameters) {
+      Map<String, Object> serviceParameters) {
     this.requestProperties = requestProperties;
     this.modelName = modelName;
     // use configured input_type if available
     requestTypeQuery = requestProperties.requestTypeQuery().orElse(null);
     requestTypeIndex = requestProperties.requestTypeIndex().orElse(null);
-    Object v = vectorizeServiceParameters.get("autoTruncate");
+    Object v = (serviceParameters == null) ? null : serviceParameters.get("autoTruncate");
     autoTruncate = (v instanceof Boolean) ? (Boolean) v : null;
 
     embeddingProvider =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingGatewayClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingGatewayClientTest.java
@@ -16,6 +16,7 @@ import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.gateway.EmbeddingGatewayClient;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +27,29 @@ import org.junit.jupiter.api.Test;
 public class EmbeddingGatewayClientTest {
 
   public static final String TESTING_COMMAND_NAME = "test_command";
+
+  // for [data-api#1088] (NPE for VoyageAI provider)
+  @Test
+  void verifyDirectConstructionWithNullServiceParameters() {
+    List<EmbeddingProviderFactory.ProviderConstructor> providerCtors =
+        Arrays.asList(
+            AzureOpenAIEmbeddingClient::new,
+            CohereEmbeddingClient::new,
+            HuggingFaceEmbeddingClient::new,
+            JinaAIEmbeddingClient::new,
+            MistralEmbeddingClient::new,
+            NvidiaEmbeddingClient::new,
+            OpenAIEmbeddingClient::new,
+            UpstageAIEmbeddingClient::new,
+            VertexAIEmbeddingClient::new,
+            VoyageAIEmbeddingClient::new);
+    for (EmbeddingProviderFactory.ProviderConstructor ctor : providerCtors) {
+      EmbeddingProviderConfigStore.RequestProperties requestProperties =
+          EmbeddingProviderConfigStore.RequestProperties.of(
+              3, 5, 5000, Optional.empty(), Optional.empty());
+      assertThat(ctor.create(requestProperties, "baseUrl", "modelName", 5, null)).isNotNull();
+    }
+  }
 
   @Test
   void handleValidResponse() {


### PR DESCRIPTION
**What this PR does**:

Adds test to reproduce issue of passing `null` for vectorize service parameters, fix to avoid, for VoyageAI client (and another check for incomplete VertexAI one as well)

**Which issue(s) this PR fixes**:
Fixes #1088

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
