### PR TITLE
upstage displayName and huggingFaceDedicated modelName small fix

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -155,6 +155,11 @@ public record CreateCollectionCommand(
           // HuggingfaceDedicated does not need user to specify model
           // use endpoint-defined-model as placeholder
           if (provider.equals(ProviderConstants.HUGGINGFACE_DEDICATED)) {
+            if (modelName != null) {
+              throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
+                  "'modelName' is not needed for provider %s",
+                  ProviderConstants.HUGGINGFACE_DEDICATED);
+            }
             this.modelName = ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL;
           } else {
             this.modelName = modelName;

--- a/src/main/resources/embedding-providers-config.yaml
+++ b/src/main/resources/embedding-providers-config.yaml
@@ -371,7 +371,7 @@ stargate:
         # In addition, implementation only supports 1-entry vectorization.
         upstageAI:
           # see https://developers.upstage.ai/docs/apis/embeddings
-          display-name: Upstage AI
+          display-name: Upstage
           enabled: true
           url: https://api.upstage.ai/v1/solar/embeddings
           supported-authentications:


### PR DESCRIPTION
- change upstage provider displayName from Upstage AI to Upstage
- error out when modelName is provider for huggingFaceDedicated, this is because, we use `endpoint-defined-model `as the placeholder, but do not error out when user provides modelName. This may cause confusion to user, because when you describe the collection, the model returned back is actually `endpoint-defined-model`


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
