### PR TITLE
Fixes #1207: handle case of unknown "createCollection.options.indexing" fields

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -22,7 +22,7 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
       throws IOException {
     if (deserializer.handledType().toString().endsWith("CreateCollectionCommand$Options")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
-          "No option \"%s\" found as createCollectionCommand option (known options: \"defaultId\", \"indexing\", \"vector\")",
+          "No option \"%s\" exists for `createCollection.options` (valid options: \"defaultId\", \"indexing\", \"vector\")",
           propertyName);
     }
     if (deserializer
@@ -30,9 +30,18 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
         .toString()
         .endsWith("CreateCollectionCommand$Options$IdConfig")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
-          "No option \"%s\" found as createCollectionCommand defaultId option (known options: \"type\")",
+          "Unrecognized field \"%s\" for `createCollection.options.defaultId` (known fields: \"type\")",
           propertyName);
     }
+    if (deserializer
+        .handledType()
+        .toString()
+        .endsWith("CreateCollectionCommand$Options$IndexingConfig")) {
+      throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
+          "Unrecognized field \"%s\" for `createCollection.options.indexing` (known fields: \"allow\", \"deny\")",
+          propertyName);
+    }
+
     // false means if not matched by above handle logic, object mapper will
     // FAIL_ON_UNKNOWN_PROPERTIES.
     return false;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import java.io.IOException;
 
 public class CommandObjectMapperHandler extends DeserializationProblemHandler {
 
@@ -18,9 +17,10 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
       JsonParser p,
       JsonDeserializer<?> deserializer,
       Object beanOrClass,
-      String propertyName)
-      throws IOException {
-    final String typeStr = deserializer.handledType().toString();
+      String propertyName) {
+    // First: handle known/observed CreateCollectionCommand mapping discrepancies
+
+    final String typeStr = (deserializer == null) ? "N/A" : deserializer.handledType().toString();
     if (typeStr.endsWith("CreateCollectionCommand$Options")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
           "No option \"%s\" exists for `createCollection.options` (valid options: \"defaultId\", \"indexing\", \"vector\")",

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -41,6 +41,14 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
           "Unrecognized field \"%s\" for `createCollection.options.indexing` (known fields: \"allow\", \"deny\")",
           propertyName);
     }
