### PR TITLE
Changes to improve CI timing - Fix 2

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountByCassandraIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountByCassandraIntegrationTest.java
@@ -10,7 +10,6 @@ import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
@@ -21,6 +20,7 @@ import org.junit.jupiter.api.TestMethodOrder;
     value = CountByCassandraIntegrationTest.CassandraCounterTestResource.class,
     restrictToAnnotatedClass = true)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CountByCassandraIntegrationTest extends AbstractCollectionIntegrationTestBase {
 
   // Need to set max count limit to -1, so cassandra count(*) is used
@@ -34,772 +34,766 @@ public class CountByCassandraIntegrationTest extends AbstractCollectionIntegrati
     }
   }
 
-  @Nested
-  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  @Test
   @Order(1)
-  class Count {
-
-    @Test
-    @Order(1)
-    public void setUp() {
-      createNamespace();
-      createSimpleCollection();
-      String json =
-          """
-          {
-            "insertOne": {
-              "document": {
-                "_id": "doc1",
-                "username": "user1",
-                "active_user" : true
-              }
-            }
-          }
-          """;
-      insert(json);
-
-      json =
-          """
-          {
-            "insertOne": {
-              "document": {
-                "_id": "doc2",
-                "username": "user2",
-                "subdoc" : {
-                   "id" : "abc"
-                },
-                "array" : [
-                    "value1"
-                ]
-              }
-            }
-          }
-          """;
-      insert(json);
-
-      json =
-          """
-          {
-            "insertOne": {
-              "document": {
-                "_id": "doc3",
-                "username": "user3",
-                "tags" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true],
-                "nestedArray" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]
-              }
-            }
-          }
-          """;
-      insert(json);
-
-      json =
-          """
-          {
-            "insertOne": {
-              "document": {
-                "_id": "doc4",
-                "indexedObject" : { "0": "value_0", "1": "value_1" }
-              }
-            }
-          }
-          """;
-      insert(json);
-
-      json =
-          """
-          {
-            "insertOne": {
-              "document": {
-                "_id": "doc5",
-                "username": "user5",
-                "sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } }
-              }
-            }
-          }
-          """;
-      insert(json);
-    }
-
-    private void insert(String json) {
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void noFilter() {
-      String json =
-          """
-          {
-            "countDocuments": {
-            }
-          }
-          """;
-
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(5))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void emptyOptionsAllowed() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "options": {}
-            }
-          }
-          """;
-
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(5))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void byColumn() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"username" : "user1"}
-            }
-          }
-          """;
-
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void countBySimpleOr() {
-      String json =
-          """
-{
-    "countDocuments": {
-        "filter": {
-            "$or": [
-                {
-                    "username": "user1"
-                },
-                {
-                    "username": "user2"
+  public void setUp() {
+    createNamespace();
+    createSimpleCollection();
+    String json =
+        """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": "doc1",
+                  "username": "user1",
+                  "active_user" : true
                 }
-            ]
-        }
-    }
-}
-              """;
-
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(2))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void withEqComparisonOperator() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"username" : {"$eq" : "user1"}}
+              }
             }
-          }
-          """;
+            """;
+    insert(json);
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void withEqSubDoc() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"subdoc.id" : {"$eq" : "abc"}}
+    json =
+        """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": "doc2",
+                  "username": "user2",
+                  "subdoc" : {
+                     "id" : "abc"
+                  },
+                  "array" : [
+                      "value1"
+                  ]
+                }
+              }
             }
-          }
-          """;
+            """;
+    insert(json);
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void withEqSubDocWithIndex() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"indexedObject.1" : {"$eq" : "value_1"}}
+    json =
+        """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": "doc3",
+                  "username": "user3",
+                  "tags" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true],
+                  "nestedArray" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]
+                }
+              }
             }
-          }
-          """;
+            """;
+    insert(json);
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void withEqArrayElement() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"array.0" : {"$eq" : "value1"}}
+    json =
+        """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": "doc4",
+                  "indexedObject" : { "0": "value_0", "1": "value_1" }
+                }
+              }
             }
