### PR TITLE
Fixes #1203: add Exception class direcly in logged message

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -58,13 +58,7 @@ public final class ThrowableToErrorMapper {
         }
 
         // handle all other exceptions
-        logger.error(
-            String.format(
-                "Unrecognized exception caught, mapped to SERVER_UNHANDLED_ERROR: %s", message),
-            throwable);
-        return ErrorCode.SERVER_UNHANDLED_ERROR
-            .toApiException("root cause: (%s) %s", throwable.getClass().getName(), message)
-            .getCommandResultError(Response.Status.INTERNAL_SERVER_ERROR);
+        return handleUnrecognizedException(throwable, message);
       };
 
   private static CommandResult.Error handleDriverException(
@@ -181,10 +175,17 @@ public final class ThrowableToErrorMapper {
         }
       }
     }
+
     // should not happen
+    return handleUnrecognizedException(throwable, message);
+  }
+
+  private static CommandResult.Error handleUnrecognizedException(
+      Throwable throwable, String message) {
     logger.error(
         String.format(
-            "Unrecognized exception caught, mapped to SERVER_UNHANDLED_ERROR: %s", message),
+            "Unrecognized Exception (%s) caught, mapped to SERVER_UNHANDLED_ERROR: %s",
+            throwable.getClass().getName(), message),
         throwable);
     return ErrorCode.SERVER_UNHANDLED_ERROR
         .toApiException("root cause: (%s) %s", throwable.getClass().getName(), message)


### PR DESCRIPTION
**What this PR does**:

Includes Exception class name in log statement about "unrecognized exception" for simpler troubleshooting (response contains it, log statement not).

**Which issue(s) this PR fixes**:
Fixes #1203

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
