### PR TITLE
Fix #1241: lower default for Azure OpenAI model "text-embedding-3-large" to observed legal value

### DIFF
--- a/src/main/resources/embedding-providers-config.yaml
+++ b/src/main/resources/embedding-providers-config.yaml
@@ -99,7 +99,10 @@ stargate:
                 - name: vectorDimension
                   type: number
                   required: true
-                  default-value: 3072
+                  # https://github.com/stargate/data-api/issues/1241: Docs claim 3072 is max,
+                  # but using values above 1536 does not seem to work. So at least default
+                  # to what seems like a legal value (but leave max higher in case issue is fixed).
+                  default-value: 1536
                   validation:
                     numeric-range: [256, 3072]
                   help: "Vector dimension to use in the database and when calling Azure OpenAI."


### PR DESCRIPTION
**What this PR does**:

Changes default dimension for Azure OpenAI model `text-embedding-3-large` to a value that is observed to work, from higher one alleged to work (but doesn't). Leave max value unchanged to let users override for know, in case issue gets resolved.

**Which issue(s) this PR fixes**:
Fixes #1241

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