-          }
-          """;
+            """;
+    insert(json);
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void withExistFalseOperator() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"active_user" : {"$exists" : false}}
+    json =
+        """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": "doc5",
+                  "username": "user5",
+                  "sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } }
+                }
+              }
             }
-          }
-          """;
+            """;
+    insert(json);
+  }
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(4))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+  private void insert(String json) {
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withExistOperator() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"active_user" : {"$exists" : true}}
+  @Test
+  public void noFilter() {
+    String json =
+        """
+            {
+              "countDocuments": {
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(5))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withAllOperator() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$all" : ["tag1", "tag2"]}}
+  @Test
+  public void emptyOptionsAllowed() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "options": {}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(5))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withAllOperatorAnd() {
-      String json =
-          """
-                              {
-                                  "countDocuments": {
-                                      "filter": {
-                                          "$and": [
-                                              {
-                                                  "tags": {
-                                                      "$all": [
-                                                          "tag1",
-                                                          "tag2"
-                                                      ]
-                                                  }
-                                              },
-                                              {
-                                                  "active_user": {
-                                                      "$exists": true
-                                                  }
-                                              }
-                                          ]
-                                      }
-                                  }
-                              }
-                      """;
-
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void withAllOperatorLongerString() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$all" : ["tag1", "tag1234567890123456789012345"]}}
+  @Test
+  public void byColumn() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"username" : "user1"}
+              }
             }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void countBySimpleOr() {
+    String json =
+        """
+  {
+      "countDocuments": {
+          "filter": {
+              "$or": [
+                  {
+                      "username": "user1"
+                  },
+                  {
+                      "username": "user2"
+                  }
+              ]
           }
-          """;
+      }
+  }
+                """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(2))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withAllOperatorMixedAFormatArray() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$all" : ["tag1", 1, true, null]}}
+  @Test
+  public void withEqComparisonOperator() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"username" : {"$eq" : "user1"}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withAllOperatorNoMatch() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$all" : ["tag1", 2, true, null]}}
+  @Test
+  public void withEqSubDoc() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"subdoc.id" : {"$eq" : "abc"}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqSubDocumentShortcut() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } } }
+  @Test
+  public void withEqSubDocWithIndex() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"indexedObject.1" : {"$eq" : "value_1"}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqSubDocument() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": false } } } }
+  @Test
+  public void withEqArrayElement() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"array.0" : {"$eq" : "value1"}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqSubDocumentOrderChangeNoMatch() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "d": false, "c": "v1" } } } }
+  @Test
+  public void withExistFalseOperator() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"active_user" : {"$exists" : false}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(4))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqSubDocumentNoMatch() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": true } } } }
+  @Test
+  public void withExistOperator() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"active_user" : {"$exists" : true}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withSizeOperator() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$size" : 6}}
+  @Test
+  public void withAllOperator() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$all" : ["tag1", "tag2"]}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withSizeOperatorNoMatch() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$size" : 1}}
+  @Test
+  public void withAllOperatorAnd() {
+    String json =
+        """
+                                {
+                                    "countDocuments": {
+                                        "filter": {
+                                            "$and": [
+                                                {
+                                                    "tags": {
+                                                        "$all": [
+                                                            "tag1",
+                                                            "tag2"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "active_user": {
+                                                        "$exists": true
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                        """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withAllOperatorLongerString() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$all" : ["tag1", "tag1234567890123456789012345"]}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqOperatorArray() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true]}}
+  @Test
+  public void withAllOperatorMixedAFormatArray() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$all" : ["tag1", 1, true, null]}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqOperatorNestedArray() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]}}
+  @Test
+  public void withAllOperatorNoMatch() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$all" : ["tag1", 2, true, null]}}
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqOperatorArrayNoMatch() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1]}}
+  @Test
+  public void withEqSubDocumentShortcut() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } } }
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withEqOperatorNestedArrayNoMatch() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null], ["abc"]]}}
+  @Test
+  public void withEqSubDocument() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": false } } } }
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(0))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void withNEComparisonOperator() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"username" : {"$ne" : "user1"}}
+  @Test
+  public void withEqSubDocumentOrderChangeNoMatch() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "d": false, "c": "v1" } } } }
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(4))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
 
-    @Test
-    public void byBooleanColumn() {
-      String json =
-          """
-          {
-            "countDocuments": {
-              "filter" : {"active_user" : true}
+  @Test
+  public void withEqSubDocumentNoMatch() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": true } } } }
+              }
             }
-          }
-          """;
+            """;
 
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.count", is(1))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
-    }
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withSizeOperator() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$size" : 6}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withSizeOperatorNoMatch() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$size" : 1}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withEqOperatorArray() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true]}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withEqOperatorNestedArray() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withEqOperatorArrayNoMatch() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1]}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withEqOperatorNestedArrayNoMatch() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null], ["abc"]]}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(0))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void withNEComparisonOperator() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"username" : {"$ne" : "user1"}}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(4))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
+  }
+
+  @Test
+  public void byBooleanColumn() {
+    String json =
+        """
+            {
+              "countDocuments": {
+                "filter" : {"active_user" : true}
+              }
+            }
+            """;
+
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+        .then()
+        .statusCode(200)
+        .body("status.count", is(1))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionTooManyTablesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionTooManyTablesIntegrationTest.java
@@ -9,8 +9,6 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.ClassOrderer;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
 
@@ -42,38 +40,23 @@ class CreateCollectionTooManyTablesIntegrationTest extends AbstractNamespaceInte
     }
   }
 
