### PR TITLE
update openjdk base image

### DIFF
--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -3,7 +3,7 @@
 # based on less minimal UBI8 OpenJDK 17 image
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.19
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.20
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.19
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
Updates the OpenJDK base image used for Data API images to version 1.20

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
