### PR TITLE
Fix #1038: improve error message for unknown dollar-starting field

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -294,7 +294,7 @@ public class DocumentProjector {
             throw new JsonApiException(
                 ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
                 ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-                    + ": path cannot start with '$' (no root-level operators)");
+                    + ": '$vector'/'$vectorize' are the only allowed paths that can start with '$'");
           }
 
           // Second: we only support one operator for now

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -166,7 +166,7 @@ public class DocumentProjectorTest {
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_PROJECTION_PARAM)
           .hasMessage(
-              "Unsupported projection parameter: path cannot start with '$' (no root-level operators)");
+              "Unsupported projection parameter: '$vector'/'$vectorize' are the only allowed paths that can start with '$'");
     }
   }
 
@@ -222,7 +222,7 @@ public class DocumentProjectorTest {
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_PROJECTION_PARAM)
           .hasMessage(
-              "Unsupported projection parameter: path cannot start with '$' (no root-level operators)");
+              "Unsupported projection parameter: '$vector'/'$vectorize' are the only allowed paths that can start with '$'");
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Improves failure message for case where user tries to project on key starting with "$" (other than $vector or $vectorize), to indicate accepted keys (instead of referring to operators)

**Which issue(s) this PR fixes**:
Fixes #1038

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