-  @Nested
-  @Order(1)
-  class TooManyCollections {
-    @Test
-    public void enforceMaxCollections() {
-      // Don't use auto-generated namespace that rest of the test uses
-      final String NS = "ns_too_many_collections";
-      createNamespace(NS);
-      final String createTemplate =
-          """
-              {
-                "createCollection": {
-                  "name": "tooMany_%d"
+  @Test
+  public void enforceMaxCollections() {
+    // Don't use auto-generated namespace that rest of the test uses
+    final String NS = "ns_too_many_collections";
+    createNamespace(NS);
+    final String createTemplate =
+        """
+                {
+                  "createCollection": {
+                    "name": "tooMany_%d"
+                  }
                 }
-              }
-              """;
+                """;
 
-      // First create maximum number of collections
-      for (int i = 1; i <= COLLECTIONS_TO_CREATE; ++i) {
-        String json = createTemplate.formatted(i);
-        given()
-            .headers(getHeaders())
-            .contentType(ContentType.JSON)
-            .body(json)
-            .when()
-            .post(NamespaceResource.BASE_PATH, NS)
-            .then()
-            .statusCode(200)
-            .body("status.ok", is(1));
-      }
-      // And then failure
-      String json = createTemplate.formatted(99);
+    // First create maximum number of collections
+    for (int i = 1; i <= COLLECTIONS_TO_CREATE; ++i) {
+      String json = createTemplate.formatted(i);
       given()
           .headers(getHeaders())
           .contentType(ContentType.JSON)
@@ -82,29 +65,40 @@ class CreateCollectionTooManyTablesIntegrationTest extends AbstractNamespaceInte
           .post(NamespaceResource.BASE_PATH, NS)
           .then()
           .statusCode(200)
-          .body("status", is(nullValue()))
-          .body("data", is(nullValue()))
-          .body(
-              "errors[0].message",
-              is(
-                  "Too many collections: number of collections in database cannot exceed "
-                      + COLLECTIONS_TO_CREATE
-                      + ", already have "
-                      + COLLECTIONS_TO_CREATE))
-          .body("errors[0].errorCode", is("TOO_MANY_COLLECTIONS"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
-
-      // But then verify that re-creating an existing one should still succeed
-      // (if using same settings)
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(createTemplate.formatted(1))
-          .when()
-          .post(NamespaceResource.BASE_PATH, NS)
-          .then()
-          .statusCode(200)
           .body("status.ok", is(1));
     }
+    // And then failure
+    String json = createTemplate.formatted(99);
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(NamespaceResource.BASE_PATH, NS)
+        .then()
+        .statusCode(200)
+        .body("status", is(nullValue()))
+        .body("data", is(nullValue()))
+        .body(
+            "errors[0].message",
+            is(
+                "Too many collections: number of collections in database cannot exceed "
+                    + COLLECTIONS_TO_CREATE
+                    + ", already have "
+                    + COLLECTIONS_TO_CREATE))
+        .body("errors[0].errorCode", is("TOO_MANY_COLLECTIONS"))
+        .body("errors[0].exceptionClass", is("JsonApiException"));
+
+    // But then verify that re-creating an existing one should still succeed
+    // (if using same settings)
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(createTemplate.formatted(1))
+        .when()
+        .post(NamespaceResource.BASE_PATH, NS)
+        .then()
+        .statusCode(200)
+        .body("status.ok", is(1));
   }
 }


### PR DESCRIPTION
**What this PR does**:
Changes to improve CI timing. When `restrictToAnnotatedClass = true` is used in `@QuarkusTestResource` it is loading the profile for every nested class meaning starting dse and coordinator for every nested class. I have moved the methods from the nested class to main class since it had only one nested class. This will make sure we load the profile once instead of twice for these classes.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
