### PR TITLE
add credential object

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/gateway/EmbeddingGatewayClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/gateway/EmbeddingGatewayClient.java
@@ -77,7 +77,7 @@ public class EmbeddingGatewayClient extends EmbeddingProvider {
    * Vectorize the given list of texts
    *
    * @param texts List of texts to be vectorized
-   * @param apiKeyOverride API key sent as header
+   * @param credentials Credentials required for the provider
    * @param embeddingRequestType Type of request (INDEX or SEARCH)
    * @return
    */
@@ -85,7 +85,7 @@ public class EmbeddingGatewayClient extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     Map<String, EmbeddingGateway.ProviderEmbedRequest.EmbeddingRequest.ParameterValue>
         grpcVectorizeServiceParameter = new HashMap<>();
@@ -136,8 +136,8 @@ public class EmbeddingGatewayClient extends EmbeddingProvider {
             .setProviderName(provider)
             .setTenantId(tenant.orElse(DEFAULT_TENANT_ID));
     builder.putAuthTokens(DATA_API_KEY, authToken.orElse(""));
-    if (apiKeyOverride.isPresent()) {
-      builder.putAuthTokens(API_KEY, apiKeyOverride.orElse(apiKey));
+    if (credentials.apiKey().isPresent()) {
+      builder.putAuthTokens(API_KEY, credentials.apiKey().orElse(apiKey));
     }
     if (authentication != null) {
       builder.putAllAuthTokens(authentication);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AzureOpenAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AzureOpenAIEmbeddingProvider.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -113,14 +112,14 @@ public class AzureOpenAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     String[] textArray = new String[texts.size()];
     EmbeddingRequest request = new EmbeddingRequest(texts.toArray(textArray), modelName, dimension);
 
     // NOTE: NO "Bearer " prefix with API key for Azure OpenAI
     Uni<EmbeddingResponse> response =
-        applyRetry(openAIEmbeddingProviderClient.embed(apiKeyOverride.get(), request));
+        applyRetry(openAIEmbeddingProviderClient.embed(credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/CohereEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/CohereEmbeddingProvider.java
@@ -16,7 +16,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -125,7 +124,7 @@ public class CohereEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     String[] textArray = new String[texts.size()];
     String input_type =
@@ -134,7 +133,8 @@ public class CohereEmbeddingProvider extends EmbeddingProvider {
         new EmbeddingRequest(texts.toArray(textArray), modelName, input_type);
 
     Uni<EmbeddingResponse> response =
-        applyRetry(cohereEmbeddingProviderClient.embed("Bearer " + apiKeyOverride.get(), request));
+        applyRetry(
+            cohereEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -70,16 +70,25 @@ public abstract class EmbeddingProvider {
    * Vectorizes the given list of texts and returns the embeddings.
    *
    * @param texts List of texts to be vectorized
-   * @param apiKeyOverride Optional API key to be used for this request. If not provided, the
-   *     default API key will be used.
+   * @param credentials Credentials required for the provider
    * @param embeddingRequestType Type of request (INDEX or SEARCH)
    * @return VectorResponse
    */
   public abstract Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType);
+
+  /**
+   * Record to hold the credentials required for the provider
+   *
+   * @param apiKey Optional API key for the all providers other than AWS Bedrock. If not provided,
+   *     the default API key will be used.
+   * @param accessKeyId AWS access key id
+   * @param secretAccessKey AWS secret access key
+   */
+  public record Credentials(Optional<String> apiKey, String accessKeyId, String secretAccessKey) {}
 
   /**
    * returns the maximum batch size supported by the provider

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceDedicatedEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceDedicatedEmbeddingProvider.java
@@ -99,7 +99,7 @@ public class HuggingFaceDedicatedEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     String[] textArray = new String[texts.size()];
     EmbeddingRequest request = new EmbeddingRequest(texts.toArray(textArray));
@@ -107,7 +107,7 @@ public class HuggingFaceDedicatedEmbeddingProvider extends EmbeddingProvider {
     Uni<EmbeddingResponse> response =
         applyRetry(
             huggingFaceDedicatedEmbeddingProviderClient.embed(
-                "Bearer " + apiKeyOverride.get(), request));
+                "Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceEmbeddingProvider.java
@@ -16,7 +16,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -93,13 +92,13 @@ public class HuggingFaceEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     EmbeddingRequest request = new EmbeddingRequest(texts, new EmbeddingRequest.Options(true));
 
     return applyRetry(
             huggingFaceEmbeddingProviderClient.embed(
-                "Bearer " + apiKeyOverride.get(), modelName, request))
+                "Bearer " + credentials.apiKey().get(), modelName, request))
         .onItem()
         .transform(
             resp -> {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/JinaAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/JinaAIEmbeddingProvider.java
@@ -97,12 +97,13 @@ public class JinaAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     EmbeddingRequest request = new EmbeddingRequest(texts, modelName);
 
     Uni<EmbeddingResponse> response =
-        applyRetry(jinaAIEmbeddingProviderClient.embed("Bearer " + apiKeyOverride.get(), request));
+        applyRetry(
+            jinaAIEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -9,7 +9,6 @@ import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -44,7 +43,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
    * call and the size of the input texts.
    *
    * @param texts the list of texts to vectorize.
-   * @param apiKeyOverride optional API key to override any default authentication mechanism.
+   * @param credentials the credentials to use for the vectorization call.
    * @param embeddingRequestType the type of embedding request, influencing how texts are processed.
    * @return a {@link Uni} that will provide the list of vectorized texts, as arrays of floats.
    */
@@ -52,7 +51,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     // String bytes metrics for vectorize
     DistributionSummary ds =
@@ -79,7 +78,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
             batch -> {
               // call vectorize by the batch id
               return embeddingProvider.vectorize(
-                  batch.getLeft(), batch.getRight(), apiKeyOverride, embeddingRequestType);
+                  batch.getLeft(), batch.getRight(), credentials, embeddingRequestType);
             })
         .merge()
         .collect()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MistralEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MistralEmbeddingProvider.java
@@ -104,12 +104,13 @@ public class MistralEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     EmbeddingRequest request = new EmbeddingRequest(texts, modelName, "float");
 
     Uni<EmbeddingResponse> response =
-        applyRetry(mistralEmbeddingProviderClient.embed("Bearer " + apiKeyOverride.get(), request));
+        applyRetry(
+            mistralEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -105,7 +104,7 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     String[] textArray = new String[texts.size()];
     String input_type = embeddingRequestType == EmbeddingRequestType.INDEX ? PASSAGE : QUERY;
@@ -114,7 +113,8 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
         new EmbeddingRequest(texts.toArray(textArray), modelName, input_type);
 
     Uni<EmbeddingResponse> response =
-        applyRetry(nvidiaEmbeddingProviderClient.embed("Bearer " + apiKeyOverride.get(), request));
+        applyRetry(
+            nvidiaEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAIEmbeddingProvider.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -114,7 +113,7 @@ public class OpenAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     String[] textArray = new String[texts.size()];
     EmbeddingRequest request = new EmbeddingRequest(texts.toArray(textArray), modelName, dimension);
@@ -124,7 +123,7 @@ public class OpenAIEmbeddingProvider extends EmbeddingProvider {
     Uni<EmbeddingResponse> response =
         applyRetry(
             openAIEmbeddingProviderClient.embed(
-                "Bearer " + apiKeyOverride.get(), organizationId, projectId, request));
+                "Bearer " + credentials.apiKey().get(), organizationId, projectId, request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingProvider.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -120,7 +119,7 @@ public class UpstageAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     // Oddity: Implementation does not support batching, so we only accept "batches"
     // of 1 String, fail for others
@@ -140,7 +139,8 @@ public class UpstageAIEmbeddingProvider extends EmbeddingProvider {
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            upstageAIEmbeddingProviderClient.embed("Bearer " + apiKeyOverride.get(), request));
+            upstageAIEmbeddingProviderClient.embed(
+                "Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingProvider.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
@@ -153,7 +152,7 @@ public class VertexAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     EmbeddingRequest request =
         new EmbeddingRequest(texts.stream().map(t -> new EmbeddingRequest.Content(t)).toList());
@@ -161,7 +160,7 @@ public class VertexAIEmbeddingProvider extends EmbeddingProvider {
     Uni<EmbeddingResponse> serviceResponse =
         applyRetry(
             vertexAIEmbeddingProviderClient.embed(
-                "Bearer " + apiKeyOverride.get(), modelName, request));
+                "Bearer " + credentials.apiKey().get(), modelName, request));
 
     return serviceResponse
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -109,7 +108,7 @@ public class VoyageAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     final String inputType =
         (embeddingRequestType == EmbeddingRequestType.SEARCH) ? requestTypeQuery : requestTypeIndex;
@@ -119,7 +118,7 @@ public class VoyageAIEmbeddingProvider extends EmbeddingProvider {
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            voyageAIEmbeddingProviderClient.embed("Bearer " + apiKeyOverride.get(), request));
+            voyageAIEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/test/CustomITEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/test/CustomITEmbeddingProvider.java
@@ -6,7 +6,6 @@ import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * This is a test implementation of the EmbeddingProvider interface. It is used for
@@ -62,11 +61,11 @@ public class CustomITEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Optional<String> apiKeyOverride,
+      Credentials credentials,
       EmbeddingRequestType embeddingRequestType) {
     List<float[]> response = new ArrayList<>(texts.size());
     if (texts.size() == 0) return Uni.createFrom().item(Response.of(batchId, response));
-    if (!apiKeyOverride.isPresent() || !apiKeyOverride.get().equals(TEST_API_KEY))
+    if (!credentials.apiKey().isPresent() || !credentials.apiKey().get().equals(TEST_API_KEY))
       return Uni.createFrom().failure(new RuntimeException("Invalid API Key"));
     for (String text : texts) {
       if (dimension == 5) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
1) Change the provider to accept a Credential object instead of Optional <String> for api key. The object will have 3 elements apiKey, access key and access Id.
2) All current provider implementation to use api key from credential object

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
