### PR TITLE
Small fix: Add status code in the error message when provider returning non-JSON content

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProviderResponseValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProviderResponseValidation.java
@@ -64,8 +64,8 @@ public class EmbeddingProviderResponseValidation implements ClientResponseFilter
             "Cannot convert the provider's error response to string: " + e.getMessage(), e);
       }
       throw EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE.toApiException(
-          "Expected response Content-Type ('application/json' or 'text/json') from the embedding provider but found '%s'. The response body is: '%s'.",
-          contentType, responseBody);
+          "Expected response Content-Type ('application/json' or 'text/json') from the embedding provider but found '%s'; HTTP Status: %s; The response body is: '%s'.",
+          contentType, responseContext.getStatus(), responseBody);
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingClientTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingClientTestResource.java
@@ -106,6 +106,15 @@ public class EmbeddingClientTestResource implements QuarkusTestResourceLifecycle
 
     wireMockServer.stubFor(
         post(urlEqualTo("/v1/embeddings"))
+            .withRequestBody(matchingJsonPath("$.input", containing("text/plain;charset=UTF-8")))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "text/plain;charset=UTF-8")
+                    .withBody("Not Found")
+                    .withStatus(500)));
+
+    wireMockServer.stubFor(
+        post(urlEqualTo("/v1/embeddings"))
             .withRequestBody(matchingJsonPath("$.input", containing("no json body")))
             .willReturn(aResponse().withHeader("Content-Type", "application/json")));
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderErrorMessageTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderErrorMessageTest.java
@@ -157,7 +157,7 @@ public class EmbeddingProviderErrorMessageTest {
     }
 
     @Test
-    public void testIncorrectContentType() {
+    public void testIncorrectContentTypeXML() {
       Throwable exception =
           new NvidiaEmbeddingProvider(
                   EmbeddingProviderConfigStore.RequestProperties.of(
@@ -181,7 +181,35 @@ public class EmbeddingProviderErrorMessageTest {
               "errorCode", ErrorCode.EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE)
           .hasFieldOrPropertyWithValue(
               "message",
-              "The Embedding Provider returned an unexpected response: Expected response Content-Type ('application/json' or 'text/json') from the embedding provider but found 'application/xml'. The response body is: '<object>list</object>'.");
+              "The Embedding Provider returned an unexpected response: Expected response Content-Type ('application/json' or 'text/json') from the embedding provider but found 'application/xml'; HTTP Status: 200; The response body is: '<object>list</object>'.");
+    }
+
+    @Test
+    public void testIncorrectContentTypePlainText() {
+      Throwable exception =
+          new NvidiaEmbeddingProvider(
+                  EmbeddingProviderConfigStore.RequestProperties.of(
+                      2, 100, 3000, 100, 0.5, Optional.empty(), Optional.empty(), 10),
+                  config.providers().get("nvidia").url(),
+                  "test",
+                  DEFAULT_DIMENSIONS,
+                  null)
+              .vectorize(
+                  1,
+                  List.of("text/plain;charset=UTF-8"),
+                  Optional.of("test"),
+                  EmbeddingProvider.EmbeddingRequestType.INDEX)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitFailure()
+              .getFailure();
+      assertThat(exception.getCause())
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue(
+              "errorCode", ErrorCode.EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE)
+          .hasFieldOrPropertyWithValue(
+              "message",
+              "The Embedding Provider returned an unexpected response: Expected response Content-Type ('application/json' or 'text/json') from the embedding provider but found 'text/plain;charset=UTF-8'; HTTP Status: 500; The response body is: 'Not Found'.");
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add status code in the error message when provider returning non-JSON content

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
