### PR TITLE
Fix a problem that would prevent Quarkus 3.12 upgrade (due to change in Smallrye lib)

### DIFF
--- a/src/main/offline/io/stargate/sgv2/jsonapi/service/cqldriver/sstablewriter/FileWriterSession.java
+++ b/src/main/offline/io/stargate/sgv2/jsonapi/service/cqldriver/sstablewriter/FileWriterSession.java
@@ -22,7 +22,6 @@ import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
 import com.datastax.oss.protocol.internal.response.result.RawType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.smallrye.faulttolerance.core.util.CompletionStages;
 import io.stargate.sgv2.jsonapi.api.request.FileWriterParams;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
 import java.io.File;
@@ -270,7 +269,7 @@ public class FileWriterSession implements CqlSession {
       throw new RuntimeException(e);
     }
     cqlSessionCache.removeSession(this.cacheKey);
-    return CompletionStages.completedStage(null);
+    return CompletableFuture.completedFuture(null);
   }
 
   @NonNull

--- a/src/main/offline/io/stargate/sgv2/jsonapi/service/cqldriver/sstablewriter/FileWriterSession.java
+++ b/src/main/offline/io/stargate/sgv2/jsonapi/service/cqldriver/sstablewriter/FileWriterSession.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.cassandra.config.Config;
@@ -213,7 +214,7 @@ public class FileWriterSession implements CqlSession {
       this.cqlsSSTableWriter.addRow(boundValues);
       buffers.add(TypeCodecs.BOOLEAN.encode(Boolean.TRUE, ProtocolVersion.DEFAULT));
       CompletionStage<AsyncResultSet> resultSetCompletionStage =
-          CompletionStages.completedStage(
+          CompletableFuture.completedFuture(
               new FileWriterAsyncResultSet(
                   responseColumnDefinitions,
                   new FileWriterResponseRow(responseColumnDefinitions, 0, buffers)));


### PR DESCRIPTION
**What this PR does**:

Fixes use of method call to be dropped by SmallRye, as part of Quarkus 3.12 upgrade

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
