### PR TITLE
Fix base64 encoding for 'cassandra' in docstring

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -44,7 +44,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       `Cassandra:Base64(username):Base64(password)`. For example,
                       assuming a username of `cassandra` and password of
                       `cassandra` the `Token` header would be set to
-                      `Cassandra:Y2Fzc2FuZHJhCg==:Y2Fzc2FuZHJhCg==`.
+                      `Cassandra:Y2Fzc2FuZHJh:Y2Fzc2FuZHJh`.
                       """),
             },
 


### PR DESCRIPTION
**What this PR does**:

The docstring that ends up in the Swagger UI provides the default token for HCD and similar which corresponds to the `cassandra/cassandra` default authentication. However, that token mistakenly base64-encodes an ending newline, resulting in the "Authorize" modal suggesting a token that in fact does not work.

This PR fixes that and changes the default token to the one corresponding to the `cassandra/cassandra` default auth.

**Checklist**

(I think none of the following apply in this case)

- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
