### PR TITLE
Null check for errors in CommandResult

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -200,7 +200,9 @@ public class MeteredCommandProcessor {
     }
     if (!isFailure
         && commandLevelLoggingConfig.onlyResultsWithErrors()
-        && (commandResult == null || commandResult.errors().isEmpty())) {
+        && (commandResult == null
+            || commandResult.errors() == null
+            || commandResult.errors().isEmpty())) {
       return false;
     }
     // return true in all other cases


### PR DESCRIPTION
**What this PR does**:
The `errors` fields can be `null` in a `CommandResult` object and so null check is added to prevent NPE in the command level logging module

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
