### PR TITLE
Unify JsonApiException construction for easier management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,10 +129,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.bpodgursky</groupId>
       <artifactId>jbool_expressions</artifactId>
       <version>1.23</version>
@@ -142,16 +138,16 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bedrockruntime</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,11 +150,6 @@
       <artifactId>sts</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.bpodgursky</groupId>
-      <artifactId>jbool_expressions</artifactId>
-      <version>1.23</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
@@ -5,7 +5,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.deserializers.FilterClauseDeserializer;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSchemaObject;
 import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import java.util.List;
@@ -67,11 +66,9 @@ public record FilterClause(LogicalExpression logicalExpression) {
         return;
       }
       // otherwise throw JsonApiException
-      throw new JsonApiException(
-          ErrorCode.ID_NOT_INDEXED,
-          String.format(
-              "%s: filter path '%s' is not indexed, you can only use $eq or $in as the operator",
-              ErrorCode.ID_NOT_INDEXED.getMessage(), DocumentConstants.Fields.DOC_ID));
+      throw ErrorCode.ID_NOT_INDEXED.toApiException(
+          "filter path '%s' is not indexed, you can only use $eq or $in as the operator",
+          ErrorCode.ID_NOT_INDEXED.getMessage(), DocumentConstants.Fields.DOC_ID);
     }
 
     // If path is not indexed, throw error

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/FilterClause.java
@@ -66,9 +66,7 @@ public record FilterClause(LogicalExpression logicalExpression) {
         return;
       }
       // otherwise throw JsonApiException
-      throw ErrorCode.ID_NOT_INDEXED.toApiException(
-          "filter path '%s' is not indexed, you can only use $eq or $in as the operator",
-          ErrorCode.ID_NOT_INDEXED.getMessage(), DocumentConstants.Fields.DOC_ID);
+      throw ErrorCode.ID_NOT_INDEXED.toApiException("you can only use $eq or $in as the operator");
     }
 
     // If path is not indexed, throw error

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/AddToSetOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/AddToSetOperation.java
@@ -68,7 +68,7 @@ public class AddToSetOperation extends UpdateOperation<AddToSetOperation.Action>
 
         default:
           throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.toApiException(
-              "$addToSet only supports $each modifier; trying to use '%s'");
+              "$addToSet only supports $each modifier; trying to use '%s'", modifier);
       }
     }
     // For now should not be possible to occur but once we add other modifiers could:

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/CurrentDateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/CurrentDateOperation.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import io.stargate.sgv2.jsonapi.util.PathMatch;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
@@ -43,12 +42,9 @@ public class CurrentDateOperation extends UpdateOperation<CurrentDateOperation.A
     } else if (value.isBoolean() && value.booleanValue()) {
       return;
     }
-    throw new JsonApiException(
-        ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-        ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-            + ": $currentDate requires argument of either `true` or `{\"$type\":\"date\"}`, got: `"
-            + value
-            + "`");
+    throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+        "$currentDate requires argument of either `true` or `{\"$type\":\"date\"}`, got: `%s`",
+        value);
   }
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/IncOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/IncOperation.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.PathMatch;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.ArrayList;
@@ -34,11 +33,8 @@ public class IncOperation extends UpdateOperation<IncOperation.Action> {
       name = validateUpdatePath(UpdateOperator.INC, name);
       JsonNode value = entry.getValue();
       if (!value.isNumber()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                + ": $inc requires numeric parameter, got: "
-                + value.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+            "$inc requires numeric parameter, got: %s", value.getNodeType());
       }
       updates.add(new Action(PathMatchLocator.forPath(name), (NumericNode) value));
     }
@@ -67,13 +63,9 @@ public class IncOperation extends UpdateOperation<IncOperation.Action> {
           modified |= !newValue.equals(oldValue);
         }
       } else { // Non-number existing value? Fail
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
-                + ": $inc requires target to be Number; value at '"
-                + target.fullPath()
-                + "' of type "
-                + oldValue.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.toApiException(
+            "$inc requires target to be Number; value at '%s' of type %s",
+            target.fullPath(), oldValue.getNodeType());
       }
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/MulOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/MulOperation.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.PathMatch;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.math.BigDecimal;
@@ -35,11 +34,8 @@ public class MulOperation extends UpdateOperation<MulOperation.Action> {
       name = validateUpdatePath(UpdateOperator.MUL, name);
       JsonNode value = entry.getValue();
       if (!value.isNumber()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                + ": $mul requires numeric parameter, got: "
-                + value.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+            "$mul requires numeric parameter, got: %s", value.getNodeType());
       }
       updates.add(new Action(PathMatchLocator.forPath(name), (NumericNode) value));
     }
@@ -66,13 +62,9 @@ public class MulOperation extends UpdateOperation<MulOperation.Action> {
           modified = true;
         }
       } else { // Non-number existing value? Fail
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
-                + ": $mul requires target to be Number; value at '"
-                + target.fullPath()
-                + "' of type "
-                + oldValue.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.toApiException(
+            "$mul requires target to be Number; value at '%s' of type %s",
+            target.fullPath(), oldValue.getNodeType());
       }
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.PathMatch;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.ArrayList;
@@ -29,11 +28,8 @@ public class PopOperation extends UpdateOperation<PopOperation.Action> {
 
       // Argument must be -1 (remove first) or 1 (remove last)
       if (!arg.isNumber()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                + ": $pop requires NUMBER argument (-1 or 1), instead got: "
-                + arg.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+            "$pop requires NUMBER argument (-1 or 1), instead got: %s", arg.getNodeType());
       }
       boolean first;
 
@@ -45,11 +41,8 @@ public class PopOperation extends UpdateOperation<PopOperation.Action> {
           first = false;
           break;
         default:
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                  + ": $pop requires argument of -1 or 1, instead got: "
-                  + arg.intValue());
+          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+              "$pop requires argument of -1 or 1, instead got: %s", arg.intValue());
       }
       actions.add(new Action(PathMatchLocator.forPath(path), first));
     }
@@ -80,13 +73,9 @@ public class PopOperation extends UpdateOperation<PopOperation.Action> {
           changes = true;
         }
       } else { // Something else? fail
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
-                + ": $pop requires target to be ARRAY; value at '"
-                + target.fullPath()
-                + "' of type "
-                + value.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.toApiException(
+            "$pop requires target to be ARRAY; value at '%s' of type %s",
+            target.fullPath(), value.getNodeType());
       }
     }
     return changes;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
@@ -89,7 +89,7 @@ public class PushOperation extends UpdateOperation<PushOperation.Action> {
     }
     // For now should not be possible to occur but once we add other modifiers could:
     if (eachArg == null) {
-      throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+      throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.toApiException(
           "$push modifiers can only be used with $each modifier; none included");
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
@@ -89,7 +89,7 @@ public class PushOperation extends UpdateOperation<PushOperation.Action> {
     }
     // For now should not be possible to occur but once we add other modifiers could:
     if (eachArg == null) {
-      throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.toApiException(
+      throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
           "$push modifiers can only be used with $each modifier; none included");
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.PathMatch;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.ArrayList;
@@ -31,11 +30,8 @@ public class PushOperation extends UpdateOperation<PushOperation.Action> {
       final String name = validateUpdatePath(UpdateOperator.PUSH, entry.getKey());
       // At main level we must have field name (no modifiers)
       if (looksLikeModifier(name)) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                + ": $push requires field names at main level, found modifier: "
-                + name);
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+            "$push requires field names at main level, found modifier: %s", name);
       }
       // But within field value modifiers are allowed: if there's one, all must be modifiers
       JsonNode value = entry.getValue();
