### PR TITLE
Fixes #1199: map `UnrecognizedPropertyException` to INVALID_REQUEST_UNKNOWN_FIELD

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -43,7 +43,7 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
     }
 
     // false means if not matched by above handle logic, object mapper will
-    // FAIL_ON_UNKNOWN_PROPERTIES.
+    // FAIL_ON_UNKNOWN_PROPERTIES -- but may be re-mapped by ThrowableToErrorMapper
     return false;
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -45,6 +45,8 @@ public enum ErrorCode {
 
   INVALID_REQUEST_NOT_JSON("Request invalid, cannot parse as JSON"),
 
+  INVALID_REQUEST_UNKNOWN_FIELD("Request invalid, unrecognized JSON field"),
+
   INVALID_INDEXING_DEFINITION("Invalid indexing definition"),
 
   UNINDEXED_FILTER_PATH("Unindexed filter path"),

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -83,6 +83,35 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
     }
 
     @Test
+    public void unknownCommandField() {
+      String json =
+          """
+              {
+                "findOne": {
+                    "unknown": "value"
+                }
+              }
+              """;
+
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("INVALID_REQUEST_UNKNOWN_FIELD"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].message", startsWith("Request invalid, unrecognized JSON field"))
+          .body("errors[0].message", containsString("\"unknown\" not one of known fields"))
+          .body(
+              "errors[0].message",
+              containsString("(\"filter\", \"options\", \"projection\", \"sort\")"));
+    }
+
+    @Test
     public void invalidNamespaceName() {
       String json =
           """


### PR DESCRIPTION
**What this PR does**:

Adds explicit mapping for `UnrecognizedPropertyException` so it no longer results in `ErrorCode. SERVER_UNHANDLED_ERROR` but gives more useful information and regular HTTP 200 JsonApiException response

**Which issue(s) this PR fixes**:
Fixes #1199

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
