### PR TITLE
Fix a performance issue wrt. not reusing ObjectMappers for command logging

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.processor;
 
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -35,7 +36,7 @@ public class MeteredCommandProcessor {
 
   private static final Logger logger = LoggerFactory.getLogger(MeteredCommandProcessor.class);
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectWriter OBJECT_WRITER = new ObjectMapper().writer();
   private static final String UNKNOWN_VALUE = "unknown";
 
   private static final String NA = "NA";
@@ -149,7 +150,7 @@ public class MeteredCommandProcessor {
             getOutgoingDocumentsCount(result),
             result != null ? result.errors() : Collections.emptyList());
     try {
-      return OBJECT_MAPPER.writeValueAsString(commandLog);
+      return OBJECT_WRITER.writeValueAsString(commandLog);
     } catch (JacksonException e) {
       return "ERROR: Failed to serialize CommandLog instance, cause = " + e;
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.processor;
 
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -34,6 +35,7 @@ public class MeteredCommandProcessor {
 
   private static final Logger logger = LoggerFactory.getLogger(MeteredCommandProcessor.class);
 
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String UNKNOWN_VALUE = "unknown";
 
   private static final String NA = "NA";
@@ -146,7 +148,11 @@ public class MeteredCommandProcessor {
             getIncomingDocumentsCount(command),
             getOutgoingDocumentsCount(result),
             result != null ? result.errors() : Collections.emptyList());
-    return new ObjectMapper().valueToTree(commandLog).toString();
+    try {
+      return OBJECT_MAPPER.writeValueAsString(commandLog);
+    } catch (JacksonException e) {
+      return "ERROR: Failed to serialize CommandLog instance, cause = " + e;
+    }
   }
 
   /**


### PR DESCRIPTION
**What this PR does**:

Adds `ObjectMapper` reused for command log, to avoid excessive cpu usage, garbage production when serializing `CommandLog` entries

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