@@ -66,48 +62,35 @@ public class PushOperation extends UpdateOperation<PushOperation.Action> {
         case "$each":
           eachArg = arg;
           if (!eachArg.isArray()) {
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-                ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                    + ": $push modifier $each requires ARRAY argument, found: "
-                    + eachArg.getNodeType());
+            throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+                "$push modifier $each requires ARRAY argument, found: %s", eachArg.getNodeType());
           }
           break;
         case "$position":
           // Mongo requires number
           if (!arg.isNumber()) {
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-                ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                    + ": $push modifier $position requires (integral) NUMBER argument, found: "
-                    + arg.getNodeType());
+            throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+                "$push modifier $position requires (integral) NUMBER argument, found: %s",
+                arg.getNodeType());
           }
           // but floating-point won't do either:
           if (!arg.isIntegralNumber()) {
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-                ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                    + ": $push modifier $position requires Integer NUMBER argument, instead got: "
-                    + arg.asText());
+            throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+                "$push modifier $position requires Integer NUMBER argument, instead got: %s",
+                arg.asText());
           }
           position = arg.intValue();
           break;
 
         default:
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER,
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.getMessage()
-                  + ": $push only supports $each and $position currently; trying to use '"
-                  + modifier
-                  + "'");
+          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+              "$push only supports $each and $position currently; trying to use '%s'", modifier);
       }
     }
     // For now should not be possible to occur but once we add other modifiers could:
     if (eachArg == null) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-          ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-              + ": $push modifiers can only be used with $each modifier; none included");
+      throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+          "$push modifiers can only be used with $each modifier; none included");
     }
 
     return new Action(PathMatchLocator.forPath(propName), eachArg, true, position);
@@ -140,13 +123,9 @@ public class PushOperation extends UpdateOperation<PushOperation.Action> {
       } else if (node.isArray()) { // Already array? Append
         array = (ArrayNode) node;
       } else { // Something else? fail
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
-                + ": $push requires target to be ARRAY; value at '"
-                + target.fullPath()
-                + "' of type "
-                + node.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.toApiException(
+            "$push requires target to be ARRAY; value at '%s' of type %s",
+            target.fullPath(), node.getNodeType());
       }
       // Regular add or $each?
       if (action.each) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
@@ -83,7 +83,7 @@ public class PushOperation extends UpdateOperation<PushOperation.Action> {
           break;
 
         default:
-          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.toApiException(
               "$push only supports $each and $position currently; trying to use '%s'", modifier);
       }
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/RenameOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/RenameOperation.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.PathMatch;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.ArrayList;
@@ -23,20 +22,13 @@ public class RenameOperation extends UpdateOperation<RenameOperation.Action> {
       String srcPath = validateUpdatePath(UpdateOperator.RENAME, entry.getKey());
       JsonNode value = entry.getValue();
       if (!value.isTextual()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.getMessage()
-                + ": $rename requires STRING parameter for 'to', got: "
-                + value.getNodeType());
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+            "$rename requires STRING parameter for 'to', got: %s", value.getNodeType());
       }
       String dstPath = validateUpdatePath(UpdateOperator.RENAME, value.textValue());
       if (srcPath.equals(dstPath)) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
-                + ": $rename requires that 'source' and `destination` differ ('"
-                + srcPath
-                + "')");
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.toApiException(
+            "$rename requires that 'source' and `destination` differ ('%s')", srcPath);
       }
       actions.add(new Action(PathMatchLocator.forPath(srcPath), PathMatchLocator.forPath(dstPath)));
     }
@@ -52,12 +44,8 @@ public class RenameOperation extends UpdateOperation<RenameOperation.Action> {
       if (value != null) {
         // $rename does not allow renaming of Array elements
         if (src.contextNode().isArray()) {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH,
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
-                  + ": $rename does not allow ARRAY field as source ('"
-                  + action.sourceLocator()
-                  + "')");
+          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.toApiException(
+              "$rename does not allow ARRAY field as source ('%s')", action.sourceLocator());
         }
 
         // If there is a value will be a modification (since source value will
@@ -67,12 +55,8 @@ public class RenameOperation extends UpdateOperation<RenameOperation.Action> {
 
         // Also not allowed: destination as Array element:
         if (dst.contextNode().isArray()) {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH,
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
-                  + ": $rename does not allow ARRAY field as destination ('"
-                  + action.targetLocator()
-                  + "')");
+          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.toApiException(
+              "$rename does not allow ARRAY field as destination ('%s')", action.targetLocator());
         }
 
         dst.replaceValue(value);

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.api.model.command.deserializers.UpdateClauseDeserializer;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -77,11 +76,9 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
         PathMatchLocator currLoc = curr.getKey();
         // So, if parent/child, parent always first so this check is enough
         if (currLoc.isSubPathOf(prevLoc)) {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-              "Update operator path conflict due to overlap: '%s' (%s) vs '%s' (%s)"
-                  .formatted(
-                      prevLoc, prev.getValue().operator(), currLoc, curr.getValue().operator()));
+          throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+              "Update operator path conflict due to overlap: '%s' (%s) vs '%s' (%s)",
+              prevLoc, prev.getValue().operator(), currLoc, curr.getValue().operator());
         }
       }
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
@@ -55,10 +55,9 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
               for (ActionWithLocator action : actions) {
                 UpdateOperator prevType = actionMap.put(action.locator(), type);
                 if (prevType != null) {
-                  throw new JsonApiException(
-                      ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-                      "Update operators '%s' and '%s' must not refer to same path: '%s'"
-                          .formatted(prevType.operator(), type.operator(), action.locator()));
+                  throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM.toApiException(
+                      "update operators '%s' and '%s' must not refer to same path: '%s'",
+                      prevType.operator(), type.operator(), action.locator());
                 }
               }
             });

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperation.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -55,24 +54,18 @@ public abstract class UpdateOperation<A extends ActionWithLocator> {
         && !(oper.operator().equals("$set")
             || oper.operator().equals("$unset")
             || oper.operator().equals("$setOnInsert"))) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTOR,
-          ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTOR.getMessage() + ": " + oper.operator());
+      throw ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTOR.toApiException("%s", oper.operator());
     }
 
     if (DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(path)
         && !(oper.operator().equals("$set")
             || oper.operator().equals("$unset")
             || oper.operator().equals("$setOnInsert"))) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTORIZE,
-          ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTORIZE.getMessage() + ": " + oper.operator());
+      throw ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTORIZE.toApiException("%s", oper.operator());
     }
 
     if (DocumentConstants.Fields.DOC_ID.equals(path)) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_UPDATE_FOR_DOC_ID,
-          ErrorCode.UNSUPPORTED_UPDATE_FOR_DOC_ID.getMessage() + ": " + oper.operator());
+      throw ErrorCode.UNSUPPORTED_UPDATE_FOR_DOC_ID.toApiException("%s", oper.operator());
     }
     return path;
   }
@@ -88,12 +81,8 @@ public abstract class UpdateOperation<A extends ActionWithLocator> {
    */
   protected static String validateNonModifierPath(UpdateOperator oper, String path) {
     if (looksLikeModifier(path)) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER,
-          ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.getMessage()
-              + ": "
-              + oper.operator()
-              + " does not support modifiers");
+      throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_MODIFIER.toApiException(
+          "%s does not support modifiers", oper.operator());
     }
     return path;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
