### PR TITLE
Fixes #1205: add explicit handling of `DriverTimeoutException` in ThrowableToErrorMapper

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -164,14 +164,16 @@ public enum ErrorCode {
 
   // Driver failure codes
   /** Error codes related to driver exceptions. */
-  SERVER_NO_NODE_AVAILABLE("No node was available to execute the query"),
-  SERVER_READ_FAILED("Database read failed"),
-  SERVER_TIMEOUT("Driver timeout"),
   SERVER_CLOSED_CONNECTION("Driver request connection is closed"),
+  SERVER_COORDINATOR_FAILURE("Coordinator failed"),
+  /** Driver failure other than timeout. */
+  SERVER_DRIVER_FAILURE("Driver failed"),
+  /** Driver timeout failure. */
+  SERVER_DRIVER_TIMEOUT("Driver timeout"),
+  SERVER_NO_NODE_AVAILABLE("No node was available to execute the query"),
   SERVER_QUERY_CONSISTENCY_FAILURE("Database query consistency failed"),
   SERVER_QUERY_EXECUTION_FAILURE("Database query execution failed"),
-  SERVER_COORDINATOR_FAILURE("Coordinator failed"),
-  SERVER_DRIVER_FAILURE("Driver failed"),
+  SERVER_READ_FAILED("Database read failed"),
   SERVER_UNHANDLED_ERROR("Server failed"),
   INVALID_PARAMETER_VALIDATION_TYPE("Invalid Parameter Validation Type"),
   SERVER_EMBEDDING_GATEWAY_NOT_AVAILABLE("Embedding Gateway is not available"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -171,7 +171,7 @@ public enum ErrorCode {
   SERVER_QUERY_CONSISTENCY_FAILURE("Database query consistency failed"),
   SERVER_QUERY_EXECUTION_FAILURE("Database query execution failed"),
   SERVER_COORDINATOR_FAILURE("Coordinator failed"),
-  SERVER_FAILURE("Driver failed"),
+  SERVER_DRIVER_FAILURE("Driver failed"),
   SERVER_UNHANDLED_ERROR("Server failed"),
   INVALID_PARAMETER_VALIDATION_TYPE("Invalid Parameter Validation Type"),
   SERVER_EMBEDDING_GATEWAY_NOT_AVAILABLE("Embedding Gateway is not available"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -79,7 +79,7 @@ public final class ThrowableToErrorMapper {
     } else if (throwable instanceof CoordinatorException) {
       return handleCoordinatorException((CoordinatorException) throwable, message);
     } else if (throwable instanceof DriverTimeoutException) {
-      return ErrorCode.SERVER_TIMEOUT
+      return ErrorCode.SERVER_DRIVER_TIMEOUT
           .toApiException(message)
           .getCommandResultError(Response.Status.INTERNAL_SERVER_ERROR);
     } else {
@@ -106,9 +106,9 @@ public final class ThrowableToErrorMapper {
       QueryExecutionException throwable, String message) {
     if (throwable instanceof QueryConsistencyException e) {
       if (e instanceof WriteTimeoutException || e instanceof ReadTimeoutException) {
-        return ErrorCode.SERVER_TIMEOUT
-            .toApiException()
-            .getCommandResultError(message, Response.Status.INTERNAL_SERVER_ERROR);
+        return ErrorCode.SERVER_DRIVER_TIMEOUT
+            .toApiException(message)
+            .getCommandResultError(Response.Status.INTERNAL_SERVER_ERROR);
       } else if (e instanceof ReadFailureException) {
         return ErrorCode.SERVER_READ_FAILED
             .toApiException("root cause: (%s) %s", e.getClass().getName(), message)
@@ -182,7 +182,7 @@ public final class ThrowableToErrorMapper {
               .getCommandResultError(message, Response.Status.INTERNAL_SERVER_ERROR);
         } else if (error instanceof DriverTimeoutException) {
           // [data-api#1205] Need to map DriverTimeoutException as well
-          return ErrorCode.SERVER_DRIVER_FAILURE
+          return ErrorCode.SERVER_DRIVER_TIMEOUT
               .toApiException(message)
               .getCommandResultError(Response.Status.INTERNAL_SERVER_ERROR);
         }


### PR DESCRIPTION
**What this PR does**:

Adds missing handling for `DriverTimeoutException` to remove one more "unmapped" server error

**Which issue(s) this PR fixes**:
Fixes #1205

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
