### PR TITLE
Fix #1102: move hyphen from UpstageAI model base name to suffix (for better UI exp)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingClient.java
@@ -25,8 +25,8 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 public class UpstageAIEmbeddingClient implements EmbeddingProvider {
-  private final static String UPSTAGE_MODEL_SUFFIX_QUERY = "-query";
-  private final static String UPSTAGE_MODEL_SUFFIX_PASSAGE = "-passage";
+  private static final String UPSTAGE_MODEL_SUFFIX_QUERY = "-query";
+  private static final String UPSTAGE_MODEL_SUFFIX_PASSAGE = "-passage";
 
   private EmbeddingProviderConfigStore.RequestProperties requestProperties;
   private String modelNamePrefix;
@@ -90,7 +90,8 @@ public class UpstageAIEmbeddingClient implements EmbeddingProvider {
     final String modelName =
         modelNamePrefix
             + ((embeddingRequestType == EmbeddingRequestType.SEARCH)
-                ? UPSTAGE_MODEL_SUFFIX_QUERY : UPSTAGE_MODEL_SUFFIX_PASSAGE);
+                ? UPSTAGE_MODEL_SUFFIX_QUERY
+                : UPSTAGE_MODEL_SUFFIX_PASSAGE);
 
     EmbeddingRequest request = new EmbeddingRequest(texts.get(0), modelName);
     Uni<EmbeddingResponse> response =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingClient.java
@@ -25,6 +25,9 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 public class UpstageAIEmbeddingClient implements EmbeddingProvider {
+  private final static String UPSTAGE_MODEL_SUFFIX_QUERY = "-query";
+  private final static String UPSTAGE_MODEL_SUFFIX_PASSAGE = "-passage";
+
   private EmbeddingProviderConfigStore.RequestProperties requestProperties;
   private String modelNamePrefix;
   private final UpstageAIEmbeddingProvider embeddingProvider;
@@ -86,7 +89,8 @@ public class UpstageAIEmbeddingClient implements EmbeddingProvider {
     // Another oddity: model name used as prefix
     final String modelName =
         modelNamePrefix
-            + ((embeddingRequestType == EmbeddingRequestType.SEARCH) ? "query" : "passage");
+            + ((embeddingRequestType == EmbeddingRequestType.SEARCH)
+                ? UPSTAGE_MODEL_SUFFIX_QUERY : UPSTAGE_MODEL_SUFFIX_PASSAGE);
 
     EmbeddingRequest request = new EmbeddingRequest(texts.get(0), modelName);
     Uni<EmbeddingResponse> response =

--- a/src/main/resources/embedding-providers-config.yaml
+++ b/src/main/resources/embedding-providers-config.yaml
@@ -328,6 +328,6 @@ stargate:
           properties:
           models:
             # NOTE: this is where weirdness exists; model name is prefix on which
-            #   either "query" or "passage" is appended to get the actual model name
-            - name: solar-1-mini-embedding-
+            #   either "-query" or "-passage" is appended to get the actual model name
+            - name: solar-1-mini-embedding
               vector-dimension: 4096


### PR DESCRIPTION
**What this PR does**:

Moves trailing hyphen from Upstage AI model base name (where it looks odd) into suffix embedding client appends (hidden from user)

**Which issue(s) this PR fixes**:
Fixes #1102

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
