### PR TITLE
Remove `vectorDimension:0` for range dimension in `findEmbeddingProviders`

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProvidersConfigImpl.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProvidersConfigImpl.java
@@ -36,7 +36,9 @@ public record EmbeddingProvidersConfigImpl(
           List<ParameterConfig> modelParameterList) {
         this(
             grpcModelConfig.getName(),
-            Optional.ofNullable(grpcModelConfig.getVectorDimension()),
+            grpcModelConfig.hasVectorDimension()
+                ? Optional.of(grpcModelConfig.getVectorDimension())
+                : Optional.empty(),
             modelParameterList,
             grpcModelConfig.getPropertiesMap());
       }
@@ -57,13 +59,13 @@ public record EmbeddingProvidersConfigImpl(
             grpcModelParameter.getName(),
             ParameterType.valueOf(grpcModelParameter.getType().name()),
             grpcModelParameter.getRequired(),
-            Optional.ofNullable(grpcModelParameter.getDefaultValue()),
+            Optional.of(grpcModelParameter.getDefaultValue()),
             grpcModelParameter.getValidationMap().entrySet().stream()
                 .collect(
                     Collectors.toMap(
                         e -> ValidationType.fromString(e.getKey()),
                         e -> new ArrayList<>(e.getValue().getValuesList()))),
-            Optional.ofNullable(grpcModelParameter.getHelp()));
+            Optional.of(grpcModelParameter.getHelp()));
       }
     }
 
@@ -82,9 +84,9 @@ public record EmbeddingProvidersConfigImpl(
             grpcProviderConfigProperties.getMaxRetries(),
             grpcProviderConfigProperties.getRetryDelayMillis(),
             grpcProviderConfigProperties.getRequestTimeoutMillis(),
-            Optional.ofNullable(grpcProviderConfigProperties.getMaxInputLength()),
-            Optional.ofNullable(grpcProviderConfigProperties.getTaskTypeStore()),
-            Optional.ofNullable(grpcProviderConfigProperties.getTaskTypeRead()));
+            Optional.of(grpcProviderConfigProperties.getMaxInputLength()),
+            Optional.of(grpcProviderConfigProperties.getTaskTypeStore()),
+            Optional.of(grpcProviderConfigProperties.getTaskTypeRead()));
       }
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Remove `vectorDimension:0` for range dimension in `findEmbeddingProviders`

**Which issue(s) this PR fixes**:
Fixes [C2-3526](https://datastax.jira.com/browse/C2-3526)

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
