### PR TITLE
Fix find command limit option for tables

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindCommandResolver.java
@@ -83,7 +83,7 @@ public class FindCommandResolver implements CommandResolver<FindCommand> {
         TableWhereCQLClause.forSelect(
             ctx.schemaObject(), tableFilterResolver.resolve(ctx, command)),
         tableRowProjection,
-        new FindTableOperation.FindTableParams(Integer.MAX_VALUE));
+        new FindTableOperation.FindTableParams(limit));
   }
 
   @Override


### PR DESCRIPTION
**What this PR does**:
Fix `find` command `limit` option for tables

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
