### PR TITLE
Fix jar publishing workflows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,4 +333,18 @@
       </properties>
     </profile>
   </profiles>
+  <distributionManagement>
+    <repository>
+      <uniqueVersion>false</uniqueVersion>
+      <id>stargate-central</id>
+      <name>stargate-releases</name>
+      <url>https://repo.datastax.com/artifactory/stargate-private</url>
+    </repository>
+    <snapshotRepository>
+      <uniqueVersion>false</uniqueVersion>
+      <id>stargate-snapshots</id>
+      <name>stargate-snapshots</name>
+      <url>https://repo.datastax.com/artifactory/stargate-private</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
In #1330 we removed the offline code and logic to publish Data API jar to private maven repo. We had originally intended to start publishing the jar to a public repo in #1331, but there are no known use cases that would rely on this, so we decided to stick with current approach of publishing to private repo. This PR restores the `distributionManagement` section to the pom so that Maven knows where to publish the jar.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