@@ -299,8 +299,7 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
             || valueObject instanceof BigDecimal
             || (valueObject instanceof DocumentId && (value.isObject() || value.isNumber())))) {
           throw ErrorCode.INVALID_FILTER_EXPRESSION.toApiException(
-              "Invalid filter expression, %s operator must have `DATE` or `NUMBER` value",
-              operator.getOperator());
+              "%s operator must have `DATE` or `NUMBER` value", operator.getOperator());
         }
       }
       ComparisonExpression expression =

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializer.java
@@ -99,8 +99,7 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
 
         if (!DocumentConstants.Fields.VALID_PATH_PATTERN.matcher(path).matches()) {
           throw ErrorCode.INVALID_SORT_CLAUSE_PATH.toApiException(
-              "sort clause path ('%s') contains character(s) not allowed",
-              ErrorCode.INVALID_SORT_CLAUSE_PATH.getMessage(), path);
+              "sort clause path ('%s') contains character(s) not allowed", path);
         }
 
         if (!inner.getValue().isInt()

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializer.java
@@ -1,9 +1,7 @@
 package io.stargate.sgv2.jsonapi.api.model.command.deserializers;
 
-import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -12,7 +10,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,8 +26,7 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
 
   /** {@inheritDoc} */
   @Override
-  public SortClause deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JacksonException {
+  public SortClause deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
     JsonNode node = ctxt.readTree(parser);
 
     // if missing or null, return null back
@@ -39,12 +35,10 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
       return null;
     }
 
-    // TODO, should we have specific exceptions, or throw generic JSON ones?
-    //  https://github.com/riptano/sgv3-docsapi/issues/9
-
     // otherwise, if it's not object throw exception
     if (!node.isObject()) {
-      throw new JsonMappingException(parser, "Sort clause must be submitted as json object");
+      throw ErrorCode.INVALID_SORT_CLAUSE.toApiException(
+          "Sort clause must be submitted as json object");
     }
 
     ObjectNode sortNode = (ObjectNode) node;
@@ -59,25 +53,20 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
       if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(path)) {
         // Vector search can't be used with other sort clause
         if (totalFields > 1) {
-          throw new JsonApiException(
-              ErrorCode.VECTOR_SEARCH_USAGE_ERROR,
-              ErrorCode.VECTOR_SEARCH_USAGE_ERROR.getMessage());
+          throw ErrorCode.VECTOR_SEARCH_USAGE_ERROR.toApiException();
         }
         if (!inner.getValue().isArray()) {
-          throw new JsonApiException(
-              ErrorCode.SHRED_BAD_VECTOR_VALUE, ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage());
+          throw ErrorCode.SHRED_BAD_VECTOR_VALUE.toApiException();
         } else {
           ArrayNode arrayNode = (ArrayNode) inner.getValue();
           float[] arrayVals = new float[arrayNode.size()];
           if (arrayNode.size() == 0) {
-            throw new JsonApiException(
-                ErrorCode.SHRED_BAD_VECTOR_SIZE, ErrorCode.SHRED_BAD_VECTOR_SIZE.getMessage());
+            throw ErrorCode.SHRED_BAD_VECTOR_SIZE.toApiException();
           }
           for (int i = 0; i < arrayNode.size(); i++) {
             JsonNode element = arrayNode.get(i);
             if (!element.isNumber()) {
-              throw new JsonApiException(
-                  ErrorCode.SHRED_BAD_VECTOR_VALUE, ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage());
+              throw ErrorCode.SHRED_BAD_VECTOR_VALUE.toApiException();
             }
             arrayVals[i] = element.floatValue();
           }
@@ -89,20 +78,14 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
       } else if (DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(path)) {
         // Vector search can't be used with other sort clause
         if (totalFields > 1) {
-          throw new JsonApiException(
-              ErrorCode.VECTOR_SEARCH_USAGE_ERROR,
-              ErrorCode.VECTOR_SEARCH_USAGE_ERROR.getMessage());
+          throw ErrorCode.VECTOR_SEARCH_USAGE_ERROR.toApiException();
         }
         if (!inner.getValue().isTextual()) {
-          throw new JsonApiException(
-              ErrorCode.SHRED_BAD_VECTORIZE_VALUE,
-              ErrorCode.SHRED_BAD_VECTORIZE_VALUE.getMessage());
+          throw ErrorCode.SHRED_BAD_VECTORIZE_VALUE.toApiException();
         }
         String vectorizeData = inner.getValue().textValue();
         if (vectorizeData.isBlank()) {
-          throw new JsonApiException(
-              ErrorCode.SHRED_BAD_VECTORIZE_VALUE,
-              ErrorCode.SHRED_BAD_VECTORIZE_VALUE.getMessage());
+          throw ErrorCode.SHRED_BAD_VECTORIZE_VALUE.toApiException();
         }
         SortExpression exp = SortExpression.vectorizeSearch(vectorizeData);
         sortExpressions.clear();
@@ -110,26 +93,21 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
         break;
       } else {
         if (path.isBlank()) {
-          throw new JsonApiException(
-              ErrorCode.INVALID_SORT_CLAUSE_PATH,
-              String.format(
-                  "%s: sort clause path must be represented as not-blank string",
-                  ErrorCode.INVALID_SORT_CLAUSE_PATH.getMessage()));
+          throw ErrorCode.INVALID_SORT_CLAUSE_PATH.toApiException(
+              "sort clause path must be represented as not-blank string");
         }
 
         if (!DocumentConstants.Fields.VALID_PATH_PATTERN.matcher(path).matches()) {
-          throw new JsonApiException(
-              ErrorCode.INVALID_SORT_CLAUSE_PATH,
-              String.format(
-                  "%s: sort clause path ('%s') contains character(s) not allowed",
-                  ErrorCode.INVALID_SORT_CLAUSE_PATH.getMessage(), path));
+          throw ErrorCode.INVALID_SORT_CLAUSE_PATH.toApiException(
+              "sort clause path ('%s') contains character(s) not allowed",
+              ErrorCode.INVALID_SORT_CLAUSE_PATH.getMessage(), path);
         }
 
         if (!inner.getValue().isInt()
             || !(inner.getValue().intValue() == 1 || inner.getValue().intValue() == -1)) {
-          throw new JsonApiException(
-              ErrorCode.INVALID_SORT_CLAUSE_VALUE,
-              ErrorCode.INVALID_SORT_CLAUSE_VALUE.getMessage());
+          throw ErrorCode.INVALID_SORT_CLAUSE_VALUE.toApiException(
+              "Sort ordering value can only be `1` for ascending or `-1` for descending (not `%s`)",
+              inner.getValue());
         }
 
         boolean ascending = inner.getValue().intValue() == 1;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/UpdateClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/UpdateClauseDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Iterator;
@@ -27,10 +26,9 @@ public class UpdateClauseDeserializer extends StdDeserializer<UpdateClause> {
       JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
     JsonNode filterNode = deserializationContext.readTree(jsonParser);
     if (!filterNode.isObject()) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_UPDATE_DATA_TYPE,
-          "Unsupported update data type for UpdateClause (must be JSON Object): "
-              + filterNode.getNodeType());
+      throw ErrorCode.UNSUPPORTED_UPDATE_DATA_TYPE.toApiException(
+          "update data type for UpdateClause must be JSON Object, was: %s",
+          filterNode.getNodeType());
     }
     final EnumMap<UpdateOperator, ObjectNode> updateDefs = new EnumMap<>(UpdateOperator.class);
     Iterator<Map.Entry<String, JsonNode>> fieldIter = filterNode.fields();
@@ -48,10 +46,9 @@ public class UpdateClauseDeserializer extends StdDeserializer<UpdateClause> {
       }
       JsonNode operationArg = entry.getValue();
       if (!operationArg.isObject()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_DATA_TYPE,
-            "Unsupported update data type for Operator '%s' (must be JSON Object): %s"
-                .formatted(operName, operationArg.getNodeType()));
+        throw ErrorCode.UNSUPPORTED_UPDATE_DATA_TYPE.toApiException(
+            "update data type for Operator '%s' must be JSON Object, was: %s",
+            operName, operationArg.getNodeType());
       }
       updateDefs.put(oper, (ObjectNode) operationArg);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -130,7 +130,7 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_USAGE_ERROR("Vector search can't be used with other sort clause"),
 
