### PR TITLE
disabling IT with dse-next from CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -117,7 +117,7 @@ jobs:
           - type: native
             #profile: '-Pnative'
           - type: docker
-            profile: '-Poffline'
+            #profile: '-Poffline'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -29,8 +29,8 @@ env:
 #
 # 1. Runs unit tests
 # 2. Then 2 jobs in parallel
-#  a) Integration tests with docker image
-#  b) Integration tests with native docker image
+#  a) Integration tests with DSE 6.9
+#  b) Integration tests with HCD
 jobs:
 
   # runs unit tests
@@ -109,8 +109,6 @@ jobs:
       matrix:
         type: [ docker, native, dse69-it, hcd-it ]
         include:
-          - type: docker
-            profile: '-Poffline'
           - type: dse69-it
             profile: '-Pdse69-it,offline'
           - type: hcd-it
@@ -118,7 +116,8 @@ jobs:
         exclude:
           - type: native
             #profile: '-Pnative'
-
+          - type: docker
+            profile: '-Poffline'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Disable step to run the Data API integration tests with the dse-next coordinator.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
