### PR TITLE
Fixes #1238: convert internal-only `ErrorCode`s into `ErrorCode.SERVER_INTERNAL_ERROR`

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
@@ -194,11 +194,9 @@ public record CommandResult(
    * @return
    */
   public RestResponse map() {
-    if (null != this.errors() && !this.errors().isEmpty()) {
+    if (null != this.errors()) {
       final Optional<Error> first =
-          this.errors().stream()
-              .filter(error -> error.status().getStatusCode() != Response.Status.OK.getStatusCode())
-              .findFirst();
+          this.errors().stream().filter(error -> error.status() != Response.Status.OK).findFirst();
       if (first.isPresent()) {
         return RestResponse.ResponseBuilder.create(first.get().status(), this).build();
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/NoOptionsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/NoOptionsCommand.java
@@ -20,10 +20,6 @@ public interface NoOptionsCommand {
     if (value.isNull() || (value.isObject() && value.isEmpty())) {
       return;
     }
-    final String msg =
-        String.format(
-            "%s: %s",
-            ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage(), getClass().getSimpleName());
-    throw new JsonApiException(ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS, msg);
+    throw ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.toApiException("`%s`", getClass().getSimpleName());
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpression.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpression.java
@@ -1,7 +1,6 @@
 package io.stargate.sgv2.jsonapi.api.model.command.clause.filter;
 
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import jakarta.validation.Valid;
@@ -139,9 +138,8 @@ public class ComparisonExpression {
     if (value instanceof UUID || value instanceof ObjectId) {
       return new JsonLiteral<>(value.toString(), JsonType.STRING);
     }
-    throw new JsonApiException(
-        ErrorCode.FILTER_UNRESOLVABLE,
-        String.format("Unsupported filter value type %s", value.getClass()));
+    throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+        "Unsupported filter value type `%s`", value.getClass().getName());
   }
 
   public List<FilterOperation<?>> match(

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperator.java
@@ -2,7 +2,6 @@ package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -106,9 +105,8 @@ public enum UpdateOperator {
   }
 
   public UpdateOperation resolveOperation(ObjectNode arguments) {
-    throw new JsonApiException(
-        ErrorCode.UNSUPPORTED_UPDATE_OPERATION,
-        "Unsupported update operator '%s'".formatted(operator));
+    throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION.toApiException(
+        "Unsupported update operator '%s'", operator);
   }
 
   private static Map<String, UpdateOperator> operatorMap = new HashMap<>();

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/UpdateClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/UpdateClauseDeserializer.java
@@ -38,15 +38,13 @@ public class UpdateClauseDeserializer extends StdDeserializer<UpdateClause> {
       Map.Entry<String, JsonNode> entry = fieldIter.next();
       final String operName = entry.getKey();
       if (!operName.startsWith("$")) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION,
-            "Invalid update operator '%s' (must start with '$')".formatted(operName));
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION.toApiException(
+            "Invalid update operator '%s' (must start with '$')", operName);
       }
       UpdateOperator oper = UpdateOperator.getUpdateOperator(operName);
       if (oper == null) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION,
-            "Unrecognized update operator '%s'".formatted(operName));
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION.toApiException(
+            "Unrecognized update operator '%s'", operName);
       }
       JsonNode operationArg = entry.getValue();
       if (!operationArg.isObject()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -148,7 +148,6 @@ public enum ErrorCode {
   INVALID_ID_TYPE("Invalid Id type"),
   INVALID_QUERY("Invalid query"),
   NO_INDEX_ERROR("Faulty collection (missing indexes). Recommend re-creating the collection"),
-  UNSUPPORTED_CQL_QUERY_TYPE("Unsupported cql query type"),
   MISSING_VECTOR_VALUE("Missing the vector value when building cql"),
 
   // Driver failure codes

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -32,8 +32,6 @@ public enum ErrorCode {
   EMBEDDING_PROVIDER_TIMEOUT("The Embedding Provider timed out"),
   EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE("The Embedding Provider returned an unexpected response"),
 
-  FILTER_UNRESOLVABLE("Unable to resolve the filter"),
-
   FILTER_MULTIPLE_ID_FILTER(
       "Cannot have more than one _id equals filter clause: use $in operator instead"),
 
@@ -65,8 +63,6 @@ public enum ErrorCode {
   SHRED_BAD_DOCUMENT_VECTORIZE_TYPE("Bad $vectorize document type to shred "),
 
   SHRED_BAD_DOCID_EMPTY_STRING("Bad value for '_id' property: empty String not allowed"),
-
-  SHRED_INTERNAL_NO_PATH("Internal: path being built does not point to a property or element"),
 
   SHRED_UNRECOGNIZED_NODE_TYPE("Unrecognized JSON node type in input document"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -150,7 +150,6 @@ public enum ErrorCode {
   NO_INDEX_ERROR("Faulty collection (missing indexes). Recommend re-creating the collection"),
   UNSUPPORTED_CQL_QUERY_TYPE("Unsupported cql query type"),
   MISSING_VECTOR_VALUE("Missing the vector value when building cql"),
-  INVALID_LOGIC_OPERATOR("Invalid logical operator"),
 
   // Driver failure codes
   /** Error codes related to driver exceptions. */

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -64,18 +64,15 @@ public enum ErrorCode {
 
   SHRED_BAD_DOCID_EMPTY_STRING("Bad value for '_id' property: empty String not allowed"),
 
-  SHRED_UNRECOGNIZED_NODE_TYPE("Unrecognized JSON node type in input document"),
-
-  SHRED_DOC_LIMIT_VIOLATION("Document size limitation violated"),
-
-  SHRED_DOC_KEY_NAME_VIOLATION("Document field name invalid"),
-
   SHRED_BAD_EJSON_VALUE("Bad JSON Extension value"),
 
   SHRED_BAD_VECTOR_SIZE("$vector value can't be empty"),
 
   SHRED_BAD_VECTOR_VALUE("$vector value needs to be array of numbers"),
   SHRED_BAD_VECTORIZE_VALUE("$vectorize search clause needs to be non-blank text value"),
+
+  SHRED_DOC_KEY_NAME_VIOLATION("Document field name invalid"),
+  SHRED_DOC_LIMIT_VIOLATION("Document size limitation violated"),
 
   EXISTING_COLLECTION_DIFFERENT_SETTINGS("Collection already exists"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -98,8 +98,6 @@ public enum ErrorCode {
 
   INVALID_USAGE_OF_VECTORIZE("`$vectorize` and `$vector` can't be used together"),
 
-  UNSUPPORTED_OPERATION("Unsupported operation class"),
-
   UNSUPPORTED_PROJECTION_PARAM("Unsupported projection parameter"),
 
   UNSUPPORTED_UPDATE_DATA_TYPE("Unsupported update data type"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
@@ -39,8 +39,7 @@ public class ConstraintViolationExceptionMapper {
         violations.stream().map(ConstraintViolationExceptionMapper::getError).distinct().toList();
 
     // return result
-    CommandResult commandResult = new CommandResult(errors);
-    return RestResponse.ok(commandResult);
+    return new CommandResult(errors).map();
   }
 
   private static CommandResult.Error getError(ConstraintViolation<?> violation) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/GenericExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/GenericExceptionMapper.java
@@ -15,6 +15,6 @@ public class GenericExceptionMapper {
   @ServerExceptionMapper({Exception.class, MismatchedInputException.class})
   public RestResponse<CommandResult> genericExceptionMapper(Throwable e) {
     CommandResult commandResult = new ThrowableCommandResultSupplier(e).get();
-    return RestResponse.ok(commandResult);
+    return commandResult.map();
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cql/ExpressionUtils.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cql/ExpressionUtils.java
@@ -15,11 +15,10 @@
  */
 package io.stargate.sgv2.jsonapi.service.cql;
 
-import static io.stargate.sgv2.jsonapi.exception.ErrorCode.INVALID_LOGIC_OPERATOR;
-
 import com.bpodgursky.jbool_expressions.And;
 import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Or;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import java.util.List;
 
 /**
@@ -61,7 +60,9 @@ public class ExpressionUtils<K> {
       case "$or" -> {
         return orOf(expressions);
       }
-      default -> throw INVALID_LOGIC_OPERATOR.toApiException();
+      default ->
+          throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+              "Invalid logical operator '%s'", logicOperator);
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cql/builder/QueryBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cql/builder/QueryBuilder.java
@@ -114,7 +114,8 @@ public class QueryBuilder {
     if (isSelect) {
       return selectQuery();
     }
-    throw ErrorCode.UNSUPPORTED_CQL_QUERY_TYPE.toApiException();
+    throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+        "Unsupported cql query type in QueryBuilder (isSelect=false)");
   }
 
   private Query selectQuery() {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -4,7 +4,7 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.data.TupleValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -129,7 +129,7 @@ public interface ReadOperation extends Operation {
                           getDocumentId(row.getTupleValue(0)), // key
                           row.getUuid(1), // tx_id
                           root);
-                } catch (JsonProcessingException e) {
+                } catch (JacksonException e) {
                   throw parsingExceptionToApiException(e);
                 }
                 documents.add(document);
@@ -496,7 +496,7 @@ public interface ReadOperation extends Operation {
     public JsonNode get() {
       try {
         return objectMapper.readTree(docJsonValue);
-      } catch (JsonProcessingException e) {
+      } catch (JacksonException e) {
         // These are data stored in the DB so the error should never happen
         throw parsingExceptionToApiException(e);
       }
@@ -506,10 +506,7 @@ public interface ReadOperation extends Operation {
   /**
    * Helper method to handle details of exactly how much information to include in error message.
    */
-  static JsonApiException parsingExceptionToApiException(JsonProcessingException e) {
-    return new JsonApiException(
-        ErrorCode.DOCUMENT_UNPARSEABLE,
-        String.format(
-            "%s: %s", ErrorCode.DOCUMENT_UNPARSEABLE.getMessage(), e.getOriginalMessage()));
+  static JsonApiException parsingExceptionToApiException(JacksonException e) {
+    return ErrorCode.DOCUMENT_UNPARSEABLE.toApiException("%s", e.getOriginalMessage());
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -381,9 +381,8 @@ public record FindOperation(
       }
       default -> {
         JsonApiException failure =
-            new JsonApiException(
-                ErrorCode.UNSUPPORTED_OPERATION,
-                "Unsupported find operation read type " + readType);
+            ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+                "Unsupported find operation read type `%s`", readType);
         return Uni.createFrom().failure(failure);
       }
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -308,14 +307,8 @@ class ProjectionLayer {
   }
 
   void reportPathConflict(String fullPath1, String fullPath2) {
-    throw new JsonApiException(
-        ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-        ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-            + ": projection path conflict between '"
-            + fullPath1
-            + "' and '"
-            + fullPath2
-            + "'");
+    throw ErrorCode.UNSUPPORTED_PROJECTION_PARAM.toApiException(
+        "projection path conflict between '%s' and '%s'", fullPath1, fullPath2);
   }
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterMatchRules.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterMatchRules.java
@@ -6,7 +6,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.LogicalExpression;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import java.util.ArrayList;
@@ -69,8 +68,7 @@ public class FilterMatchRules<T extends Command & Filterable> {
         .findFirst() // unwraps the Optional from the resolver function.
         .orElseThrow(
             () ->
-                new JsonApiException(
-                    ErrorCode.FILTER_UNRESOLVABLE,
+                ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
                     "Filter type not supported, unable to resolve to a filtering strategy"));
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
@@ -2,7 +2,6 @@ package io.stargate.sgv2.jsonapi.service.shredding;
 
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.Objects;
 
 /**
@@ -146,7 +145,8 @@ public final class JsonPath implements Comparable<JsonPath> {
     public Builder nestedArrayBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {
-        throw new JsonApiException(ErrorCode.SHRED_INTERNAL_NO_PATH);
+        throw ErrorCode.SHRED_INTERNAL_NO_PATH.toApiException(
+            "Shredder path being built does not point to a property or element");
       }
       return new Builder(childPath, true);
     }
@@ -155,7 +155,8 @@ public final class JsonPath implements Comparable<JsonPath> {
     public Builder nestedObjectBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {
-        throw new JsonApiException(ErrorCode.SHRED_INTERNAL_NO_PATH);
+        throw ErrorCode.SHRED_INTERNAL_NO_PATH.toApiException(
+            "Shredder path being built does not point to a property or element");
       }
       return new Builder(childPath, false);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
@@ -145,8 +145,9 @@ public final class JsonPath implements Comparable<JsonPath> {
     public Builder nestedArrayBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {
-        throw ErrorCode.SHRED_INTERNAL_NO_PATH.toApiException(
-            "Shredder path being built does not point to a property or element");
+        throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+            "Shredder path being built does not point to a property or element (basePath: '%s')",
+            basePath);
       }
       return new Builder(childPath, true);
     }
@@ -155,8 +156,9 @@ public final class JsonPath implements Comparable<JsonPath> {
     public Builder nestedObjectBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {
-        throw ErrorCode.SHRED_INTERNAL_NO_PATH.toApiException(
-            "Shredder path being built does not point to a property or element");
+        throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+            "Shredder path being built does not point to a property or element (basePath: '%s')",
+            basePath);
       }
       return new Builder(childPath, false);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -291,7 +291,8 @@ public class Shredder {
       } else if (value.isNull()) {
         callback.shredNull(path);
       } else {
-        throw ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE.toApiException(value.getNodeType().toString());
+        throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+            "Unsupported `JsonNodeType` in input document, `%s`", value.getNodeType());
       }
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
@@ -45,12 +45,9 @@ public class DocValueHasher {
       case OBJECT -> objectHash((ObjectNode) value);
       case STRING -> stringValue(value.textValue()).hash();
 
-      default -> // case BINARY, MISSING, POJO
-          throw new JsonApiException(
-              ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE,
-              String.format(
-                  "%s: %s",
-                  ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE.getMessage(), value.getNodeType()));
+      default -> // case BINARY, MISSING, POJO -- should these ever occur?
+          throw ErrorCode.SERVER_INTERNAL_ERROR.toApiException(
+              "Unsupported `JsonNodeType` in input document, `%s`", value.getNodeType());
     };
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -278,7 +278,7 @@ class ObjectMapperConfigurationTest {
       assertThat(e)
           .isInstanceOf(JsonMappingException.class)
           .hasMessageStartingWith(
-              ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": InsertOneCommand");
+              ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": `InsertOneCommand`");
     }
 
     @Test
@@ -367,7 +367,7 @@ class ObjectMapperConfigurationTest {
       assertThat(e)
           .isInstanceOf(JsonMappingException.class)
           .hasMessageStartingWith(
-              ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": DeleteOneCommand");
+              ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": `DeleteOneCommand`");
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
@@ -147,9 +147,9 @@ public class DeleteOneIntegrationTest extends AbstractCollectionIntegrationTestB
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", is("Command accepts no options: DeleteOneCommand"))
           .body("errors[0].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].message", is("Command accepts no options: `DeleteOneCommand`"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -381,9 +381,9 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", startsWith("Command accepts no options: InsertOneCommand"))
           .body("errors[0].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].message", startsWith("Command accepts no options: `InsertOneCommand`"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
@@ -256,7 +256,8 @@ public class DocumentUpdaterTest {
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION)
-          .hasMessageStartingWith("Invalid update operator 'location' (must start with '$')");
+          .hasMessageStartingWith(
+              "Unsupported update operation: Invalid update operator 'location' (must start with '$')");
     }
 
     @Test
@@ -274,7 +275,8 @@ public class DocumentUpdaterTest {
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION)
-          .hasMessageStartingWith("Unsupported update operator '$pullAll'");
+          .hasMessageStartingWith(
+              "Unsupported update operation: Unsupported update operator '$pullAll'");
     }
 
     /** Test for ensuring it is not legal to "$set" document id (_id) */


### PR DESCRIPTION
**What this PR does**:

Removes redundant "internal-only" `ErrorCode`s with `SERVER_INTERNAL_ERROR`

**Which issue(s) this PR fixes**:
Fixes #1238

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