-  VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection "),
+  VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection"),
 
   VECTOR_SEARCH_INVALID_FUNCTION_NAME("Invalid vector search function name"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
   COMMAND_FIELD_INVALID("Request invalid"),
 
   CONCURRENCY_FAILURE("Unable to complete transaction due to concurrent transactions"),
-  COLLECTION_NOT_EXIST("Collection does not exist, collection name: "),
+  COLLECTION_NOT_EXIST("Collection does not exist, collection name"),
   DATASET_TOO_BIG("Response data set too big to be sorted, add more filters"),
 
   DOCUMENT_ALREADY_EXISTS("Document already exists with the given _id"),
@@ -59,7 +59,7 @@ public enum ErrorCode {
 
   ID_NOT_INDEXED("_id is not indexed"),
 
-  NAMESPACE_DOES_NOT_EXIST("The provided namespace does not exist."),
+  NAMESPACE_DOES_NOT_EXIST("The provided namespace does not exist"),
 
   SHRED_BAD_DOCUMENT_TYPE("Bad document type to shred"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -87,7 +87,7 @@ public enum ErrorCode {
 
   INVALID_FILTER_EXPRESSION("Invalid filter expression"),
 
-  INVALID_JSONAPI_COLLECTION_SCHEMA("Not a valid json api collection schema: "),
+  INVALID_JSONAPI_COLLECTION_SCHEMA("Not a valid json api collection schema"),
 
   TOO_MANY_COLLECTIONS("Too many collections"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -98,10 +98,11 @@ public enum ErrorCode {
 
   UNSUPPORTED_FILTER_OPERATION("Unsupported filter operator"),
 
+  INVALID_SORT_CLAUSE("Invalid sort clause"),
+
   INVALID_SORT_CLAUSE_PATH("Invalid sort clause path"),
 
-  INVALID_SORT_CLAUSE_VALUE(
-      "Sort ordering value can only be `1` for ascending or `-1` for descending."),
+  INVALID_SORT_CLAUSE_VALUE("Invalid sort clause value"),
 
   INVALID_USAGE_OF_VECTORIZE("`$vectorize` and `$vector` can't be used together"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -132,7 +132,7 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection "),
 
-  VECTOR_SEARCH_INVALID_FUNCTION_NAME("Invalid vector search function name: "),
+  VECTOR_SEARCH_INVALID_FUNCTION_NAME("Invalid vector search function name"),
 
   VECTOR_SEARCH_TOO_BIG_VALUE("Vector embedding property '$vector' length too big"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/WebApplicationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/WebApplicationExceptionMapper.java
@@ -24,12 +24,8 @@ public class WebApplicationExceptionMapper {
 
     // and if we have StreamConstraintsException, re-create as ApiException
     if (toReport instanceof StreamConstraintsException) {
-      toReport =
-          new JsonApiException(
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage() + ": " + toReport.getMessage(),
-              // but leave out the root cause, as it is not useful
-              null);
+      // but leave out the root cause, as it is not useful
+      toReport = ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(toReport.getMessage());
     }
     CommandResult commandResult = new ThrowableCommandResultSupplier(toReport).get();
     if (toReport instanceof JsonApiException jae) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cql/builder/QueryBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cql/builder/QueryBuilder.java
@@ -4,7 +4,6 @@ import com.bpodgursky.jbool_expressions.Expression;
 import com.bpodgursky.jbool_expressions.Variable;
 import com.datastax.oss.driver.api.core.data.CqlVector;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cql.ColumnUtils;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSchemaObject;
 import io.stargate.sgv2.jsonapi.service.cqldriver.serializer.CQLBindValues;
@@ -276,9 +275,8 @@ public class QueryBuilder {
           functionCalls.add(
               FunctionCall.similarityFunctionCall(columnName, "SIMILARITY_DOT_PRODUCT"));
       default ->
-          throw new JsonApiException(
-              ErrorCode.VECTOR_SEARCH_INVALID_FUNCTION_NAME,
-              ErrorCode.VECTOR_SEARCH_INVALID_FUNCTION_NAME.getMessage() + similarityFunction);
+          throw ErrorCode.VECTOR_SEARCH_INVALID_FUNCTION_NAME.toApiException(
+              "%s", similarityFunction);
     }
     return this;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSchemaObject.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSchemaObject.java
@@ -14,7 +14,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateCollectionCommand;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.config.constants.TableCommentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import java.util.HashSet;
 import java.util.Map;
@@ -162,9 +161,8 @@ public final class CollectionSchemaObject extends SchemaObject {
         case "euclidean" -> EUCLIDEAN;
         case "dot_product" -> DOT_PRODUCT;
         default ->
-            throw new JsonApiException(
-                ErrorCode.VECTOR_SEARCH_INVALID_FUNCTION_NAME,
-                ErrorCode.VECTOR_SEARCH_INVALID_FUNCTION_NAME.getMessage() + similarityFunction);
+            throw ErrorCode.VECTOR_SEARCH_INVALID_FUNCTION_NAME.toApiException(
+                "'%s'", similarityFunction);
       };
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCache.java
@@ -99,9 +99,7 @@ public class NamespaceCache {
               // TODO: error code here needs to be for collections and tables
               var table =
                   optionalTable.orElseThrow(
-                      () ->
-                          new RuntimeException(
-                              ErrorCode.COLLECTION_NOT_EXIST.getMessage() + collectionName));
+                      () -> ErrorCode.COLLECTION_NOT_EXIST.toApiException("%s", collectionName));
 
               // check if its a valid json api table
               // TODO: re-use the table matcher this is on the request hot path

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCache.java
@@ -66,11 +66,8 @@ public class NamespaceCache {
                           == ErrorCode.VECTORIZECONFIG_CHECK_FAIL) {
                     return Uni.createFrom()
                         .failure(
-                            new JsonApiException(
-                                ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA,
-                                ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA
-                                    .getMessage()
-                                    .concat(collectionName)));
+                            ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA.toApiException(
+                                "%s", collectionName));
                   }
                   // collection does not exist
                   // TODO: DO NOT do a string starts with, use proper error structures
@@ -79,11 +76,7 @@ public class NamespaceCache {
                       && rte.getMessage().startsWith(ErrorCode.COLLECTION_NOT_EXIST.getMessage())) {
                     return Uni.createFrom()
                         .failure(
-                            new JsonApiException(
-                                ErrorCode.COLLECTION_NOT_EXIST,
-                                ErrorCode.COLLECTION_NOT_EXIST
-                                    .getMessage()
-                                    .concat(collectionName)));
+                            ErrorCode.COLLECTION_NOT_EXIST.toApiException("%s", collectionName));
                   }
                   return Uni.createFrom().failure(error);
                 } else {
@@ -122,9 +115,8 @@ public class NamespaceCache {
               }
 
               // Target is not a collection and we are not supporting tables
-              throw new JsonApiException(
-                  ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA,
-                  ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA.getMessage() + collectionName);
+              throw ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA.toApiException(
+                  "%s", collectionName);
             });
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/QueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/QueryExecutor.java
@@ -12,7 +12,6 @@ import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -263,10 +262,7 @@ public class QueryExecutor {
     // if namespace does not exist, throw error
     if (keyspaceMetadata == null) {
       return Uni.createFrom()
-          .failure(
-              new JsonApiException(
-                  ErrorCode.NAMESPACE_DOES_NOT_EXIST,
-                  "The provided namespace does not exist: " + namespace));
+          .failure(ErrorCode.NAMESPACE_DOES_NOT_EXIST.toApiException("%s", namespace));
     }
     // else get the table
     // TODO: this should probably use CqlIdentifier.fromCql() if we want to be case sensitive

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
@@ -67,11 +67,8 @@ public class DataVectorizer {
         JsonNode document = documents.get(position);
         if (document.has(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
           if (document.has(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
-            throw new JsonApiException(
-                ErrorCode.INVALID_USAGE_OF_VECTORIZE,
-                ErrorCode.INVALID_USAGE_OF_VECTORIZE.getMessage()
-                    + ", issue in document at position "
-                    + (position + 1));
+            throw ErrorCode.INVALID_USAGE_OF_VECTORIZE.toApiException(
+                "issue in document at position %d", (position + 1));
           }
           final JsonNode jsonNode =
               document.get(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD);
@@ -81,11 +78,8 @@ public class DataVectorizer {
             continue;
           }
           if (!jsonNode.isTextual()) {
-            throw new JsonApiException(
-                ErrorCode.INVALID_VECTORIZE_VALUE_TYPE,
-                ErrorCode.INVALID_VECTORIZE_VALUE_TYPE.getMessage()
-                    + ", issue in document at position "
-                    + (position + 1));
+            throw ErrorCode.INVALID_VECTORIZE_VALUE_TYPE.toApiException(
+                "issue in document at position %s", (position + 1));
           }
 
           String vectorizeData = jsonNode.asText();
@@ -230,7 +224,7 @@ public class DataVectorizer {
                 if (unsetNode != null
                     && unsetNode.has(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
                   if (unsetNode.has(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
-                    throw new JsonApiException(ErrorCode.INVALID_USAGE_OF_VECTORIZE);
+                    throw ErrorCode.INVALID_USAGE_OF_VECTORIZE.toApiException();
                   }
                   unsetNode.putNull(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD);
                 }
@@ -245,7 +239,7 @@ public class DataVectorizer {
     if (node == null) return Uni.createFrom().item(true);
     if (node.has(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
       if (node.has(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
-        throw new JsonApiException(ErrorCode.INVALID_USAGE_OF_VECTORIZE);
+        throw ErrorCode.INVALID_USAGE_OF_VECTORIZE.toApiException();
       }
       final JsonNode jsonNode = node.get(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD);
       if (jsonNode.isNull()) {
@@ -290,8 +284,7 @@ public class DataVectorizer {
         }
 
       } else {
-        throw new JsonApiException(
-            ErrorCode.SHRED_BAD_VECTORIZE_VALUE, ErrorCode.SHRED_BAD_VECTORIZE_VALUE.getMessage());
+        throw ErrorCode.SHRED_BAD_VECTORIZE_VALUE.toApiException();
       }
     }
     return Uni.createFrom().item(true);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CollectionReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CollectionReadOperation.java
@@ -431,7 +431,7 @@ public interface CollectionReadOperation extends CollectionOperation {
 
   private void getCount(AsyncResultSet rs, Throwable error, AtomicLong counter) {
     if (error != null) {
-      throw new JsonApiException(ErrorCode.COUNT_READ_FAILED);
+      throw ErrorCode.COUNT_READ_FAILED.toApiException();
     } else {
       counter.addAndGet(rs.remaining());
       if (rs.hasMorePages()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperation.java
@@ -358,7 +358,7 @@ public record CreateCollectionOperation(
     if (collectionCount >= MAX_COLLECTIONS) {
       throw ErrorCode.TOO_MANY_COLLECTIONS.toApiException(
           "number of collections in database cannot exceed %d, already have %d",
-          ErrorCode.TOO_MANY_COLLECTIONS.getMessage(), MAX_COLLECTIONS, collectionCount);
+          MAX_COLLECTIONS, collectionCount);
     }
     // And then see how many Indexes have been created, how many available
     int saisUsed = allTables.stream().mapToInt(table -> table.getIndexes().size()).sum();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperation.java
@@ -119,10 +119,9 @@ public record CreateCollectionOperation(
     if (currKeyspace == null) {
       return Uni.createFrom()
           .failure(
-              new JsonApiException(
-                  ErrorCode.NAMESPACE_DOES_NOT_EXIST,
-                  "INVALID_ARGUMENT: Unknown namespace '%s', you must create it first."
-                      .formatted(commandContext.schemaObject().name.keyspace())));
+              ErrorCode.NAMESPACE_DOES_NOT_EXIST.toApiException(
+                  "Unknown namespace '%s', you must create it first",
+                  commandContext.schemaObject().name.keyspace()));
     }
     TableMetadata table = findTableAndValidateLimits(allKeyspaces, currKeyspace, name);
 
@@ -357,11 +356,9 @@ public record CreateCollectionOperation(
     final long collectionCount = allTables.stream().filter(COLLECTION_MATCHER).count();
     final int MAX_COLLECTIONS = dbLimitsConfig.maxCollections();
     if (collectionCount >= MAX_COLLECTIONS) {
-      throw new JsonApiException(
-          ErrorCode.TOO_MANY_COLLECTIONS,
-          String.format(
-              "%s: number of collections in database cannot exceed %d, already have %d",
-              ErrorCode.TOO_MANY_COLLECTIONS.getMessage(), MAX_COLLECTIONS, collectionCount));
+      throw ErrorCode.TOO_MANY_COLLECTIONS.toApiException(
+          "number of collections in database cannot exceed %d, already have %d",
+          ErrorCode.TOO_MANY_COLLECTIONS.getMessage(), MAX_COLLECTIONS, collectionCount);
     }
     // And then see how many Indexes have been created, how many available
     int saisUsed = allTables.stream().mapToInt(table -> table.getIndexes().size()).sum();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperation.java
@@ -306,10 +306,8 @@ public record FindCollectionOperation(
     if (vector() != null && !vectorEnabled) {
       return Uni.createFrom()
           .failure(
-              new JsonApiException(
-                  ErrorCode.VECTOR_SEARCH_NOT_SUPPORTED,
-                  ErrorCode.VECTOR_SEARCH_NOT_SUPPORTED.getMessage()
-                      + commandContext().schemaObject().name.table()));
+              ErrorCode.VECTOR_SEARCH_NOT_SUPPORTED.toApiException(
+                  "%s", commandContext().schemaObject().name.table()));
     }
     // get FindResponse
     return getDocuments(dataApiRequestInfo, queryExecutor, pageState(), null)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionsCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionsCollectionOperation.java
@@ -10,7 +10,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateCollectionCommand;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSchemaObject;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.KeyspaceSchemaObject;
@@ -65,10 +64,9 @@ public record FindCollectionsCollectionOperation(
     if (keyspaceMetadata == null) {
       return Uni.createFrom()
           .failure(
-              new JsonApiException(
-                  ErrorCode.NAMESPACE_DOES_NOT_EXIST,
-                  "Unknown namespace %s, you must create it first."
-                      .formatted(commandContext.schemaObject().name.keyspace())));
+              ErrorCode.NAMESPACE_DOES_NOT_EXIST.toApiException(
+                  "Unknown namespace '%s', you must create it first",
+                  commandContext.schemaObject().name.keyspace()));
     }
     return Uni.createFrom()
         .item(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/IDCollectionFilter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/IDCollectionFilter.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.base.Preconditions;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.serializer.CQLBindValues;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltCondition;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltConditionPredicate;
@@ -86,9 +85,8 @@ public class IDCollectionFilter extends CollectionFilter {
                   BuiltConditionPredicate.NEQ,
                   new JsonTerm(DOC_ID, strId)));
         } else {
-          throw new JsonApiException(
-              ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-              String.format("Unsupported $ne operand value : %s", documentId.value()));
+          throw ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE.toApiException(
+              "Unsupported $ne operand value: %s", documentId.value());
         }
       case IN:
         if (values.isEmpty()) return List.of();
@@ -103,9 +101,8 @@ public class IDCollectionFilter extends CollectionFilter {
                 })
             .collect(Collectors.toList());
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_OPERATION,
-            String.format("Unsupported id column operation %s", operator));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "Unsupported id column operation %s", operator);
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/InCollectionFilter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/InCollectionFilter.java
@@ -6,7 +6,6 @@ import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltCondition;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltConditionPredicate;
 import io.stargate.sgv2.jsonapi.service.operation.builder.ConditionLHS;
@@ -160,18 +159,16 @@ public class InCollectionFilter extends CollectionFilter {
                         new JsonTerm(DOC_ID, strId));
                 conditions.add(condition);
               } else {
-                throw new JsonApiException(
-                    ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-                    String.format("Unsupported _id $nin operand value: %s", docIdValue));
+                throw ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE.toApiException(
+                    "Unsupported _id $nin operand value: %s", docIdValue);
               }
             }
           }
           return conditions;
         }
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_OPERATION,
-            String.format("Unsupported %s column operation %s", getPath(), operator));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "Unsupported %s column operation %s", getPath(), operator);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/MapCollectionFilter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/MapCollectionFilter.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.service.operation.filters.collection;
 import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields.DATA_CONTAINS;
 
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltCondition;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltConditionPredicate;
 import io.stargate.sgv2.jsonapi.service.operation.builder.ConditionLHS;
@@ -130,9 +129,8 @@ public abstract class MapCollectionFilter<T> extends CollectionFilter {
             BuiltConditionPredicate.LTE,
             new JsonTerm(key, value));
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_OPERATION,
-            String.format("Unsupported map operation %s on column %s", operator, columnName));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "Map operation '%s' on column '%s'", operator, columnName);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/SetCollectionFilter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/collection/SetCollectionFilter.java
@@ -1,7 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.operation.filters.collection;
 
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltCondition;
 import io.stargate.sgv2.jsonapi.service.operation.builder.BuiltConditionPredicate;
 import io.stargate.sgv2.jsonapi.service.operation.builder.ConditionLHS;
@@ -55,9 +54,8 @@ public abstract class SetCollectionFilter<T> extends CollectionFilter {
             BuiltConditionPredicate.NOT_CONTAINS,
             new JsonTerm(value));
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_OPERATION,
-            String.format("Unsupported set operation %s on column %s", operator, columnName));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "Set operation '%s' on column '%s'", operator, columnName);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
@@ -213,13 +213,8 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
             "The 'dimension' can not be null if 'service' is not provided");
       }
       if (vectorDimension > documentLimitsConfig.maxVectorEmbeddingLength()) {
-        throw new JsonApiException(
-            ErrorCode.VECTOR_SEARCH_TOO_BIG_VALUE,
-            String.format(
-                "%s: %d (max %d)",
-                ErrorCode.VECTOR_SEARCH_TOO_BIG_VALUE.getMessage(),
-                vectorDimension,
-                documentLimitsConfig.maxVectorEmbeddingLength()));
+        throw ErrorCode.VECTOR_SEARCH_TOO_BIG_VALUE.toApiException(
+            "%d (max %d)", vectorDimension, documentLimitsConfig.maxVectorEmbeddingLength());
       }
     }
     return vector;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/matcher/FilterableResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/matcher/FilterableResolver.java
@@ -7,7 +7,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.*;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.filters.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.filters.collection.*;
 import io.stargate.sgv2.jsonapi.service.shredding.collections.DocValueHasher;
@@ -149,13 +148,9 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
     }
     LogicalExpression filter = matchRules.apply(commandContext, command);
     if (filter.getTotalComparisonExpressionCount() > operationsConfig.maxFilterObjectProperties()) {
-      throw new JsonApiException(
-          ErrorCode.FILTER_FIELDS_LIMIT_VIOLATION,
-          String.format(
-              "%s: filter has %d fields, exceeds maximum allowed %s",
-              ErrorCode.FILTER_FIELDS_LIMIT_VIOLATION.getMessage(),
-              filter.getTotalComparisonExpressionCount(),
-              operationsConfig.maxFilterObjectProperties()));
+      throw ErrorCode.FILTER_FIELDS_LIMIT_VIOLATION.toApiException(
+          "filter has %d fields, exceeds maximum allowed %s",
+          filter.getTotalComparisonExpressionCount(), operationsConfig.maxFilterObjectProperties());
     }
     return filter;
   }
@@ -200,10 +195,8 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
                     (DocumentId) filterOperation.operand().value()));
             break;
           default:
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-                String.format(
-                    "Unsupported filter operator %s ", filterOperation.operator().getOperator()));
+            throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+                "%s", filterOperation.operator().getOperator());
         }
       }
       if (captureExpression.marker() == ID_GROUP_IN) {
@@ -222,10 +215,8 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
                     (List<Object>) filterOperation.operand().value()));
             break;
           default:
-            throw new JsonApiException(
-                ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-                String.format(
-                    "Unsupported filter operator %s ", filterOperation.operator().getOperator()));
+            throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+                "%s", filterOperation.operator().getOperator());
         }
       }
 
@@ -371,9 +362,8 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
       case LTE:
         return MapCollectionFilter.Operator.LTE;
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-            String.format("Unsupported filter operator %s ", filterOperator.getOperator()));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "%s", filterOperator.getOperator());
     }
   }
 
@@ -385,9 +375,8 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
       case NIN:
         return InCollectionFilter.Operator.NIN;
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-            String.format("Unsupported filter operator %s ", filterOperator.getOperator()));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "%s", filterOperator.getOperator());
     }
   }
 
@@ -399,9 +388,8 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
       case NE:
         return SetCollectionFilter.Operator.NOT_CONTAINS;
       default:
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-            String.format("Unsupported filter operator %s ", filterOperator.getOperator()));
+        throw ErrorCode.UNSUPPORTED_FILTER_OPERATION.toApiException(
+            "%s", filterOperator.getOperator());
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocValueHasher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocValueHasher.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -205,8 +204,6 @@ public class DocValueHasher {
     } else if (value instanceof Byte b) {
       return booleanValue(Byte.compare(true_byte, b) == 0).hash();
     }
