### PR TITLE
Fix modelName constraint for huggingFace Dedicated provider

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -149,10 +149,12 @@ public record CreateCollectionCommand(
             Map<String, String> authentication,
             Map<String, Object> parameters) {
           this.provider = provider;
-          // HuggingfaceDedicated does not need user to specify model
-          // use endpoint-defined-model as placeholder
+          // HuggingfaceDedicated does not need user to specify model explicitly
+          // If user specifies modelName other than endpoint-defined-model, will error out
+          // By default, huggingfaceDedicated provider use endpoint-defined-model as placeholder
           if (provider.equals(ProviderConstants.HUGGINGFACE_DEDICATED)) {
-            if (modelName != null) {
+            if (modelName != null
+                && !modelName.equals(ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL)) {
               throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
                   "'modelName' is not needed for provider %s",
                   ProviderConstants.HUGGINGFACE_DEDICATED);

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -156,8 +156,9 @@ public record CreateCollectionCommand(
             if (modelName != null
                 && !modelName.equals(ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL)) {
               throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
-                  "'modelName' is not needed for provider %s",
-                  ProviderConstants.HUGGINGFACE_DEDICATED);
+                  "'modelName' is not needed for provider %s explicitly, only '%s' is accepted",
+                  ProviderConstants.HUGGINGFACE_DEDICATED,
+                  ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL);
             }
             this.modelName = ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL;
           } else {


### PR DESCRIPTION
HuggingfaceDedicated does not need user to specify model explicitly, If user specifies modelName other than `endpoint-defined-model`, will error out. By default, huggingfaceDedicated provider use `endpoint-defined-model` as placeholder

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