+    if (deserializer
+        .handledType()
+        .toString()
+        .endsWith("CreateCollectionCommand$Options$VectorConfig")) {
+      throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
+          "Unrecognized field \"%s\" for `createCollection.options.vector` (known fields: \"dimension\", \"metric\", \"service\")",
+          propertyName);
+    }
 
     // false means if not matched by above handle logic, object mapper will
     // FAIL_ON_UNKNOWN_PROPERTIES.

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -20,31 +20,23 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
       Object beanOrClass,
       String propertyName)
       throws IOException {
-    if (deserializer.handledType().toString().endsWith("CreateCollectionCommand$Options")) {
+    final String typeStr = deserializer.handledType().toString();
+    if (typeStr.endsWith("CreateCollectionCommand$Options")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
           "No option \"%s\" exists for `createCollection.options` (valid options: \"defaultId\", \"indexing\", \"vector\")",
           propertyName);
     }
-    if (deserializer
-        .handledType()
-        .toString()
-        .endsWith("CreateCollectionCommand$Options$IdConfig")) {
+    if (typeStr.endsWith("CreateCollectionCommand$Options$IdConfig")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
           "Unrecognized field \"%s\" for `createCollection.options.defaultId` (known fields: \"type\")",
           propertyName);
     }
-    if (deserializer
-        .handledType()
-        .toString()
-        .endsWith("CreateCollectionCommand$Options$IndexingConfig")) {
+    if (typeStr.endsWith("CreateCollectionCommand$Options$IndexingConfig")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
           "Unrecognized field \"%s\" for `createCollection.options.indexing` (known fields: \"allow\", \"deny\")",
           propertyName);
     }
-    if (deserializer
-        .handledType()
-        .toString()
-        .endsWith("CreateCollectionCommand$Options$VectorConfig")) {
+    if (typeStr.endsWith("CreateCollectionCommand$Options$VectorSearchConfig")) {
       throw ErrorCode.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
           "Unrecognized field \"%s\" for `createCollection.options.vector` (known fields: \"dimension\", \"metric\", \"service\")",
           propertyName);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -20,67 +20,67 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
   class CreateCollection {
     String createNonVectorCollectionJson =
         """
-            {
-              "createCollection": {
-                "name": "simple_collection"
-              }
-            }
-            """;
+                    {
+                      "createCollection": {
+                        "name": "simple_collection"
+                      }
+                    }
+                    """;
 
     String createVectorCollection =
         """
-            {
-              "createCollection": {
-                "name": "simple_collection",
-                "options" : {
-                  "vector" : {
-                  "size" : 5,
-                    "function" : "cosine"
-                  }
-                }
-              }
-            }
-            """;
-    String createVectorCollectionWithOtherSizeSettings =
-        """
-            {
-              "createCollection": {
-                "name": "simple_collection",
-                "options" : {
-                  "vector" : {
-                  "size" : 6,
-                    "function" : "cosine"
-                  }
-                }
-              }
-            }
-            """;
-    String createVectorCollectionWithOtherFunctionSettings =
-        """
-                {
-                  "createCollection": {
-                    "name": "simple_collection",
-                    "options" : {
-                      "vector" : {
-                      "size" : 5,
-                        "function" : "euclidean"
+                    {
+                      "createCollection": {
+                        "name": "simple_collection",
+                        "options" : {
+                          "vector" : {
+                          "size" : 5,
+                            "function" : "cosine"
+                          }
+                        }
                       }
                     }
-                  }
-                }
-                """;
+                    """;
+    String createVectorCollectionWithOtherSizeSettings =
+        """
+                    {
+                      "createCollection": {
+                        "name": "simple_collection",
+                        "options" : {
+                          "vector" : {
+                          "size" : 6,
+                            "function" : "cosine"
+                          }
+                        }
+                      }
+                    }
+                    """;
+    String createVectorCollectionWithOtherFunctionSettings =
+        """
+                    {
+                      "createCollection": {
+                        "name": "simple_collection",
+                        "options" : {
+                          "vector" : {
+                          "size" : 5,
+                            "function" : "euclidean"
+                          }
+                        }
+                      }
+                    }
+                    """;
 
     @Test
     public void happyPath() {
       final String collectionName = "col" + RandomStringUtils.randomNumeric(16);
       String json =
               """
-          {
-            "createCollection": {
-              "name": "%s"
-            }
-          }
-          """
+                      {
+                        "createCollection": {
+                          "name": "%s"
+                        }
+                      }
+                      """
               .formatted(collectionName);
 
       given()
@@ -99,12 +99,12 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
     public void caseSensitive() {
       String json =
               """
-          {
-            "createCollection": {
-              "name": "%s"
-            }
-          }
-          """
+                      {
+                        "createCollection": {
+                          "name": "%s"
+                        }
+                      }
+                      """
               .formatted("testcollection");
 
       given()
@@ -119,12 +119,12 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
 
       json =
               """
-          {
-            "createCollection": {
-              "name": "%s"
-            }
-          }
-          """
+                      {
+                        "createCollection": {
+                          "name": "%s"
+                        }
+                      }
+                      """
               .formatted("testCollection");
 
       given()
@@ -280,21 +280,21 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
     public void happyCreateCollectionWithIndexingAllow() {
       final String createCollectionRequest =
           """
-              {
-                "createCollection": {
-                  "name": "simple_collection_allow_indexing",
-                  "options" : {
-                    "vector" : {
-                      "size" : 5,
-                      "function" : "cosine"
-                    },
-                    "indexing" : {
-                      "allow" : ["field1", "field2", "address.city", "_id", "$vector"]
-                    }
-                  }
-                }
-              }
-              """;
+                      {
+                        "createCollection": {
+                          "name": "simple_collection_allow_indexing",
+                          "options" : {
+                            "vector" : {
+                              "size" : 5,
+                              "function" : "cosine"
+                            },
+                            "indexing" : {
+                              "allow" : ["field1", "field2", "address.city", "_id", "$vector"]
+                            }
+                          }
+                        }
+                      }
+                      """;
 
       // create vector collection with indexing allow option
       given()
@@ -326,21 +326,21 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
       // create vector collection with indexing deny option
       final String createCollectionRequest =
           """
-              {
-                "createCollection": {
-                  "name": "simple_collection_deny_indexing",
-                  "options" : {
-                    "vector" : {
-                      "size" : 5,
-                      "function" : "cosine"
-                    },
-                    "indexing" : {
-                      "deny" : ["field1", "field2", "address.city", "_id"]
-                    }
-                  }
-                }
-              }
-              """;
+                      {
+                        "createCollection": {
+                          "name": "simple_collection_deny_indexing",
+                          "options" : {
+                            "vector" : {
+                              "size" : 5,
+                              "function" : "cosine"
+                            },
+                            "indexing" : {
+                              "deny" : ["field1", "field2", "address.city", "_id"]
+                            }
+                          }
+                        }
+                      }
+                      """;
 
       given()
           .headers(getHeaders())
@@ -446,7 +446,11 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("errors[0].errorCode", is("INVALID_INDEXING_DEFINITION"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }
+  }
 
+  @Nested
+  @Order(2)
+  class CreateCollectionFail {
     @Test
     public void failCreateCollectionWithIndexHavingDuplicates() {
       // create vector collection with error indexing option
@@ -582,7 +586,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
     }
 
     @Test
-    public void failWithInvalidOption() {
+    public void failWithInvalidMainLevelOption() {
       given()
           .headers(getHeaders())
           .contentType(ContentType.JSON)
@@ -603,17 +607,117 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
               startsWith(
-                  "The provided options are invalid: No option \"InDex\" exists for `createCollection.options` (valid options: \"defaultId\", \"indexing\", \"vector\")"))
+                  "The provided options are invalid: No option \"InDex\" exists for `createCollection.options` (valid options: \"defaultId\", \"indexing\", \"vector\")"));
+    }
+
+    @Test
+    public void failWithInvalidIdConfigOption() {
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                                    {
+                                      "createCollection": {
+                                        "name": "collection_with_invalid_idconfig",
+                                        "options" : {
+                                          "defaultId" : {
+                                            "unknown": 3
+                                          }
+                                        }
+                                      }
+                                    }
+                                    """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "The provided options are invalid: Unrecognized field \"unknown\" for `createCollection.options.defaultId`"));
+    }
+
+    @Test
+    public void failWithInvalidIndexingConfigOption() {
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                                    {
+                                      "createCollection": {
+                                        "name": "collection_with_invalid_indexconfig",
+                                        "options" : {
+                                          "indexing" : {
+                                            "unknown": 3
+                                          }
+                                        }
+                                      }
+                                    }
+                                    """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "The provided options are invalid: Unrecognized field \"unknown\" for `createCollection.options.indexing` (known fields"));
+    }
+
+    @Test
+    public void failWithInvalidVectorConfigOption() {
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                                    {
+                                      "createCollection": {
+                                        "name": "collection_with_invalid_vectorconfig",
+                                        "options" : {
+                                          "vector" : {
+                                            "unknown": 3
+                                          }
+                                        }
+                                      }
+                                    }
+                                    """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "The provided options are invalid: Unrecognized field \"unknown\" for `createCollection.options.vector` (known fields"));
     }
   }
 
   @Nested
