### PR TITLE
Fixed #1185: change `ErrorCode` constant to better reflect semantics

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -79,11 +79,11 @@ public enum ErrorCode {
   SHRED_BAD_VECTOR_VALUE("$vector value needs to be array of numbers"),
   SHRED_BAD_VECTORIZE_VALUE("$vectorize search clause needs to be non-blank text value"),
 
+  EXISTING_COLLECTION_DIFFERENT_SETTINGS("Collection already exists"),
+
   INVALID_VECTORIZE_VALUE_TYPE("$vectorize value needs to be text value"),
 
   INVALID_FILTER_EXPRESSION("Invalid filter expression"),
-
-  INVALID_COLLECTION_NAME("Invalid collection name"),
 
   INVALID_JSONAPI_COLLECTION_SCHEMA("Not a valid json api collection schema: "),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -148,9 +148,8 @@ public record CreateCollectionOperation(
     }
     return Uni.createFrom()
         .failure(
-            ErrorCode.INVALID_COLLECTION_NAME.toApiException(
-                "provided collection ('%s') already exists with different collection options",
-                name));
+            ErrorCode.EXISTING_COLLECTION_DIFFERENT_SETTINGS.toApiException(
+                "trying to create Collection ('%s') with different settings", name));
   }
 
   /**

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.*;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.*;
@@ -172,11 +173,12 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .then()
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is(ErrorCode.EXISTING_COLLECTION_DIFFERENT_SETTINGS.name()))
           .body(
               "errors[0].message",
-              containsString("provided collection ('simple_collection') already exists with"))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+              containsString(
+                  "trying to create Collection ('simple_collection') with different settings"));
 
       deleteCollection("simple_collection");
     }
@@ -213,11 +215,12 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .then()
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is(ErrorCode.EXISTING_COLLECTION_DIFFERENT_SETTINGS.name()))
           .body(
               "errors[0].message",
-              containsString("provided collection ('simple_collection') already exists with"))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+              containsString(
+                  "trying to create Collection ('simple_collection') with different settings"));
 
       deleteCollection("simple_collection");
     }
@@ -245,11 +248,13 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is(ErrorCode.EXISTING_COLLECTION_DIFFERENT_SETTINGS.name()))
           .body(
               "errors[0].message",
-              containsString("provided collection ('simple_collection') already exists with"))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+              containsString(
+                  "trying to create Collection ('simple_collection') with different settings"));
+
       // create another vector collection with the same name but different function setting
       given()
           .headers(getHeaders())
@@ -261,11 +266,12 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is(ErrorCode.EXISTING_COLLECTION_DIFFERENT_SETTINGS.name()))
           .body(
               "errors[0].message",
-              containsString("provided collection ('simple_collection') already exists with"))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+              containsString(
+                  "trying to create Collection ('simple_collection') with different settings"));
 
       deleteCollection("simple_collection");
     }


### PR DESCRIPTION
**What this PR does**:

Renames `ErrorCode.INVALID_COLLECTION_NAME` to better reflect its semantics

**Which issue(s) this PR fixes**:
Fixes #1185

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
