### PR TITLE
Update UpstageAI discontinued model

### DIFF
--- a/src/main/resources/embedding-providers-config.yaml
+++ b/src/main/resources/embedding-providers-config.yaml
@@ -394,5 +394,5 @@ stargate:
           models:
             # NOTE: this is where weirdness exists; model name is prefix on which
             #   either "-query" or "-passage" is appended to get the actual model name
-            - name: solar-1-mini-embedding
+            - name: solar-embedding-1-large
               vector-dimension: 4096


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
According to [UpstageAI docs](https://developers.upstage.ai/docs/apis/embeddings), `solar-1-mini-embedding` will be discontinued. Update the model to new version.  

> Current available models are solar-embedding-1-large-query, solar-embedding-1-large-passage. solar-1-mini-embedding-query and solar-1-mini-embedding-passage are discontinued on June 17th, 2024.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