-  @Order(2)
+  @Order(3)
   class CreateCollectionWithEmbeddingServiceTestModelsAndProviders {
     @Test
     public void happyEmbeddingService() {
@@ -753,7 +857,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
   }
 
   @Nested
-  @Order(3)
+  @Order(4)
   class CreateCollectionWithEmbeddingServiceTestDimension {
     @Test
     public void happyFixDimensionAutoPopulate() {
@@ -1105,7 +1209,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
   }
 
   @Nested
-  @Order(4)
+  @Order(5)
   class CreateCollectionWithEmbeddingServiceTestAuth {
     @Test
     public void happyWithNoneAuth() {
@@ -1358,7 +1462,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
   }
 
   @Nested
-  @Order(5)
+  @Order(6)
   class CreateCollectionWithEmbeddingServiceTestParameters {
     @Test
     public void failWithMissingRequiredProviderParameters() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -606,7 +606,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body(
               "errors[0].message",
               startsWith(
-                  "The provided options are invalid: No option \"InDex\" found as createCollectionCommand option (known options: \"defaultId\", \"indexing\", \"vector\")"))
+                  "The provided options are invalid: No option \"InDex\" exists for `createCollection.options` (valid options: \"defaultId\", \"indexing\", \"vector\")"))
           .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }


### PR DESCRIPTION
**What this PR does**:

Adds explicit handling for another "CreateCollection" options mismatch

**Which issue(s) this PR fixes**:
Fixes #1207

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
