### PR TITLE
Fixes #1332: separate out ErrorCode.VECTOR_SIZE_MISMATCH from INVALID_QUERY

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -145,6 +145,7 @@ public enum ErrorCode {
   VECTOR_SEARCH_INVALID_FUNCTION_NAME("Invalid vector search function name"),
 
   VECTOR_SEARCH_TOO_BIG_VALUE("Vector embedding property '$vector' length too big"),
+  VECTOR_SIZE_MISMATCH("Length of vector parameter different from declared '$vector' dimension"),
 
   VECTORIZE_FEATURE_NOT_AVAILABLE("Vectorize feature is not available in the environment"),
   VECTORIZE_SERVICE_NOT_REGISTERED("Vectorize service name provided is not registered : "),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
@@ -161,11 +161,11 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
     DebugModeConfig debugModeConfig = config.getConfigMapping(DebugModeConfig.class);
     final boolean debugEnabled = debugModeConfig.enabled();
     final boolean extendError = config.getConfigMapping(OperationsConfig.class).extendError();
-    Map<String, Object> fields = null;
+    Map<String, Object> fields;
 
     if (extendError) {
       fields =
-          new HashMap<String, Object>(
+          new HashMap<>(
               Map.of(
                   "id",
                   id,
@@ -178,7 +178,7 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
                   "title",
                   title));
     } else {
-      fields = new HashMap<String, Object>(Map.of("errorCode", errorCode.name()));
+      fields = new HashMap<>(Map.of("errorCode", errorCode.name()));
     }
 
     if (debugEnabled) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -154,7 +154,7 @@ public final class ThrowableToErrorMapper {
           .getCommandResultError(ErrorCode.NO_INDEX_ERROR.getMessage(), Response.Status.OK);
     }
     if (message.contains("vector<float,")) {
-      // Alas, it is tricky to find the actual vector dimension from the message
+      // It is tricky to find the actual vector dimension from the message, include as-is
       return ErrorCode.VECTOR_SIZE_MISMATCH
           .toApiException("root cause = (%s) %s", throwable.getClass().getSimpleName(), message)
           .getCommandResultError(Response.Status.OK);

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -153,11 +153,15 @@ public final class ThrowableToErrorMapper {
           .toApiException()
           .getCommandResultError(ErrorCode.NO_INDEX_ERROR.getMessage(), Response.Status.OK);
     }
-    String errorMessage =
-        message.contains("vector<float,") ? "Mismatched vector dimension" : message;
+    if (message.contains("vector<float,")) {
+      // Alas, it is tricky to find the actual vector dimension from the message
+      return ErrorCode.VECTOR_SIZE_MISMATCH
+          .toApiException("root cause = (%s) %s", throwable.getClass().getSimpleName(), message)
+          .getCommandResultError(Response.Status.OK);
+    }
     return ErrorCode.INVALID_QUERY
         .toApiException()
-        .getCommandResultError(errorMessage, Response.Status.OK);
+        .getCommandResultError(message, Response.Status.OK);
   }
 
   /** Driver AllNodesFailedException a composite exception, peeling the errors from it */

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -1621,7 +1621,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
-          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Length of vector parameter different from declared '$vector' dimension: root cause ="));
 
       // Insert data with $vector array size greater than vector index defined size.
       final String vectorStrCount7 = buildVectorElements(0, 7);
@@ -1650,7 +1653,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
-          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Length of vector parameter different from declared '$vector' dimension: root cause ="));
     }
 
     @Test
@@ -1681,7 +1687,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
-          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Length of vector parameter different from declared '$vector' dimension: root cause ="));
 
       // Insert data with $vector array size greater than vector index defined size.
       final String vectorStrCount7 = buildVectorElements(0, 7);
@@ -1708,7 +1717,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
-          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Length of vector parameter different from declared '$vector' dimension: root cause ="));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -985,7 +985,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void failWithZerosVector() {
       String json =
           """
@@ -1016,7 +1016,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     public void failWithInvalidVectorElements() {
       String json =
           """
@@ -1045,7 +1045,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     // Vector columns can only use ANN, not regular filtering
     @Test
-    @Order(6)
+    @Order(7)
     public void failWithVectorFilter() {
       String json =
           """
@@ -1619,8 +1619,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, vectorSizeTestCollectionName)
           .then()
           .statusCode(200)
-          .body("errors", is(notNullValue()))
-          .body("errors[0].message", endsWith("Mismatched vector dimension"));
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
+          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
 
       // Insert data with $vector array size greater than vector index defined size.
       final String vectorStrCount7 = buildVectorElements(0, 7);
@@ -1647,8 +1648,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, vectorSizeTestCollectionName)
           .then()
           .statusCode(200)
-          .body("errors", is(notNullValue()))
-          .body("errors[0].message", endsWith("Mismatched vector dimension"));
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
+          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
     }
 
     @Test
@@ -1677,8 +1679,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, vectorSizeTestCollectionName)
           .then()
           .statusCode(200)
-          .body("errors", is(notNullValue()))
-          .body("errors[0].message", endsWith("Mismatched vector dimension"));
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
+          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
 
       // Insert data with $vector array size greater than vector index defined size.
       final String vectorStrCount7 = buildVectorElements(0, 7);
@@ -1703,8 +1706,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, vectorSizeTestCollectionName)
           .then()
           .statusCode(200)
-          .body("errors", is(notNullValue()))
-          .body("errors[0].message", endsWith("Mismatched vector dimension"));
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
+          .body("errors[0].message", startsWith("Length of vector parameter different from declared '$vector' dimension: root cause ="));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Separates out new `ErrorCode`, `VECTOR_SIZE_MISMATCH` out of generic `INVALID_QUERY`; improves message slightly. But mostly helps with metrics dashboard to spell out actual issue.

**Which issue(s) this PR fixes**:
Fixes #1332

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
