### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -182,4 +182,4 @@ jobs:
         env:
           COORD_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next
         run: |
-          ./mvnw -B -ntp clean verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE -Dstargate.jsonapi.operations.database-config.ddl-delay-millis=0 ${{ matrix.profile }}
+          ./mvnw -B -ntp clean verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE -Drun-create-index-parallel=true ${{ matrix.profile }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -182,4 +182,4 @@ jobs:
         env:
           COORD_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next
         run: |
-          ./mvnw -B -ntp clean verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}
+          ./mvnw -B -ntp clean verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE -Dstargate.jsonapi.operations.database-config.ddl-delay-millis=0 ${{ matrix.profile }}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -168,21 +168,23 @@ public record CreateCollectionOperation(
         execute
             .onItem()
             .delayIt()
-            .by(Duration.ofMillis(ddlDelayMillis))
+            .by(Duration.ofMillis(ddlDelayMillis > 0 ? ddlDelayMillis : 100))
             .onItem()
             .transformToUni(
                 res -> {
                   if (res.wasApplied()) {
                     final List<SimpleStatement> indexStatements =
                         getIndexStatements(commandContext.namespace(), name);
-                    return Multi.createFrom()
-                        .items(indexStatements.stream())
-                        .onItem()
-                        .transformToUni(
-                            indexStatement ->
-                                queryExecutor.executeCreateSchemaChange(
-                                    dataApiRequestInfo, indexStatement))
-                        .concatenate()
+                    Multi<AsyncResultSet> indexResultMulti;
+                    if (ddlDelayMillis == 0) {
+                      indexResultMulti =
+                          createIndexParallel(queryExecutor, dataApiRequestInfo, indexStatements);
+                    } else {
+                      indexResultMulti =
+                          createIndexOrdered(queryExecutor, dataApiRequestInfo, indexStatements);
+                    }
+
+                    return indexResultMulti
                         .collect()
                         .asList()
                         .onItem()
@@ -234,6 +236,48 @@ public record CreateCollectionOperation(
                               "collection \"%s\" creation failed due to index creation failing; need %d indexes to create the collection;",
                               name, dbLimitsConfig.indexesNeededPerCollection()));
             });
+  }
+
+  /**
+   * Create indexes for collections in ordered. This is to avoid schema change conflicts.
+   *
+   * @param queryExecutor
+   * @param dataApiRequestInfo
+   * @param indexStatements
+   * @return
+   */
+  private Multi<AsyncResultSet> createIndexOrdered(
+      QueryExecutor queryExecutor,
+      DataApiRequestInfo dataApiRequestInfo,
+      List<SimpleStatement> indexStatements) {
+    return Multi.createFrom()
+        .items(indexStatements.stream())
+        .onItem()
+        .transformToUni(
+            indexStatement ->
+                queryExecutor.executeCreateSchemaChange(dataApiRequestInfo, indexStatement))
+        .concatenate();
+  }
+
+  /**
+   * Create indexes for collections in parallel. TO speed up the CI actions.
+   *
+   * @param queryExecutor
+   * @param dataApiRequestInfo
+   * @param indexStatements
+   * @return
+   */
+  private Multi<AsyncResultSet> createIndexParallel(
+      QueryExecutor queryExecutor,
+      DataApiRequestInfo dataApiRequestInfo,
+      List<SimpleStatement> indexStatements) {
+    return Multi.createFrom()
+        .items(indexStatements.stream())
+        .onItem()
+        .transformToUni(
+            indexStatement ->
+                queryExecutor.executeCreateSchemaChange(dataApiRequestInfo, indexStatement))
+        .merge();
   }
 
   public Uni<JsonApiException> cleanUpCollectionFailedWithTooManyIndex(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -176,6 +176,12 @@ public record CreateCollectionOperation(
                     final List<SimpleStatement> indexStatements =
                         getIndexStatements(commandContext.namespace(), name);
                     Multi<AsyncResultSet> indexResultMulti;
+                    /*
+                    CI will override ddlDelayMillis to 0 using `-Dstargate.jsonapi.operations.database-config.ddl-delay-millis=0`
+                       to speed up the test execution
+                       This is ok because CI is run as single cassandra instance and there is no need to wait for the schema changes to propagate
+                    */
+
                     if (ddlDelayMillis == 0) {
                       indexResultMulti =
                           createIndexParallel(queryExecutor, dataApiRequestInfo, indexStatements);

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -95,7 +95,7 @@ public class DseTestResource extends StargateTestResource {
     propsBuilder.put("stargate.data-store.ignore-bridge", "true");
     propsBuilder.put("stargate.debug.enabled", "true");
     // Reduce the delay for ITs
-    propsBuilder.put("stargate.jsonapi.operations.database-config.ddl-delay-millis", "50");
+    propsBuilder.put("stargate.jsonapi.operations.database-config.ddl-delay-millis", "0");
     return propsBuilder.build();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -94,6 +94,12 @@ public class DseTestResource extends StargateTestResource {
     }
     propsBuilder.put("stargate.data-store.ignore-bridge", "true");
     propsBuilder.put("stargate.debug.enabled", "true");
+    // Reduce the delay for ITs
+    if (Boolean.getBoolean("run-create-index-parallel")) {
+      propsBuilder.put("stargate.jsonapi.operations.database-config.ddl-delay-millis", "0");
+    } else {
+      propsBuilder.put("stargate.jsonapi.operations.database-config.ddl-delay-millis", "50");
+    }
     return propsBuilder.build();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -94,8 +94,6 @@ public class DseTestResource extends StargateTestResource {
     }
     propsBuilder.put("stargate.data-store.ignore-bridge", "true");
     propsBuilder.put("stargate.debug.enabled", "true");
-    // Reduce the delay for ITs
-    propsBuilder.put("stargate.jsonapi.operations.database-config.ddl-delay-millis", "0");
     return propsBuilder.build();
   }
 }


### PR DESCRIPTION
**What this PR does**:
Run index creation in parallel to improve CI performance. Parallel run only for CI.
Adding the delay is not done in pom file or DseTestResource, so CI against cndb can be executed with the sequential indexing.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
