### PR TITLE
Fixes #1343: Upgrade Jackson to 2.17(.2) from 2.16(.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
   <properties>
     <stargate.version>${project.parent.version}</stargate.version>
     <!-- 17-May-2023, tatu: [json-api#172] Need at least Jackson 2.15.x -->
-    <!-- 16-Nov-2023, tatu: but may use 2.16 now that it's available -->
-    <jackson.version>2.16.2</jackson.version>
+    <!-- 16-Aug-2024, tatu: Quarkus depends on 2.17 already, but keep explicit -->
+    <jackson.version>2.17.2</jackson.version>
     <!-- 14-Aug-2024, tatu: override here until Stargate gets to this version too -->
     <quarkus.platform.version>3.13.2</quarkus.platform.version>
     <wiremock.version>3.4.2</wiremock.version>


### PR DESCRIPTION
**What this PR does**:
Upgrades Jackson to 2.17.2 to align with version Quarkus (3.13) expects; also may get some performance improvement wrt Vector reads/writes (JSON FP codec improvements).

**Which issue(s) this PR fixes**:
Fixes #1343

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
