### PR TITLE
Fixes #1236: add valid Command names in fail message

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -65,6 +65,7 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
     final String baseCommand =
         rawCommandClassString.substring(rawCommandClassString.lastIndexOf('.') + 1);
     throw ErrorCode.COMMAND_UNKNOWN.toApiException(
-        "\"%s\" not one of \"%s\"s", subTypeId, baseCommand);
+        "\"%s\" not one of \"%s\"s: known commands are %s",
+        subTypeId, baseCommand, idResolver.getDescForKnownTypeIds());
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -80,7 +80,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .body(
               "errors[0].message",
               startsWith(
-                  "Provided command unknown: \"unknownCommand\" not one of \"CollectionCommand\"s, known commands are [countDocuments,"));
+                  "Provided command unknown: \"unknownCommand\" not one of \"CollectionCommand\"s: known commands are [countDocuments,"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -80,7 +80,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .body(
               "errors[0].message",
               startsWith(
-                  "Provided command unknown: \"unknownCommand\" not one of \"CollectionCommand\"s"));
+                  "Provided command unknown: \"unknownCommand\" not one of \"CollectionCommand\"s, known commands are [countDocuments,"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
@@ -73,11 +73,11 @@ class GeneralResourceIntegrationTest extends AbstractNamespaceIntegrationTestBas
           .post(GeneralResource.BASE_PATH)
           .then()
           .statusCode(200)
+          .body("errors[0].errorCode", is("COMMAND_UNKNOWN"))
           .body(
               "errors[0].message",
               startsWith(
-                  "Provided command unknown: \"unknownCommand\" not one of \"GeneralCommand\"s"))
-          .body("errors[0].errorCode", is("COMMAND_UNKNOWN"));
+                  "Provided command unknown: \"unknownCommand\" not one of \"GeneralCommand\"s: known commands are [createNamespace,"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
@@ -70,7 +70,7 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .body(
               "errors[0].message",
               startsWith(
-                  "Provided command unknown: \"unknownCommand\" not one of \"NamespaceCommand\"s"));
+                  "Provided command unknown: \"unknownCommand\" not one of \"NamespaceCommand\"s: known commands are [createCollection"));
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Follow-up to #1232: adds Lists of valid Command ids in failure messages

**Which issue(s) this PR fixes**:
Fixes #1236

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