-    throw new JsonApiException(
-        ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE,
-        String.format("Unsupported filter data type %s", value.getClass()));
+    throw ErrorCode.UNSUPPORTED_FILTER_DATA_TYPE.toApiException("%s", value.getClass());
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentId.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentId.java
@@ -101,11 +101,9 @@ public interface DocumentId extends DocRowIdentifer {
           case "false":
             return fromBoolean(false);
         }
-        throw new JsonApiException(
-            ErrorCode.SHRED_BAD_DOCID_TYPE,
-            String.format(
-                "%s: Document Id type Boolean stored as invalid String '%s' (must be 'true' or 'false')",
-                ErrorCode.SHRED_BAD_DOCID_TYPE.getMessage(), documentIdAsText));
+        throw ErrorCode.SHRED_BAD_DOCID_TYPE.toApiException(
+            "Document Id type Boolean stored as invalid String '%s' (must be 'true' or 'false')",
+            documentIdAsText);
       }
       case NULL -> {
         return fromNull();
@@ -114,11 +112,9 @@ public interface DocumentId extends DocRowIdentifer {
         try {
           return fromNumber(new BigDecimal(documentIdAsText));
         } catch (NumberFormatException e) {
-          throw new JsonApiException(
-              ErrorCode.SHRED_BAD_DOCID_TYPE,
-              String.format(
-                  "%s: Document Id type Number stored as invalid String '%s' (not a valid Number)",
-                  ErrorCode.SHRED_BAD_DOCID_TYPE.getMessage(), documentIdAsText));
+          throw ErrorCode.SHRED_BAD_DOCID_TYPE.toApiException(
+              "Document Id type Number stored as invalid String '%s' (not a valid Number)",
+              documentIdAsText);
         }
       }
       case STRING -> {
@@ -129,15 +125,13 @@ public interface DocumentId extends DocRowIdentifer {
           long ts = Long.parseLong(documentIdAsText);
           return fromTimestamp(ts);
         } catch (NumberFormatException e) {
-          throw new JsonApiException(
-              ErrorCode.SHRED_BAD_DOCID_TYPE,
-              String.format(
-                  "%s: Document Id type Date stored as invalid String '%s' (needs to be Number)",
-                  ErrorCode.SHRED_BAD_DOCID_TYPE.getMessage(), documentIdAsText));
+          throw ErrorCode.SHRED_BAD_DOCID_TYPE.toApiException(
+              "Document Id type Date stored as invalid String '%s' (needs to be Number)",
+              documentIdAsText);
         }
       }
     }
