### PR TITLE
Fix #1194: change max-collection/max-indexes-available setting (double up)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
@@ -30,7 +30,7 @@ public interface DatabaseLimitsConfig {
    * Default setting for {@link #maxCollections()}}: maximum number of Collections allowed to be
    * created per Database, regardless of whether enough Indexes are available.
    */
-  int DEFAULT_MAX_COLLECTIONS = 5;
+  int DEFAULT_MAX_COLLECTIONS = 10;
 
   /**
    * Default setting for {@link #indexesNeededPerCollection()}: number of SAIs needed to create one
@@ -42,7 +42,7 @@ public interface DatabaseLimitsConfig {
    * Default setting for {@link #indexesAvailablePerDatabase()}: number of SAIs per Database that
    * can be created (and needed for Collection creation)
    */
-  int DEFAULT_INDEXES_AVAILABLE_PER_DATABASE = 50;
+  int DEFAULT_INDEXES_AVAILABLE_PER_DATABASE = 100;
 
   /**
    * @return Defines maximum Collections allowed to be created per Database. Defaults to {@link


### PR DESCRIPTION
**What this PR does**:

Increases 2 default settings for DB config:

1. Max collections allowed from 5 to 10
2. Max indexes available per DB from 50 to 100

**Which issue(s) this PR fixes**:
Fixes #1194

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
