### PR TITLE
Bedrock code cleanup

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/request/DataApiRequestInfo.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/request/DataApiRequestInfo.java
@@ -2,7 +2,6 @@ package io.stargate.sgv2.jsonapi.api.request;
 
 import io.stargate.sgv2.jsonapi.api.request.tenant.DataApiTenantResolver;
 import io.stargate.sgv2.jsonapi.api.request.token.DataApiTokenResolver;
-import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Instance;
@@ -18,7 +17,7 @@ import java.util.Optional;
 public class DataApiRequestInfo {
   private final Optional<String> tenantId;
   private final Optional<String> cassandraToken;
-  private EmbeddingProvider.Credentials credentials;
+  private final EmbeddingCredentials embeddingCredentials;
 
   /**
    * Constructor that will be useful in the offline library mode, where only the tenant will be set
@@ -29,7 +28,7 @@ public class DataApiRequestInfo {
   public DataApiRequestInfo(Optional<String> tenantId) {
     this.tenantId = tenantId;
     this.cassandraToken = Optional.empty();
-    this.credentials = null;
+    this.embeddingCredentials = null;
   }
 
   @Inject
@@ -38,14 +37,8 @@ public class DataApiRequestInfo {
       SecurityContext securityContext,
       Instance<DataApiTenantResolver> tenantResolver,
       Instance<DataApiTokenResolver> tokenResolver,
-      Instance<EmbeddingCredentialResolver> apiKeysResolver) {
-    final EmbeddingCredential embeddingCredential =
-        apiKeysResolver.get().resolveEmbeddingCredential(routingContext);
-    this.credentials =
-        new EmbeddingProvider.Credentials(
-            embeddingCredential.apiKey(),
-            embeddingCredential.accessId(),
-            embeddingCredential.secretId());
+      Instance<EmbeddingCredentialsResolver> apiKeysResolver) {
+    this.embeddingCredentials = apiKeysResolver.get().resolveEmbeddingCredentials(routingContext);
     this.tenantId = (tenantResolver.get()).resolve(routingContext, securityContext);
     this.cassandraToken = (tokenResolver.get()).resolve(routingContext, securityContext);
   }
@@ -58,7 +51,7 @@ public class DataApiRequestInfo {
     return this.cassandraToken;
   }
 
-  public EmbeddingProvider.Credentials getCredentials() {
-    return this.credentials;
+  public EmbeddingCredentials getEmbeddingCredentials() {
+    return this.embeddingCredentials;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/request/EmbeddingCredentials.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/request/EmbeddingCredentials.java
@@ -3,12 +3,12 @@ package io.stargate.sgv2.jsonapi.api.request;
 import java.util.Optional;
 
 /**
- * EmbeddingCredential is a record that holds the embedding provider credentials for the embedding
+ * EmbeddingCredentials is a record that holds the embedding provider credentials for the embedding
  * service passed as header.
  *
  * @param apiKey - API token for the embedding service
  * @param accessId - Access Id used for AWS Bedrock embedding service
  * @param secretId - Secret Id used for AWS Bedrock embedding service
  */
-public record EmbeddingCredential(
+public record EmbeddingCredentials(
     Optional<String> apiKey, Optional<String> accessId, Optional<String> secretId) {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/request/EmbeddingCredentialsResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/request/EmbeddingCredentialsResolver.java
@@ -4,6 +4,6 @@ import io.vertx.ext.web.RoutingContext;
 
 /** Functional interface to resolve the embedding api key from the request context. */
 @FunctionalInterface
-public interface EmbeddingCredentialResolver {
-  EmbeddingCredential resolveEmbeddingCredential(RoutingContext context);
+public interface EmbeddingCredentialsResolver {
+  EmbeddingCredentials resolveEmbeddingCredentials(RoutingContext context);
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/request/HeaderBasedEmbeddingCredentialsResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/request/HeaderBasedEmbeddingCredentialsResolver.java
@@ -8,27 +8,27 @@ import java.util.Optional;
 /**
  * Implementation to resolve the embedding api key, access id and secret id from the request header.
  */
-public class HeaderBasedEmbeddingCredentialResolver implements EmbeddingCredentialResolver {
+public class HeaderBasedEmbeddingCredentialsResolver implements EmbeddingCredentialsResolver {
   private final String tokenHeaderName;
   private final String accessIdHeaderName;
   private final String secretIdHeaderName;
 
-  public HeaderBasedEmbeddingCredentialResolver(
+  public HeaderBasedEmbeddingCredentialsResolver(
       String tokenHeaderName, String accessIdHeaderName, String secretIdHeaderName) {
-    Objects.requireNonNull(tokenHeaderName, "Token header name cannot be null");
-    Objects.requireNonNull(accessIdHeaderName, "Access Id header name cannot be null");
-    Objects.requireNonNull(secretIdHeaderName, "Secret Id header name cannot be null");
-    this.tokenHeaderName = tokenHeaderName;
-    this.accessIdHeaderName = accessIdHeaderName;
-    this.secretIdHeaderName = secretIdHeaderName;
+    this.tokenHeaderName =
+        Objects.requireNonNull(tokenHeaderName, "Token header name cannot be null");
+    this.accessIdHeaderName =
+        Objects.requireNonNull(accessIdHeaderName, "Access Id header name cannot be null");
+    this.secretIdHeaderName =
+        Objects.requireNonNull(secretIdHeaderName, "Secret Id header name cannot be null");
   }
 
-  public EmbeddingCredential resolveEmbeddingCredential(RoutingContext context) {
+  public EmbeddingCredentials resolveEmbeddingCredentials(RoutingContext context) {
     HttpServerRequest request = context.request();
     String headerValue = request.getHeader(this.tokenHeaderName);
     String accessId = request.getHeader(this.accessIdHeaderName);
     String secretId = request.getHeader(this.secretIdHeaderName);
-    return new EmbeddingCredential(
+    return new EmbeddingCredentials(
         Optional.ofNullable(headerValue),
         Optional.ofNullable(accessId),
         Optional.ofNullable(secretId));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
@@ -11,6 +11,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
@@ -29,7 +30,7 @@ import java.util.Map;
 public class DataVectorizer {
   private final EmbeddingProvider embeddingProvider;
   private final JsonNodeFactory nodeFactory;
-  private final EmbeddingProvider.Credentials credentials;
+  private final EmbeddingCredentials embeddingCredentials;
   private final CollectionSettings collectionSettings;
 
   /**
@@ -38,17 +39,17 @@ public class DataVectorizer {
    * @param embeddingProvider - Service client based on embedding service configuration set for the
    *     table
    * @param nodeFactory - Jackson node factory to create json nodes added to the document
-   * @param credentials - Credentials for the embedding service
+   * @param embeddingCredentials - Credentials for the embedding service
    * @param collectionSettings - The collection setting for vectorize call
    */
   public DataVectorizer(
       EmbeddingProvider embeddingProvider,
       JsonNodeFactory nodeFactory,
-      EmbeddingProvider.Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       CollectionSettings collectionSettings) {
     this.embeddingProvider = embeddingProvider;
     this.nodeFactory = nodeFactory;
-    this.credentials = credentials;
+    this.embeddingCredentials = embeddingCredentials;
     this.collectionSettings = collectionSettings;
   }
 
@@ -108,7 +109,10 @@ public class DataVectorizer {
         Uni<List<float[]>> vectors =
             embeddingProvider
                 .vectorize(
-                    1, vectorizeTexts, credentials, EmbeddingProvider.EmbeddingRequestType.INDEX)
+                    1,
+                    vectorizeTexts,
+                    embeddingCredentials,
+                    EmbeddingProvider.EmbeddingRequestType.INDEX)
                 .map(res -> res.embeddings());
         return vectors
             .onItem()
@@ -172,7 +176,10 @@ public class DataVectorizer {
         Uni<List<float[]>> vectors =
             embeddingProvider
                 .vectorize(
-                    1, List.of(text), credentials, EmbeddingProvider.EmbeddingRequestType.SEARCH)
+                    1,
+                    List.of(text),
+                    embeddingCredentials,
+                    EmbeddingProvider.EmbeddingRequestType.SEARCH)
                 .map(res -> res.embeddings());
         return vectors
             .onItem()
@@ -255,7 +262,10 @@ public class DataVectorizer {
           final Uni<List<float[]>> vectors =
               embeddingProvider
                   .vectorize(
-                      1, List.of(text), credentials, EmbeddingProvider.EmbeddingRequestType.INDEX)
+                      1,
+                      List.of(text),
+                      embeddingCredentials,
+                      EmbeddingProvider.EmbeddingRequestType.INDEX)
                   .map(res -> res.embeddings());
           return vectors
               .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
@@ -62,7 +62,7 @@ public class DataVectorizerService {
         new DataVectorizer(
             embeddingProvider,
             objectMapper.getNodeFactory(),
-            dataApiRequestInfo.getCredentials(),
+            dataApiRequestInfo.getEmbeddingCredentials(),
             commandContext.collectionSettings());
     return vectorizeSortClause(dataVectorizer, commandContext, command)
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/EmbeddingApiKeyResolverProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/EmbeddingApiKeyResolverProvider.java
@@ -1,7 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.embedding;
 
-import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentialResolver;
-import io.stargate.sgv2.jsonapi.api.request.HeaderBasedEmbeddingCredentialResolver;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentialsResolver;
+import io.stargate.sgv2.jsonapi.api.request.HeaderBasedEmbeddingCredentialsResolver;
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -9,7 +9,7 @@ import jakarta.inject.Singleton;
 import jakarta.ws.rs.Produces;
 
 /**
- * Simple CDI producer for the {@link EmbeddingCredentialResolver} to be used in the embedding
+ * Simple CDI producer for the {@link EmbeddingCredentialsResolver} to be used in the embedding
  * service
  */
 @Singleton
@@ -18,8 +18,8 @@ public class EmbeddingApiKeyResolverProvider {
 
   @Produces
   @ApplicationScoped
-  EmbeddingCredentialResolver headerTokenResolver() {
-    return new HeaderBasedEmbeddingCredentialResolver(
+  EmbeddingCredentialsResolver headerTokenResolver() {
+    return new HeaderBasedEmbeddingCredentialsResolver(
         httpConstants.embeddingApiKey(),
         httpConstants.embeddingAccessId(),
         httpConstants.embeddingSecretId());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/gateway/EmbeddingGatewayClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/gateway/EmbeddingGatewayClient.java
@@ -5,6 +5,7 @@ import io.grpc.StatusRuntimeException;
 import io.smallrye.mutiny.Uni;
 import io.stargate.embedding.gateway.EmbeddingGateway;
 import io.stargate.embedding.gateway.EmbeddingService;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
@@ -87,7 +88,7 @@ public class EmbeddingGatewayClient extends EmbeddingProvider {
    * Vectorize the given list of texts
    *
    * @param texts List of texts to be vectorized
-   * @param credentials Credentials required for the provider
+   * @param embeddingCredentials Credentials required for the provider
    * @param embeddingRequestType Type of request (INDEX or SEARCH)
    * @return
    */
@@ -95,7 +96,7 @@ public class EmbeddingGatewayClient extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
     Map<String, EmbeddingGateway.ProviderEmbedRequest.EmbeddingRequest.ParameterValue>
         grpcVectorizeServiceParameter = new HashMap<>();
@@ -148,16 +149,16 @@ public class EmbeddingGatewayClient extends EmbeddingProvider {
     // Add the value of `Token` in the header
     builder.putAuthTokens(DATA_API_TOKEN, authToken.orElse(""));
     // Add the value of `x-embedding-api-key` in the header
-    if (credentials.apiKey().isPresent()) {
-      builder.putAuthTokens(EMBEDDING_API_KEY, credentials.apiKey().get());
+    if (embeddingCredentials.apiKey().isPresent()) {
+      builder.putAuthTokens(EMBEDDING_API_KEY, embeddingCredentials.apiKey().get());
     }
     // Add the value of `x-embedding-access-id` in the header
-    if (credentials.accessKeyId().isPresent()) {
-      builder.putAuthTokens(EMBEDDING_ACCESS_ID, credentials.accessKeyId().get());
+    if (embeddingCredentials.accessId().isPresent()) {
+      builder.putAuthTokens(EMBEDDING_ACCESS_ID, embeddingCredentials.accessId().get());
     }
     // Add the value of `x-embedding-secret-id` in the header
-    if (credentials.secretAccessKey().isPresent()) {
-      builder.putAuthTokens(EMBEDDING_SECRET_ID, credentials.secretAccessKey().get());
+    if (embeddingCredentials.secretId().isPresent()) {
+      builder.putAuthTokens(EMBEDDING_SECRET_ID, embeddingCredentials.secretId().get());
     }
     // Add the `authentication` (sync service key) in the createCollection command
     if (authentication != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AzureOpenAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AzureOpenAIEmbeddingProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -112,15 +113,16 @@ public class AzureOpenAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
     String[] textArray = new String[texts.size()];
     EmbeddingRequest request = new EmbeddingRequest(texts.toArray(textArray), modelName, dimension);
 
     // NOTE: NO "Bearer " prefix with API key for Azure OpenAI
     Uni<EmbeddingResponse> response =
-        applyRetry(openAIEmbeddingProviderClient.embed(credentials.apiKey().get(), request));
+        applyRetry(
+            openAIEmbeddingProviderClient.embed(embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/CohereEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/CohereEmbeddingProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -124,9 +125,9 @@ public class CohereEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
 
     String[] textArray = new String[texts.size()];
     String input_type =
@@ -136,7 +137,8 @@ public class CohereEmbeddingProvider extends EmbeddingProvider {
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            cohereEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
+            cohereEmbeddingProviderClient.embed(
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -4,6 +4,7 @@ import static io.stargate.sgv2.jsonapi.config.constants.HttpConstants.EMBEDDING_
 import static io.stargate.sgv2.jsonapi.exception.ErrorCode.EMBEDDING_PROVIDER_API_KEY_MISSING;
 
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
@@ -73,26 +74,15 @@ public abstract class EmbeddingProvider {
    * Vectorizes the given list of texts and returns the embeddings.
    *
    * @param texts List of texts to be vectorized
-   * @param credentials Credentials required for the provider
+   * @param embeddingCredentials embeddingCredentials required for the provider
    * @param embeddingRequestType Type of request (INDEX or SEARCH)
    * @return VectorResponse
    */
   public abstract Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType);
-
-  /**
-   * Record to hold the credentials required for the provider
-   *
-   * @param apiKey Optional API key for the all providers other than AWS Bedrock. If not provided,
-   *     the default API key will be used.
-   * @param accessKeyId AWS access key id
-   * @param secretAccessKey AWS secret access key
-   */
-  public record Credentials(
-      Optional<String> apiKey, Optional<String> accessKeyId, Optional<String> secretAccessKey) {}
 
   /**
    * returns the maximum batch size supported by the provider

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceDedicatedEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceDedicatedEmbeddingProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -99,9 +100,9 @@ public class HuggingFaceDedicatedEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
 
     String[] textArray = new String[texts.size()];
     EmbeddingRequest request = new EmbeddingRequest(texts.toArray(textArray));
@@ -109,7 +110,7 @@ public class HuggingFaceDedicatedEmbeddingProvider extends EmbeddingProvider {
     Uni<EmbeddingResponse> response =
         applyRetry(
             huggingFaceDedicatedEmbeddingProviderClient.embed(
-                "Bearer " + credentials.apiKey().get(), request));
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceEmbeddingProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -92,14 +93,14 @@ public class HuggingFaceEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
     EmbeddingRequest request = new EmbeddingRequest(texts, new EmbeddingRequest.Options(true));
 
     return applyRetry(
             huggingFaceEmbeddingProviderClient.embed(
-                "Bearer " + credentials.apiKey().get(), modelName, request))
+                "Bearer " + embeddingCredentials.apiKey().get(), modelName, request))
         .onItem()
         .transform(
             resp -> {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/JinaAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/JinaAIEmbeddingProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -97,15 +98,16 @@ public class JinaAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
 
     EmbeddingRequest request = new EmbeddingRequest(texts, modelName);
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            jinaAIEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
+            jinaAIEmbeddingProviderClient.embed(
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.*;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,7 +44,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
    * call and the size of the input texts.
    *
    * @param texts the list of texts to vectorize.
-   * @param credentials the credentials to use for the vectorization call.
+   * @param embeddingCredentials the credentials to use for the vectorization call.
    * @param embeddingRequestType the type of embedding request, influencing how texts are processed.
    * @return a {@link Uni} that will provide the list of vectorized texts, as arrays of floats.
    */
@@ -51,7 +52,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
     // String bytes metrics for vectorize
     DistributionSummary ds =
@@ -78,7 +79,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
             batch -> {
               // call vectorize by the batch id
               return embeddingProvider.vectorize(
-                  batch.getLeft(), batch.getRight(), credentials, embeddingRequestType);
+                  batch.getLeft(), batch.getRight(), embeddingCredentials, embeddingRequestType);
             })
         .merge()
         .collect()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MistralEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MistralEmbeddingProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -104,15 +105,16 @@ public class MistralEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
 
     EmbeddingRequest request = new EmbeddingRequest(texts, modelName, "float");
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            mistralEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
+            mistralEmbeddingProviderClient.embed(
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -104,9 +105,9 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
 
     String[] textArray = new String[texts.size()];
     String input_type = embeddingRequestType == EmbeddingRequestType.INDEX ? PASSAGE : QUERY;
@@ -116,7 +117,8 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            nvidiaEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
+            nvidiaEmbeddingProviderClient.embed(
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAIEmbeddingProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -113,9 +114,9 @@ public class OpenAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
     String[] textArray = new String[texts.size()];
     EmbeddingRequest request = new EmbeddingRequest(texts.toArray(textArray), modelName, dimension);
     String organizationId = (String) vectorizeServiceParameters.get("organizationId");
@@ -124,7 +125,10 @@ public class OpenAIEmbeddingProvider extends EmbeddingProvider {
     Uni<EmbeddingResponse> response =
         applyRetry(
             openAIEmbeddingProviderClient.embed(
-                "Bearer " + credentials.apiKey().get(), organizationId, projectId, request));
+                "Bearer " + embeddingCredentials.apiKey().get(),
+                organizationId,
+                projectId,
+                request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
@@ -119,9 +120,9 @@ public class UpstageAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
     // Oddity: Implementation does not support batching, so we only accept "batches"
     // of 1 String, fail for others
     if (texts.size() != 1) {
@@ -141,7 +142,7 @@ public class UpstageAIEmbeddingProvider extends EmbeddingProvider {
     Uni<EmbeddingResponse> response =
         applyRetry(
             upstageAIEmbeddingProviderClient.embed(
-                "Bearer " + credentials.apiKey().get(), request));
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -152,16 +153,16 @@ public class VertexAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
     EmbeddingRequest request =
         new EmbeddingRequest(texts.stream().map(t -> new EmbeddingRequest.Content(t)).toList());
 
     Uni<EmbeddingResponse> serviceResponse =
         applyRetry(
             vertexAIEmbeddingProviderClient.embed(
-                "Bearer " + credentials.apiKey().get(), modelName, request));
+                "Bearer " + embeddingCredentials.apiKey().get(), modelName, request));
 
     return serviceResponse
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderResponseValidation;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.ProviderConstants;
@@ -108,9 +109,9 @@ public class VoyageAIEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
-    checkEmbeddingApiKeyHeader(providerId, credentials.apiKey());
+    checkEmbeddingApiKeyHeader(providerId, embeddingCredentials.apiKey());
     final String inputType =
         (embeddingRequestType == EmbeddingRequestType.SEARCH) ? requestTypeQuery : requestTypeIndex;
     String[] textArray = new String[texts.size()];
@@ -119,7 +120,8 @@ public class VoyageAIEmbeddingProvider extends EmbeddingProvider {
 
     Uni<EmbeddingResponse> response =
         applyRetry(
-            voyageAIEmbeddingProviderClient.embed("Bearer " + credentials.apiKey().get(), request));
+            voyageAIEmbeddingProviderClient.embed(
+                "Bearer " + embeddingCredentials.apiKey().get(), request));
 
     return response
         .onItem()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/test/CustomITEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/test/CustomITEmbeddingProvider.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.embedding.operation.test;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,11 +62,12 @@ public class CustomITEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
     List<float[]> response = new ArrayList<>(texts.size());
     if (texts.size() == 0) return Uni.createFrom().item(Response.of(batchId, response));
-    if (!credentials.apiKey().isPresent() || !credentials.apiKey().get().equals(TEST_API_KEY))
+    if (!embeddingCredentials.apiKey().isPresent()
+        || !embeddingCredentials.apiKey().get().equals(TEST_API_KEY))
       return Uni.createFrom().failure(new RuntimeException("Invalid API Key"));
     for (String text : texts) {
       if (dimension == 5) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
@@ -15,6 +15,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
@@ -33,8 +34,8 @@ public class DataVectorizerTest {
   private final EmbeddingProvider testService = new TestEmbeddingProvider();
   private final CollectionSettings collectionSettings =
       TestEmbeddingProvider.commandContextWithVectorize.collectionSettings();
-  private final EmbeddingProvider.Credentials credentials =
-      new EmbeddingProvider.Credentials(Optional.empty(), Optional.empty(), Optional.empty());
+  private final EmbeddingCredentials embeddingCredentials =
+      new EmbeddingCredentials(Optional.empty(), Optional.empty(), Optional.empty());
 
   @Nested
   public class TestTextValues {
@@ -47,7 +48,7 @@ public class DataVectorizerTest {
       }
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorize(documents).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -74,7 +75,7 @@ public class DataVectorizerTest {
 
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorize(documents).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -104,7 +105,7 @@ public class DataVectorizerTest {
 
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         Throwable failure =
             dataVectorizer
@@ -133,7 +134,7 @@ public class DataVectorizerTest {
 
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorize(documents).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -156,7 +157,7 @@ public class DataVectorizerTest {
       documents.add(document);
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         Throwable failure =
             dataVectorizer
@@ -184,7 +185,7 @@ public class DataVectorizerTest {
             public Uni<Response> vectorize(
                 int batchId,
                 List<String> texts,
-                Credentials credentials,
+                EmbeddingCredentials embeddingCredentials,
                 EmbeddingRequestType embeddingRequestType) {
               List<float[]> customResponse = new ArrayList<>();
               texts.forEach(t -> customResponse.add(new float[] {0.5f, 0.5f, 0.5f}));
@@ -199,7 +200,10 @@ public class DataVectorizerTest {
       }
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testProvider, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testProvider,
+              objectMapper.getNodeFactory(),
+              embeddingCredentials,
+              collectionSettings);
 
       Throwable failure =
           dataVectorizer
@@ -237,7 +241,7 @@ public class DataVectorizerTest {
       }
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
 
       Throwable failure =
           dataVectorizer
@@ -266,7 +270,7 @@ public class DataVectorizerTest {
       SortClause sortClause = new SortClause(sortExpressions);
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorize(sortClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -296,7 +300,7 @@ public class DataVectorizerTest {
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -324,7 +328,7 @@ public class DataVectorizerTest {
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -351,7 +355,7 @@ public class DataVectorizerTest {
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       Throwable t =
           dataVectorizer
               .vectorizeUpdateClause(updateClause)
@@ -384,8 +388,7 @@ public class DataVectorizerTest {
           new DataVectorizer(
               testService,
               objectMapper.getNodeFactory(),
-              new EmbeddingProvider.Credentials(
-                  Optional.of("test"), Optional.empty(), Optional.empty()),
+              new EmbeddingCredentials(Optional.of("test"), Optional.empty(), Optional.empty()),
               collectionSettings);
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
@@ -415,7 +418,7 @@ public class DataVectorizerTest {
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       Throwable t =
           dataVectorizer
               .vectorizeUpdateClause(updateClause)
@@ -446,7 +449,7 @@ public class DataVectorizerTest {
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -473,7 +476,7 @@ public class DataVectorizerTest {
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
           new DataVectorizer(
-              testService, objectMapper.getNodeFactory(), credentials, collectionSettings);
+              testService, objectMapper.getNodeFactory(), embeddingCredentials, collectionSettings);
       try {
         Throwable t =
             dataVectorizer

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingGatewayClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingGatewayClientTest.java
@@ -11,6 +11,7 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.embedding.gateway.EmbeddingGateway;
 import io.stargate.embedding.gateway.EmbeddingService;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
@@ -28,8 +29,8 @@ public class EmbeddingGatewayClientTest {
 
   public static final String TESTING_COMMAND_NAME = "test_command";
 
-  private final EmbeddingProvider.Credentials credentials =
-      new EmbeddingProvider.Credentials(Optional.empty(), Optional.empty(), Optional.empty());
+  private final EmbeddingCredentials embeddingCredentials =
+      new EmbeddingCredentials(Optional.empty(), Optional.empty(), Optional.empty());
 
   // for [data-api#1088] (NPE for VoyageAI provider)
   @Test
@@ -92,7 +93,7 @@ public class EmbeddingGatewayClientTest {
             .vectorize(
                 1,
                 List.of("data 1", "data 2"),
-                credentials,
+                embeddingCredentials,
                 EmbeddingGatewayClient.EmbeddingRequestType.INDEX)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())
@@ -142,7 +143,7 @@ public class EmbeddingGatewayClientTest {
             .vectorize(
                 1,
                 List.of("data 1", "data 2"),
-                credentials,
+                embeddingCredentials,
                 EmbeddingGatewayClient.EmbeddingRequestType.INDEX)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderErrorMessageTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderErrorMessageTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
@@ -20,8 +21,8 @@ import org.junit.jupiter.api.Test;
 public class EmbeddingProviderErrorMessageTest {
   private static final int DEFAULT_DIMENSIONS = 0;
 
-  private final EmbeddingProvider.Credentials credentials =
-      new EmbeddingProvider.Credentials(Optional.of("test"), Optional.empty(), Optional.empty());
+  private final EmbeddingCredentials embeddingCredentials =
+      new EmbeddingCredentials(Optional.of("test"), Optional.empty(), Optional.empty());
 
   @Inject EmbeddingProvidersConfig config;
 
@@ -38,7 +39,10 @@ public class EmbeddingProviderErrorMessageTest {
                   DEFAULT_DIMENSIONS,
                   null)
               .vectorize(
-                  1, List.of("429"), credentials, EmbeddingProvider.EmbeddingRequestType.INDEX)
+                  1,
+                  List.of("429"),
+                  embeddingCredentials,
+                  EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()
@@ -62,7 +66,10 @@ public class EmbeddingProviderErrorMessageTest {
                   DEFAULT_DIMENSIONS,
                   null)
               .vectorize(
-                  1, List.of("400"), credentials, EmbeddingProvider.EmbeddingRequestType.INDEX)
+                  1,
+                  List.of("400"),
+                  embeddingCredentials,
+                  EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()
@@ -86,7 +93,10 @@ public class EmbeddingProviderErrorMessageTest {
                   DEFAULT_DIMENSIONS,
                   null)
               .vectorize(
-                  1, List.of("503"), credentials, EmbeddingProvider.EmbeddingRequestType.INDEX)
+                  1,
+                  List.of("503"),
+                  embeddingCredentials,
+                  EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()
@@ -110,7 +120,10 @@ public class EmbeddingProviderErrorMessageTest {
                   DEFAULT_DIMENSIONS,
                   null)
               .vectorize(
-                  1, List.of("408"), credentials, EmbeddingProvider.EmbeddingRequestType.INDEX)
+                  1,
+                  List.of("408"),
+                  embeddingCredentials,
+                  EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitFailure()
@@ -136,7 +149,7 @@ public class EmbeddingProviderErrorMessageTest {
               .vectorize(
                   1,
                   List.of("application/json"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -160,7 +173,7 @@ public class EmbeddingProviderErrorMessageTest {
               .vectorize(
                   1,
                   List.of("application/xml"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -188,7 +201,7 @@ public class EmbeddingProviderErrorMessageTest {
               .vectorize(
                   1,
                   List.of("text/plain;charset=UTF-8"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -216,7 +229,7 @@ public class EmbeddingProviderErrorMessageTest {
               .vectorize(
                   1,
                   List.of("no json body"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -244,7 +257,7 @@ public class EmbeddingProviderErrorMessageTest {
               .vectorize(
                   1,
                   List.of("empty json body"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAiEmbeddingClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAiEmbeddingClientTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProviderConfigStore;
@@ -22,8 +23,8 @@ public class OpenAiEmbeddingClientTest {
 
   @Inject EmbeddingProvidersConfig config;
 
-  private final EmbeddingProvider.Credentials credentials =
-      new EmbeddingProvider.Credentials(Optional.of("test"), Optional.empty(), Optional.empty());
+  private final EmbeddingCredentials embeddingCredentials =
+      new EmbeddingCredentials(Optional.of("test"), Optional.empty(), Optional.empty());
 
   @Nested
   class OpenAiEmbeddingTest {
@@ -40,7 +41,7 @@ public class OpenAiEmbeddingClientTest {
               .vectorize(
                   1,
                   List.of("some data"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -69,7 +70,7 @@ public class OpenAiEmbeddingClientTest {
               .vectorize(
                   1,
                   List.of("application/json"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -98,7 +99,7 @@ public class OpenAiEmbeddingClientTest {
               .vectorize(
                   1,
                   List.of("some data"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
@@ -125,7 +126,7 @@ public class OpenAiEmbeddingClientTest {
               .vectorize(
                   1,
                   List.of("some data"),
-                  credentials,
+                  embeddingCredentials,
                   EmbeddingProvider.EmbeddingRequestType.INDEX)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/TestEmbeddingProvider.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/TestEmbeddingProvider.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,7 @@ public class TestEmbeddingProvider extends EmbeddingProvider {
   public Uni<Response> vectorize(
       int batchId,
       List<String> texts,
-      Credentials credentials,
+      EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
     List<float[]> response = new ArrayList<>(texts.size());
     texts.forEach(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CommandResolverWithVectorizerTest.java
@@ -22,13 +22,13 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertManyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertOneCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.UpdateOneCommand;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizer;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizerService;
-import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingProvider;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
@@ -544,8 +544,7 @@ public class CommandResolverWithVectorizerTest {
       new DataVectorizer(
               TestEmbeddingProvider.commandContextWithVectorize.embeddingProvider(),
               objectMapper.getNodeFactory(),
-              new EmbeddingProvider.Credentials(
-                  Optional.empty(), Optional.empty(), Optional.empty()),
+              new EmbeddingCredentials(Optional.empty(), Optional.empty(), Optional.empty()),
               TestEmbeddingProvider.commandContextWithVectorize.collectionSettings())
           .vectorizeUpdateClause(updateClause)
           .subscribe()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolverTest.java
@@ -11,9 +11,9 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.UpdateManyCommand;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
+import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizer;
-import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingProvider;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
@@ -245,8 +245,7 @@ public class UpdateManyCommandResolverTest {
       new DataVectorizer(
               TestEmbeddingProvider.commandContextWithVectorize.embeddingProvider(),
               objectMapper.getNodeFactory(),
-              new EmbeddingProvider.Credentials(
-                  Optional.empty(), Optional.empty(), Optional.empty()),
+              new EmbeddingCredentials(Optional.empty(), Optional.empty(), Optional.empty()),
               TestEmbeddingProvider.commandContextWithVectorize.collectionSettings())
           .vectorizeUpdateClause(updateClause);
       assertThat(operation)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
1. Add `s` for `EmbeddingCredential` class name
2. Remove `EmbeddingProvider.Credentials` class and use `EmbeddingCredentials` class. Two classes were created due to parallel coding.
3. Remove hardcoded `x-embedding-access-id` and `x-embedding-secret-id` in error message


**Which issue(s) this PR fixes**:
Fixes NA

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
