### PR TITLE
(WIP) Allow use of `_id` for "insertOne"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/InsertTableOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/InsertTableOperation.java
@@ -1,8 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.operation.tables;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.*;
-
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.insert.InsertInto;
 import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
 import io.smallrye.mutiny.Multi;
@@ -94,7 +93,7 @@ public class InsertTableOperation extends TableMutationOperation {
       QueryExecutor queryExecutor, TableInsertAttempt insertAttempt) {
 
     InsertInto insertInto =
-        insertInto(
+        QueryBuilder.insertInto(
             commandContext.schemaObject().tableMetadata.getKeyspace(),
             commandContext.schemaObject().tableMetadata.getName());
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
@@ -58,8 +58,9 @@ public class RowShredder {
             .map(ColumnMetadata::getName)
             .map(
                 colIdentifier -> {
-                  if (columnValues.containsKey(colIdentifier)) {
-                    return columnValues.get(colIdentifier);
+                  Object value = columnValues.get(colIdentifier);
+                  if (value != null) {
+                    return value;
                   }
                   throw new UnvalidatedClauseException(
                       String.format(


### PR DESCRIPTION
**What this PR does**:

Fix the issue with unquoted `_id` for "insertOne" (see #1334)

**Which issue(s) this PR fixes**:
Fixes #1334

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
