### PR TITLE
Fix CreateTableOperation identifier issue, add several table ITs.

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/CreateTableOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/CreateTableOperation.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.operation.tables;
 
 import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.*;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder;
@@ -55,9 +56,10 @@ public class CreateTableOperation implements Operation {
   @Override
   public Uni<Supplier<CommandResult>> execute(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
-    String keyspaceQuoted = "\"%s\"".formatted(commandContext.schemaObject().name.keyspace());
-    String tableNameQuoted = "\"%s\"".formatted(tableName);
-    CreateTableStart create = createTable(keyspaceQuoted, tableNameQuoted).ifNotExists();
+    CqlIdentifier keyspaceIdentifier =
+        CqlIdentifier.fromInternal(commandContext.schemaObject().name.keyspace());
+    CqlIdentifier tableIdentifier = CqlIdentifier.fromInternal(tableName);
+    CreateTableStart create = createTable(keyspaceIdentifier, tableIdentifier).ifNotExists();
 
     // Add all primary keys and colunms
     CreateTable createTable = addColumnsAndKeys(create);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/CreateTableOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/CreateTableOperation.java
@@ -55,9 +55,9 @@ public class CreateTableOperation implements Operation {
   @Override
   public Uni<Supplier<CommandResult>> execute(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
-
-    CreateTableStart create =
-        createTable(commandContext.schemaObject().name.keyspace(), tableName).ifNotExists();
+    String keyspaceQuoted = "\"%s\"".formatted(commandContext.schemaObject().name.keyspace());
+    String tableNameQuoted = "\"%s\"".formatted(tableName);
+    CreateTableStart create = createTable(keyspaceQuoted, tableNameQuoted).ifNotExists();
 
     // Add all primary keys and colunms
     CreateTable createTable = addColumnsAndKeys(create);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/AbstractTableIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/AbstractTableIntegrationTestBase.java
@@ -1,0 +1,68 @@
+package io.stargate.sgv2.jsonapi.api.v1.tableIntegrationTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.api.v1.AbstractNamespaceIntegrationTestBase;
+import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
+
+/** Abstract class for all table int tests that needs a collection to execute tests in. */
+public class AbstractTableIntegrationTestBase extends AbstractNamespaceIntegrationTestBase {
+
+  protected void createTable(String tableName, String createTableJSON) {
+    given()
+        .port(getTestPort())
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(createTableJSON.formatted().formatted(tableName))
+        .when()
+        .post(NamespaceResource.BASE_PATH, namespaceName)
+        .then()
+        .statusCode(200);
+  }
+
+  protected void createTable(String createTableJSON) {
+    given()
+        .port(getTestPort())
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(createTableJSON)
+        .when()
+        .post(NamespaceResource.BASE_PATH, namespaceName)
+        .then()
+        .statusCode(200)
+        .body("status.ok", is(1));
+  }
+
+  protected void deleteAllRowsFromTable(String tableName) {
+    String json =
+        """
+                {
+                  "deleteMany": {
+                  }
+                }
+                """;
+
+    while (true) {
+      Boolean moreData =
+          given()
+              .headers(getHeaders())
+              .contentType(ContentType.JSON)
+              .body(json)
+              .when()
+              .post(CollectionResource.BASE_PATH, namespaceName, tableName)
+              .then()
+              .statusCode(200)
+              .body("errors", is(nullValue()))
+              .extract()
+              .path("status.moreData");
+
+      if (!Boolean.TRUE.equals(moreData)) {
+        break;
+      }
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/AddTableIndexIntegrationTest.java
@@ -1,0 +1,106 @@
+package io.stargate.sgv2.jsonapi.api.v1.tableIntegrationTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.*;
+
+@QuarkusIntegrationTest
+@WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+// TODO, it is currently called AddIndex, do we want to change to createIndex
+class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
+  String simpleTableName = "simpleTableForAddIndexTest";
+
+  @BeforeAll
+  public final void createSimpleTable() {
+    String tableJson =
+            """
+                          {
+                              "createTable": {
+                                  "name": "%s",
+                                  "definition": {
+                                      "columns": {
+                                          "id": {
+                                              "type": "text"
+                                          },
+                                          "age": {
+                                              "type": "int"
+                                          },
+                                          "name": {
+                                              "type": "text"
+                                          }
+                                      },
+                                      "primaryKey": "id"
+                                  }
+                              }
+                          }
+                    """
+            .formatted(simpleTableName);
+    createTable(tableJson);
+  }
+
+  @Nested
+  @Order(1)
+  class addIndexSuccess {
+
+    @Test
+    @Order(1)
+    public void addIndex() {
+      String json =
+          """
+                      {
+                          "addIndex": {
+                              "column": "age",
+                              "indexName": "age_index"
+                          }
+                      }
+                      """;
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, simpleTableName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+    }
+  }
+
+  @Nested
+  @Order(2)
+  class addIndexFailure {
+    @Test
+    public void addIndex() {
+      String json =
+          """
+                      {
+                          "addIndex": {
+                              "column": "city",
+                              "indexName": "city_index"
+                          }
+                      }
+                      """;
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, simpleTableName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(notNullValue()))
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_QUERY"))
+          .body("errors[0].message", containsString("Undefined column name city"));
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/AddTableIndexIntegrationTest.java
@@ -48,7 +48,7 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
 
   @Nested
   @Order(1)
-  class addIndexSuccess {
+  class AddIndexSuccess {
 
     @Test
     @Order(1)
@@ -76,7 +76,7 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
 
   @Nested
   @Order(2)
-  class addIndexFailure {
+  class AddIndexFailure {
     @Test
     public void addIndex() {
       String json =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/CreateTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/CreateTableIntegrationTest.java
@@ -1,0 +1,126 @@
+package io.stargate.sgv2.jsonapi.api.v1.tableIntegrationTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.api.v1.AbstractNamespaceIntegrationTestBase;
+import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.Test;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestClassOrder;
+
+@QuarkusIntegrationTest
+@WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+class CreateTableIntegrationTest extends AbstractNamespaceIntegrationTestBase {
+
+  @Nested
+  @Order(1)
+  class CreateTable {
+    @Test
+    public void primaryKeyAsString() {
+      String json =
+          """
+                            {
+                                 "createTable": {
+                                     "name": "primaryKeyAsStringTable",
+                                     "definition": {
+                                         "columns": {
+                                             "id": {
+                                                 "type": "text"
+                                             },
+                                             "age": {
+                                                 "type": "int"
+                                             },
+                                             "name": {
+                                                 "type": "text"
+                                             }
+                                         },
+                                         "primaryKey": "id"
+                                     }
+                                 }
+                             }
+                    """;
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+      deleteTable("primaryKeyAsStringTable");
+    }
+
+    @Test
+    public void primaryKeyAsJsonObject() {
+
+      String json =
+          """
+                        {
+                            "createTable": {
+                                "name": "primaryKeyAsJsonObjectTable",
+                                "definition": {
+                                    "columns": {
+                                        "id": {
+                                            "type": "text"
+                                        },
+                                        "age": {
+                                            "type": "int"
+                                        },
+                                        "name": {
+                                            "type": "text"
+                                        }
+                                    },
+                                    "primaryKey": {
+                                        "partitionBy": [
+                                            "id"
+                                        ],
+                                        "partitionSort" : {
+                                            "name" : 1, "age" : -1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    """;
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+      deleteTable("primaryKeyAsJsonObjectTable");
+    }
+  }
+
+  private void deleteTable(String tableName) {
+    given()
+        .headers(getHeaders())
+        .contentType(ContentType.JSON)
+        .body(
+                """
+                                {
+                                  "deleteTable": {
+                                    "name": "%s"
+                                  }
+                                }
+                                """
+                .formatted(tableName))
+        .when()
+        .post(NamespaceResource.BASE_PATH, namespaceName)
+        .then()
+        .statusCode(200)
+        .body("status.ok", is(1));
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/DropTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/DropTableIndexIntegrationTest.java
@@ -1,0 +1,93 @@
+package io.stargate.sgv2.jsonapi.api.v1.tableIntegrationTest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.*;
+
+@QuarkusIntegrationTest
+@WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+class DropTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
+
+  String simpleTableName = "simpleTableForDropIndexTest";
+
+  @BeforeAll
+  public final void createSimpleTable() {
+    String tableJson =
+            """
+                              {
+                                  "createTable": {
+                                      "name": "%s",
+                                      "definition": {
+                                          "columns": {
+                                              "id": {
+                                                  "type": "text"
+                                              },
+                                              "age": {
+                                                  "type": "int"
+                                              },
+                                              "name": {
+                                                  "type": "text"
+                                              }
+                                          },
+                                          "primaryKey": "id"
+                                      }
+                                  }
+                              }
+                        """
+            .formatted(simpleTableName);
+    createTable(tableJson);
+  }
+
+  @Nested
+  @Order(1)
+  class dropIndexSuccess {
+
+    @Test
+    @Order(1)
+    public void dropIndex() {
+      String addIndexJson =
+          """
+                                {
+                                    "addIndex": {
+                                        "column": "age",
+                                        "indexName": "age_index"
+                                    }
+                                }
+                                """;
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(addIndexJson)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, simpleTableName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      String dropIndexJson =
+          """
+                                {
+                                    "dropIndex": {
+                                        "indexName": "age_index"
+                                    }
+                                }
+                                """;
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body(dropIndexJson)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, simpleTableName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/DropTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tableIntegrationTest/DropTableIndexIntegrationTest.java
@@ -47,7 +47,7 @@ class DropTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
 
   @Nested
   @Order(1)
-  class dropIndexSuccess {
+  class DropIndexSuccess {
 
     @Test
     @Order(1)

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -71,6 +71,7 @@ public class DseTestResource extends StargateTestResource {
     ImmutableMap.Builder<String, String> propsBuilder = ImmutableMap.builder();
     propsBuilder.putAll(env);
     propsBuilder.put("stargate.jsonapi.custom.embedding.enabled", "true");
+    propsBuilder.put("stargate.tables.enabled", "true");
     propsBuilder.put(
         "stargate.jsonapi.custom.embedding.clazz",
         "io.stargate.sgv2.jsonapi.service.embedding.operation.test.CustomITEmbeddingProvider");


### PR DESCRIPTION
1. 
So in previous implementation of CreateTableOperation,
```
 public static CreateTableStart createTable(@Nullable String keyspace, @NonNull String tableName) {
        return createTable(keyspace == null ? null : CqlIdentifier.fromCql(keyspace), CqlIdentifier.fromCql(tableName));
    }
```
we are using createTable method from CQL Driver, which uses fromCql method to resolve identifier. This is a problematic, because if things are not quoted, driver will make them case-insensitive, to lower case.

e.g. 
keyspace in DB:  `Yuqi_Keyspace`
because of this string is not quoted, then CQL Driver decides to convert it to `yuqi_keyspace`, which does not exist.

So to be consistent with what we did for collection, I just added quote for keyspace and tableName in createTableCommand.

2.
Enable table feature in test resource

3. 
add AbstractTableIntegrationTestBase, add few ITs for table.



**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