-    throw new JsonApiException(ErrorCode.SHRED_BAD_DOCID_TYPE);
+    throw ErrorCode.SHRED_BAD_DOCID_TYPE.toApiException();
   }
 
   static DocumentId fromBoolean(boolean key) {
@@ -156,7 +150,7 @@ public interface DocumentId extends DocRowIdentifer {
   static DocumentId fromString(String key) {
     key = Objects.requireNonNull(key);
     if (key.isEmpty()) {
-      throw new JsonApiException(ErrorCode.SHRED_BAD_DOCID_EMPTY_STRING);
+      throw ErrorCode.SHRED_BAD_DOCID_EMPTY_STRING.toApiException();
     }
     return new StringId(key);
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -12,7 +12,6 @@ import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonProcessingMetricsReporter;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSchemaObject;
 import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import io.stargate.sgv2.jsonapi.util.JsonUtil;
@@ -317,7 +316,7 @@ public class DocumentShredder {
     }
     ArrayNode arr = (ArrayNode) value;
     if (arr.size() == 0) {
-      throw new JsonApiException(ErrorCode.SHRED_BAD_VECTOR_SIZE);
+      throw ErrorCode.SHRED_BAD_VECTOR_SIZE.toApiException();
     }
     callback.shredVector(path, arr);
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/WritableShreddedDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/WritableShreddedDocument.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.shredding.DocRowIdentifer;
 import io.stargate.sgv2.jsonapi.service.shredding.WritableDocRow;
 import io.stargate.sgv2.jsonapi.util.JsonUtil;
@@ -306,8 +305,7 @@ public record WritableShreddedDocument(
       for (int i = 0; i < vector.size(); i++) {
         JsonNode element = vector.get(i);
         if (!element.isNumber()) {
-          throw new JsonApiException(
-              ErrorCode.SHRED_BAD_VECTOR_VALUE, ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage());
+          throw ErrorCode.SHRED_BAD_VECTOR_VALUE.toApiException();
         }
         arrayVals[i] = element.floatValue();
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdater.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdater.java
@@ -6,7 +6,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperation;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import java.util.List;
 
@@ -85,7 +84,8 @@ public record DocumentUpdater(
     if (replaceDocumentId != null && idNode != null) {
       if (!JsonUtil.equalsOrdered(replaceDocumentId, idNode)) {
         // throw error id cannot be different
-        throw new JsonApiException(ErrorCode.DOCUMENT_REPLACE_DIFFERENT_DOCID);
+        throw ErrorCode.DOCUMENT_REPLACE_DIFFERENT_DOCID.toApiException(
+            "'%s' vs '%s'", idNode, replaceDocumentId);
       }
     }
     // In case there is no difference between document return modified as false, so db update

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
@@ -226,12 +226,8 @@ public class PathMatchLocator implements Comparable<PathMatchLocator> {
     String[] result = DOT.split(dotPath);
     for (String segment : result) {
       if (segment.isEmpty()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH,
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
-                + ": empty segment ('') in path '"
-                + dotPath
-                + "'");
+        throw ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.toApiException(
+            "empty segment ('') in path '%s'", dotPath);
       }
     }
     return result;
@@ -245,17 +241,12 @@ public class PathMatchLocator implements Comparable<PathMatchLocator> {
   }
 
   private JsonApiException cantCreatePropertyPath(String fullPath, String prop, JsonNode context) {
-    return new JsonApiException(
-        ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH,
-        String.format(
-            "%s: cannot create field ('%s') in path '%s'; only OBJECT nodes have properties (got %s)",
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage(),
-            prop,
-            fullPath,
-            context.getNodeType()));
+    return ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.toApiException(
+        "cannot create field ('%s') in path '%s'; only OBJECT nodes have properties (got %s)",
+        prop, fullPath, context.getNodeType());
   }
 
-  // Needed because Command Resolver unit tests rely in equality checks for Command equality
+  // Needed because Command Resolver unit tests rely on equality checks for Command equality
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -106,7 +106,7 @@ public class FilterClauseDeserializerTest {
           .satisfies(
               t -> {
                 assertThat(t.getMessage())
-                    .isEqualTo(
+                    .contains(
                         "Invalid filter expression, $gte operator must have `DATE` or `NUMBER` value");
               });
     }
@@ -403,7 +403,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$all operator must have `ARRAY` value");
+                assertThat(t.getMessage()).contains("$all operator must have `ARRAY` value");
               });
     }
 
@@ -418,7 +418,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$all operator must have at least one value");
+                assertThat(t.getMessage()).contains("$all operator must have at least one value");
               });
     }
 
@@ -502,7 +502,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$size operator must have integer");
+                assertThat(t.getMessage()).contains("$size operator must have integer");
               });
     }
 
@@ -518,7 +518,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$size operator must have integer");
+                assertThat(t.getMessage()).contains("$size operator must have integer");
               });
 
       String json1 =
@@ -531,7 +531,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$size operator must have integer");
+                assertThat(t.getMessage()).contains("$size operator must have integer");
               });
     }
 
@@ -546,7 +546,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$size operator must have integer value >= 0");
+                assertThat(t.getMessage()).contains("$size operator must have integer value >= 0");
               });
     }
 
@@ -1491,7 +1491,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$in operator must have `ARRAY`");
+                assertThat(t.getMessage()).contains("$in operator must have `ARRAY`");
               });
     }
 
@@ -1506,7 +1506,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$nin operator must have `ARRAY`");
+                assertThat(t.getMessage()).contains("$nin operator must have `ARRAY`");
               });
     }
 
@@ -1528,7 +1528,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$nin operator must have `ARRAY`");
+                assertThat(t.getMessage()).contains("$nin operator must have `ARRAY`");
               });
     }
 
