### PR TITLE
Increase mem limit of single-HCD set up from 2 to 3 gigs; DSEx3 to 2.5 gigs per node

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -19,6 +19,26 @@ You can control the platform using the `-Dquarkus.docker.buildx.platform=linux/a
 
 Follow instructions under the [Script options](#script-options) section to use the locally built image.
 
+### Resource requirements
+
+To run different set-ups, Docker runtime environment (like Docker Desktop) requires following resources:
+
+#### Memory: HCD (docker-compose-hcd.yml)
+
+HCD cluster only runs a single HCD node, requiring 3 gigabytes of memory.
+Data API requires additional 2 gigabyte of memory, if run (`-d` NOT specified):
+
+* 3 GB if running only HCD
+* 5 GB if running both HCD and Data API
+
+#### Memory: DSE-6.9 (docker-compose.yml)
+
+DSE-6.9 cluster runs 3 nodes, each requiring 2.5 gigabytes of memory.
+Data API requires additional 2 gigabyte of memory, if run (`-d` NOT specified):
+
+* 7.5 GB if running only DSE-6.9
+* 9.6 GB if running both DSE-6.9 and Data API
+
 ## Data API with HCD or DSE-6.9 cluster
 
 You can start a simple configuration with HCD with the following command:

--- a/docker-compose/docker-compose-hcd.yml
+++ b/docker-compose/docker-compose-hcd.yml
@@ -5,7 +5,7 @@ services:
     image: datastax/hcd:${HCDTAG}
     networks:
       - stargate
-    mem_limit: 2G
+    mem_limit: 3G
     environment:
       - MAX_HEAP_SIZE=1536M
       - CLUSTER_NAME=hcd-${HCDTAG}-cluster

--- a/docker-compose/docker-compose-hcd.yml
+++ b/docker-compose/docker-compose-hcd.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   hcd:
     image: datastax/hcd:${HCDTAG}
+    platform: linux/amd64
     networks:
       - stargate
     mem_limit: 3G

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: datastax/dse-server:${DSETAG}
     networks:
       - stargate
-    mem_limit: 2G
+    mem_limit: 2500M
     environment:
       - MAX_HEAP_SIZE=1536M
       - CLUSTER_NAME=dse-${DSETAG}-cluster
@@ -25,6 +25,7 @@ services:
     platform: linux/amd64
     networks:
       - stargate
+    mem_limit: 2500M
     depends_on:
       dse-1:
         condition: service_healthy
@@ -44,6 +45,7 @@ services:
     platform: linux/amd64
     networks:
       - stargate
+    mem_limit: 2500M
     depends_on:
       dse-1:
         condition: service_healthy

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   dse-1:
     image: datastax/dse-server:${DSETAG}
+    platform: linux/amd64
     networks:
       - stargate
     mem_limit: 2500M


### PR DESCRIPTION
**What this PR does**:

Increases max mem for HCD-backed single node cluster

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
