### PR TITLE
Fixes #1200: add handling for invalid JSON requests

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -40,7 +40,10 @@ public enum ErrorCode {
 
   FILTER_FIELDS_LIMIT_VIOLATION("Filter fields size limitation violated"),
 
+  /** note: Only used by EmbeddingGateway */
   INVALID_REQUEST("Request not supported by the data store"),
+
+  INVALID_REQUEST_NOT_JSON("Request invalid, cannot parse as JSON"),
 
   INVALID_INDEXING_DEFINITION("Invalid indexing definition"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -40,7 +40,7 @@ public final class ThrowableToErrorMapper {
           return jae.getCommandResultError(message, Response.Status.OK);
         }
 
-        // General Exception by Jackson
+        // General Exception related to JSON handling, thrown by Jackson
         if (throwable instanceof JacksonException jacksonE) {
           return handleJsonProcessingException(jacksonE, message);
         }
@@ -196,7 +196,7 @@ public final class ThrowableToErrorMapper {
           .getCommandResultError(Response.Status.OK);
     }
 
-    // Will need to add more handling
+    // Will need to add more handling but start with above
     return handleUnrecognizedException(e, message);
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -42,13 +42,16 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
       given()
           .headers(getHeaders())
           .contentType(ContentType.JSON)
-          .body("{wrong}")
+          .body("wrong")
           .when()
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("INVALID_REQUEST_NOT_JSON"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].message", is(not(blankString())));
+          .body("errors[0].message", is("acb"));
+      //         .body("errors[0].message", is(not(blankString())));
     }
 
     @Test
@@ -69,7 +72,9 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("NO_COMMAND_MATCHED"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
               startsWith("No \"unknownCommand\" command found as \"CollectionCommand\""));
@@ -94,6 +99,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, "7_no_leading_number", collectionName)
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("COMMAND_FIELD_INVALID"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
@@ -121,6 +127,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, "7_no_leading_number")
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("COMMAND_FIELD_INVALID"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
@@ -138,6 +145,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("COMMAND_FIELD_INVALID"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -50,8 +50,10 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("INVALID_REQUEST_NOT_JSON"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].message", is("acb"));
-      //         .body("errors[0].message", is(not(blankString())));
+          .body(
+              "errors[0].message",
+              startsWith("Request invalid, cannot parse as JSON: underlying problem:"))
+          .body("errors[0].message", containsString("Unrecognized token 'wrong'"));
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Adds exception mapper for `JsonParseException` to handle low-level JSON parse failures.

**Which issue(s) this PR fixes**:
Fixes #1200

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