@@ -1545,7 +1545,7 @@ public class FilterClauseDeserializerTest {
           .satisfies(
               t -> {
                 assertThat(t.getMessage())
-                    .isEqualTo(
+                    .contains(
                         "$in operator must have at most "
                             + operationsConfig.maxInOperatorValueSize()
                             + " values");
@@ -1565,7 +1565,7 @@ public class FilterClauseDeserializerTest {
           .satisfies(
               t -> {
                 assertThat(t.getMessage())
-                    .isEqualTo(
+                    .contains(
                         "$nin operator must have at most "
                             + operationsConfig.maxInOperatorValueSize()
                             + " values");

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -107,7 +107,7 @@ public class FilterClauseDeserializerTest {
               t -> {
                 assertThat(t.getMessage())
                     .contains(
-                        "Invalid filter expression, $gte operator must have `DATE` or `NUMBER` value");
+                        "Invalid filter expression: $gte operator must have `DATE` or `NUMBER` value");
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializerTest.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.api.model.command.deserializers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -251,7 +250,7 @@ class SortClauseDeserializerTest {
 
       Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, SortClause.class));
 
-      assertThat(throwable).isInstanceOf(JsonMappingException.class);
+      assertThat(throwable).isInstanceOf(JsonApiException.class);
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -306,7 +307,7 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
           .body("errors[0].errorCode", is("NAMESPACE_DOES_NOT_EXIST"))
           .body(
               "errors[0].message",
-              is("Unknown namespace should_not_be_there, you must create it first."));
+              containsString("Unknown namespace 'should_not_be_there', you must create it first"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -473,7 +473,7 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
           .body("errors[0].errorCode", is("DOCUMENT_REPLACE_DIFFERENT_DOCID"))
           .body(
               "errors[0].message",
-              is("The replace document and document resolved using filter have different _id"));
+              startsWith("The replace document and document resolved using filter have different _id"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -473,7 +473,8 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
           .body("errors[0].errorCode", is("DOCUMENT_REPLACE_DIFFERENT_DOCID"))
           .body(
               "errors[0].message",
-              startsWith("The replace document and document resolved using filter have different _id"));
+              startsWith(
+                  "The replace document and document resolved using filter have different _id"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -376,9 +376,9 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", is("$in operator must have `ARRAY`"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", containsString("$in operator must have `ARRAY`"));
     }
 
     @Test
@@ -401,9 +401,9 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", is("$nin operator must have `ARRAY`"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", containsString("$nin operator must have `ARRAY`"));
     }
 
     @Test
@@ -696,9 +696,9 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", is("$all operator must have `ARRAY` value"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", containsString("$all operator must have `ARRAY` value"));
     }
 
     @Test
@@ -772,9 +772,9 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", is("$size operator must have integer"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", containsString("$size operator must have integer"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
@@ -184,10 +184,9 @@ public class HttpStatusCodeIntegrationTest extends AbstractCollectionIntegration
              """;
       AnyOf<String> anyOf =
           AnyOf.anyOf(
-              endsWith("INVALID_ARGUMENT: Keyspace '%s' doesn't exist".formatted("badNamespace")),
+              endsWith("Keyspace '%s' doesn't exist".formatted("badNamespace")),
               endsWith(
-                  "INVALID_ARGUMENT: Unknown namespace '%s', you must create it first."
-                      .formatted("badNamespace")));
+                  "Unknown namespace '%s', you must create it first".formatted("badNamespace")));
       given()
           .headers(getHeaders())
           .contentType(ContentType.JSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InAndNinIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InAndNinIntegrationTest.java
@@ -466,9 +466,9 @@ class InAndNinIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("data", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", is("$in operator must have `ARRAY`"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", containsString("$in operator must have `ARRAY`"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/IndexingConfigIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/IndexingConfigIntegrationTest.java
@@ -423,7 +423,7 @@ public class IndexingConfigIntegrationTest extends AbstractCollectionIntegration
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
-              endsWith("_id is not indexed, you can only use $eq or $in as the operator"));
+              is("_id is not indexed: you can only use $eq or $in as the operator"));
     }
 
     @Test
@@ -510,7 +510,7 @@ public class IndexingConfigIntegrationTest extends AbstractCollectionIntegration
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
-              endsWith("_id is not indexed, you can only use $eq or $in as the operator"));
+              is("_id is not indexed: you can only use $eq or $in as the operator"));
       String filterData3 =
           """
                       {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/IndexingConfigIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/IndexingConfigIntegrationTest.java
@@ -419,12 +419,11 @@ public class IndexingConfigIntegrationTest extends AbstractCollectionIntegration
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors[0].errorCode", is("ID_NOT_INDEXED"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
-              endsWith(
-                  "filter path '_id' is not indexed, you can only use $eq or $in as the operator"))
-          .body("errors[0].errorCode", is("ID_NOT_INDEXED"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+              endsWith("_id is not indexed, you can only use $eq or $in as the operator"));
     }
 
     @Test
@@ -507,12 +506,11 @@ public class IndexingConfigIntegrationTest extends AbstractCollectionIntegration
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
+          .body("errors[0].errorCode", is("ID_NOT_INDEXED"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
-              endsWith(
-                  "filter path '_id' is not indexed, you can only use $eq or $in as the operator"))
-          .body("errors[0].errorCode", is("ID_NOT_INDEXED"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+              endsWith("_id is not indexed, you can only use $eq or $in as the operator"));
       String filterData3 =
           """
                       {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RangeReadIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RangeReadIntegrationTest.java
@@ -230,7 +230,11 @@ public class RangeReadIntegrationTest extends AbstractCollectionIntegrationTestB
           .body(
               "errors[0].message",
               is("Invalid filter expression, $gt operator must have `DATE` or `NUMBER` value"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body(
+              "errors[0].errorCode",
+              is(
+                  "          .body(\"errors[0].errorCode\", is(\"INVALID_VECTORIZE_VALUE_TYPE\"))\n"
+                      + "          .body(\"errors[0].exceptionClass\", is(\"JsonApiException\"));\n"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RangeReadIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RangeReadIntegrationTest.java
@@ -229,12 +229,8 @@ public class RangeReadIntegrationTest extends AbstractCollectionIntegrationTestB
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              is("Invalid filter expression, $gt operator must have `DATE` or `NUMBER` value"))
-          .body(
-              "errors[0].errorCode",
-              is(
-                  "          .body(\"errors[0].errorCode\", is(\"INVALID_VECTORIZE_VALUE_TYPE\"))\n"
-                      + "          .body(\"errors[0].exceptionClass\", is(\"JsonApiException\"));\n"));
+              is("Invalid filter expression: $gt operator must have `DATE` or `NUMBER` value"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -2072,7 +2072,7 @@ public class UpdateOneIntegrationTest extends AbstractCollectionIntegrationTestB
           .body("errors[0].errorCode", is("UNSUPPORTED_UPDATE_OPERATION_PARAM"))
           .body(
               "errors[0].message",
-              is(
+              constainsString(
                   "Update operator path conflict due to overlap: 'root.array' ($unset) vs 'root.array.1' ($set)"));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 
 import static io.restassured.RestAssured.given;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -2072,7 +2073,7 @@ public class UpdateOneIntegrationTest extends AbstractCollectionIntegrationTestB
           .body("errors[0].errorCode", is("UNSUPPORTED_UPDATE_OPERATION_PARAM"))
           .body(
               "errors[0].message",
-              constainsString(
+              containsString(
                   "Update operator path conflict due to overlap: 'root.array' ($unset) vs 'root.array.1' ($set)"));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -1071,7 +1071,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
           .body(
               "errors[0].message",
-              is(
+              containsString(
                   "Cannot filter on '$vector' field using operator '$eq': only '$exists' is supported"));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -263,12 +263,12 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("INVALID_VECTORIZE_VALUE_TYPE"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
               startsWith(
-                  "$vectorize value needs to be text value, issue in document at position 1"))
-          .body("errors[0].errorCode", is("INVALID_VECTORIZE_VALUE_TYPE"))
-          .body("errors[0].exceptionClass", is("JsonApiException"));
+                  "$vectorize value needs to be text value: issue in document at position 1"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCacheTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/NamespaceCacheTest.java
@@ -364,7 +364,8 @@ public class NamespaceCacheTest {
               s -> {
                 assertThat(s.getErrorCode()).isEqualTo(ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA);
                 assertThat(s.getMessage())
-                    .isEqualTo(ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA.getMessage() + "table");
+                    .isEqualTo(
+                        ErrorCode.INVALID_JSONAPI_COLLECTION_SCHEMA.getMessage() + ": table");
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
@@ -120,7 +120,7 @@ public class DataVectorizerTest {
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_VECTORIZE_VALUE_TYPE)
             .hasFieldOrPropertyWithValue(
                 "message",
-                "$vectorize value needs to be text value, issue in document at position 1");
+                "$vectorize value needs to be text value: issue in document at position 1");
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
@@ -331,7 +331,8 @@ public class DocumentUpdaterTest {
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
-          .hasMessage("Update operators '$set' and '$unset' must not refer to same path: 'common'");
+          .hasMessageContaining(
+              "update operators '$set' and '$unset' must not refer to same path: 'common'");
     }
 
     @Test
@@ -348,7 +349,8 @@ public class DocumentUpdaterTest {
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
-          .hasMessage("Update operators '$inc' and '$mul' must not refer to same path: 'root.x'");
+          .hasMessageContaining(
+              "update operators '$inc' and '$mul' must not refer to same path: 'root.x'");
     }
 
     @Test
@@ -363,7 +365,7 @@ public class DocumentUpdaterTest {
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
-          .hasMessage(
+          .hasMessageContaining(
               "Update operator path conflict due to overlap: 'root' ($set) vs 'root.1' ($set)");
     }
 
@@ -389,7 +391,7 @@ public class DocumentUpdaterTest {
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
-          .hasMessage(
+          .hasMessageContaining(
               "Update operator path conflict due to overlap: 'root' ($set) vs 'root.a' ($set)");
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/ExceptionUtilTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/ExceptionUtilTest.java
@@ -6,7 +6,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
-import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.shredding.collections.DocumentId;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
 import java.util.List;
@@ -19,7 +18,7 @@ public class ExceptionUtilTest {
   @Test
   public void checkKey() {
     String key =
-        ExceptionUtil.getThrowableGroupingKey(new JsonApiException(ErrorCode.CONCURRENCY_FAILURE));
+        ExceptionUtil.getThrowableGroupingKey(ErrorCode.CONCURRENCY_FAILURE.toApiException());
     assertThat(key).isNotNull();
     assertThat(key).isEqualTo(ErrorCode.CONCURRENCY_FAILURE.name());
 
@@ -33,7 +32,7 @@ public class ExceptionUtilTest {
     String message = "test error for ids %s: %s";
     List<DocumentId> ids = List.of(DocumentId.fromString("doc1"), DocumentId.fromString("doc2"));
 
-    Exception throwable = new JsonApiException(ErrorCode.CONCURRENCY_FAILURE);
+    Exception throwable = ErrorCode.CONCURRENCY_FAILURE.toApiException();
     CommandResult.Error error = ExceptionUtil.getError(message, ids, throwable);
     assertThat(error).isNotNull();
     assertThat(error)


### PR DESCRIPTION
**What this PR does**:

Unifies existing construction of `JsonApiException` instances using `ErrorCode.toApiException()` pattern: this ensures proper construction of detail message and makes it easier to find calls for further work on improving error reporting.

**Which issue(s) this PR fixes**:
Fixes #1283

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
