### PR TITLE
Fixes #1210: pre-validate token before passing to Java CQL driver

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
@@ -163,11 +163,15 @@ public class CQLSessionCache {
       }
       return builder.build();
     } else if (ASTRA.equals(databaseConfig.type())) {
+      String token = ((TokenCredentials) cacheKey.credentials()).token();
+      // If we pass empty token (password), would throw IllegalArgumentException so instead:
+      if ((token == null) || token.isBlank()) {
+        throw new UnauthorizedException(
+            "Missing AstraDB token for tenant '" + cacheKey.tenantId + "'");
+      }
       CqlSession cqlSession =
           new TenantAwareCqlSessionBuilder(cacheKey.tenantId())
-              .withAuthCredentials(
-                  TOKEN,
-                  Objects.requireNonNull(((TokenCredentials) cacheKey.credentials()).token()))
+              .withAuthCredentials(TOKEN, token)
               .withLocalDatacenter(operationsConfig.databaseConfig().localDatacenter())
               .withClassLoader(Thread.currentThread().getContextClassLoader())
               .withApplicationName(APPLICATION_NAME)


### PR DESCRIPTION
**What this PR does**:

Adds explicit validation of cached token, to throw better exception instead of accidental `IllegalArgumentException` from CQL Driver (resulting in 500/unmapped response)

**Which issue(s) this PR fixes**:
Fixes #1210

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
