### PR TITLE
Added support for optional http_response_override yaml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,14 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <!-- Support for Optional used when loading error config seehttps://github.com/FasterXML/jackson-modules-java8/tree/2.18/datatypes -->
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfig.java
@@ -62,7 +62,7 @@ public class ErrorConfig {
   private Map<String, String> snippetVars;
 
   // Prefix used when adding snippets to the variables for a template.
-  private static final String SNIPPET_VAR_PREFIX = "SNIPPET.";
+  public static final String SNIPPET_VAR_PREFIX = "SNIPPET.";
 
   // TIDY: move this to the config sections
   public static final String DEFAULT_ERROR_CONFIG_FILE = "errors.yaml";
@@ -148,6 +148,15 @@ public class ErrorConfig {
         throw new IllegalArgumentException("body cannot be blank");
       }
     }
+
+    /**
+     * Name to use for this snippet when substituting into templates.
+     *
+     * @return
+     */
+    public String variableName(){
+      return SNIPPET_VAR_PREFIX + name;
+    }
   }
 
   /**
@@ -215,7 +224,7 @@ public class ErrorConfig {
       snippetVars =
           Map.copyOf(
               snippets.stream()
-                  .collect(Collectors.toMap(s -> SNIPPET_VAR_PREFIX + s.name(), Snippet::body)));
+                  .collect(Collectors.toMap(s -> s.variableName(), Snippet::body)));
     }
     return snippetVars;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfig.java
@@ -154,7 +154,7 @@ public class ErrorConfig {
      *
      * @return
      */
-    public String variableName(){
+    public String variableName() {
       return SNIPPET_VAR_PREFIX + name;
     }
   }
@@ -223,8 +223,7 @@ public class ErrorConfig {
       // want the map to be immutable because we hand it out
       snippetVars =
           Map.copyOf(
-              snippets.stream()
-                  .collect(Collectors.toMap(s -> s.variableName(), Snippet::body)));
+              snippets.stream().collect(Collectors.toMap(s -> s.variableName(), Snippet::body)));
     }
     return snippetVars;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorInstance.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorInstance.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.exception.playing;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -14,7 +15,8 @@ import java.util.UUID;
  * <p>Will make it easier if / when we add more info to an error such as links to documentation.
  * They can be passed from the template through the ErrorInstance into to the APIException.
  *
- * <p>
+ * <p><b>NOTE:</b> keeping variable checking out of this class for now, it's just a way to pass a
+ * single param rather than many.
  *
  * @param errorId
  * @param family
@@ -22,6 +24,13 @@ import java.util.UUID;
  * @param code
  * @param title
  * @param body
+ * @param httpResponseOverride
  */
 public record ErrorInstance(
-    UUID errorId, ErrorFamily family, ErrorScope scope, String code, String title, String body) {}
+    UUID errorId,
+    ErrorFamily family,
+    ErrorScope scope,
+    String code,
+    String title,
+    String body,
+    Optional<Integer> httpResponseOverride) {}

--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -34,6 +34,10 @@
 # Each error object has:
 # - scope: UPPER_SNAKE_CASE_1
 # - code: UPPER_SNAKE_CASE_1
+# - http_response_override: (optional) The HTTP status code to return when this error is thrown. If not present, the
+#                           default status code is 200 for most things. This is not returned in the error object JSON
+#                           It is used to override the HTTP status code in the response.
+#                           NOTE: NO checking is done to confirm this is a valid HTTP status code.
 # - title: A short title for the error, that must not change between instances of the error.
 # - body: A longer body that may contain ${vars} to be passed by the code when created, and references to snippets.
 #         This can be a multi line string, recommend using the `|-` to trim trailing newlines.

--- a/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfigTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfigTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.FileNotFoundException;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,6 +45,7 @@ public class ErrorConfigTest {
           - scope: TEST_SCOPE_1
             code: TEST_ERROR_ID_1
             title: the title for the error
+            http_response_override: 501
             body: |-
               big long body with ${vars} in it
           - scope:
@@ -70,6 +72,7 @@ public class ErrorConfigTest {
               assertThat(e.code()).isEqualTo("TEST_ERROR_ID_1");
               assertThat(e.title()).isEqualTo("the title for the error");
               assertThat(e.body()).isEqualTo("big long body with ${vars} in it");
+              assertThat(e.httpResponseOverride()).isPresent().get().isEqualTo(501);
             });
 
     assertThat(errorConfig.getErrorDetail(ErrorFamily.REQUEST, "", "TEST_ERROR_ID_2"))
@@ -81,6 +84,7 @@ public class ErrorConfigTest {
               assertThat(e.code()).isEqualTo("TEST_ERROR_ID_2");
               assertThat(e.title()).isEqualTo("This error has no scope");
               assertThat(e.body()).isEqualTo("Line 1 of body\n\nLine 2 of body");
+              assertThat(e.httpResponseOverride()).isEmpty();
             });
 
     assertThat(errorConfig.getErrorDetail(ErrorFamily.SERVER, "TEST_SCOPE_3", "TEST_ERROR_ID_2"))
@@ -92,17 +96,26 @@ public class ErrorConfigTest {
               assertThat(e.code()).isEqualTo("TEST_ERROR_ID_2");
               assertThat(e.title()).isEqualTo("the title for the error");
               assertThat(e.body()).isEqualTo("big long body with ${vars} in it");
+              assertThat(e.httpResponseOverride()).isEmpty();
             });
   }
 
   @ParameterizedTest
   @MethodSource("errorDetailTestCases")
   public <T extends Throwable> void errorDetailValidation(
-      String scope, String code, String title, String body, Class<T> errorClass, String message) {
+      String scope,
+      String code,
+      String title,
+      String body,
+      Optional<Integer> httpStatusOverride,
+      Class<T> errorClass,
+      String message) {
 
     T error =
         assertThrows(
-            errorClass, () -> new ErrorConfig.ErrorDetail(scope, code, title, body), "Error Type");
+            errorClass,
+            () -> new ErrorConfig.ErrorDetail(scope, code, title, body, httpStatusOverride),
+            "Error Type");
 
     assertThat(error.getMessage()).as("Error Message").isEqualTo(message);
   }
@@ -114,25 +127,65 @@ public class ErrorConfigTest {
             "CODE",
             "title",
             "body",
+            Optional.empty(),
             IllegalArgumentException.class,
             "scope must be in UPPER_SNAKE_CASE_1 format, got: not_snake_scope"),
         Arguments.of(
-            "SCOPE", null, "title", "body", NullPointerException.class, "code cannot be null"),
+            "SCOPE",
+            null,
+            "title",
+            "body",
+            Optional.empty(),
+            NullPointerException.class,
+            "code cannot be null"),
         Arguments.of(
             "SCOPE",
             "not snake code",
             "title",
             "body",
+            Optional.empty(),
             IllegalArgumentException.class,
             "code must be in UPPER_SNAKE_CASE_1 format, got: not snake code"),
         Arguments.of(
-            "SCOPE", "CODE", null, "body", NullPointerException.class, "title cannot be null"),
+            "SCOPE",
+            "CODE",
+            null,
+            "body",
+            Optional.empty(),
+            NullPointerException.class,
+            "title cannot be null"),
         Arguments.of(
-            "SCOPE", "CODE", "", "body", IllegalArgumentException.class, "title cannot be blank"),
+            "SCOPE",
+            "CODE",
+            "",
+            "body",
+            Optional.empty(),
+            IllegalArgumentException.class,
+            "title cannot be blank"),
         Arguments.of(
-            "SCOPE", "CODE", "title", null, NullPointerException.class, "body cannot be null"),
+            "SCOPE",
+            "CODE",
+            "title",
+            null,
+            Optional.empty(),
+            NullPointerException.class,
+            "body cannot be null"),
         Arguments.of(
-            "SCOPE", "CODE", "title", "", IllegalArgumentException.class, "body cannot be blank"));
+            "SCOPE",
+            "CODE",
+            "title",
+            "",
+            Optional.empty(),
+            IllegalArgumentException.class,
+            "body cannot be blank"),
+        Arguments.of(
+            "SCOPE",
+            "CODE",
+            "title",
+            "body",
+            null,
+            NullPointerException.class,
+            "httpResponseOverride cannot be null"));
   }
 
   @Test
@@ -160,6 +213,7 @@ public class ErrorConfigTest {
             s -> {
               assertThat(s.name()).isEqualTo("SNIPPET_1");
               assertThat(s.body()).isEqualTo("Snippet 1 body");
+              assertThat(errorConfig.getSnippetVars()).containsKey(s.name());
             });
     assertThat(
             errorConfig.snippets().stream().filter(e -> e.name().equals("SNIPPET_2")).findFirst())
@@ -169,6 +223,7 @@ public class ErrorConfigTest {
             s -> {
               assertThat(s.name()).isEqualTo("SNIPPET_2");
               assertThat(s.body()).isEqualTo("Snippet 2 body\n\nmulti line");
+              assertThat(errorConfig.getSnippetVars()).containsKey(s.name());
             });
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfigTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/ErrorConfigTest.java
@@ -213,7 +213,7 @@ public class ErrorConfigTest {
             s -> {
               assertThat(s.name()).isEqualTo("SNIPPET_1");
               assertThat(s.body()).isEqualTo("Snippet 1 body");
-              assertThat(errorConfig.getSnippetVars()).containsKey(s.name());
+              assertThat(errorConfig.getSnippetVars()).containsKey(s.variableName());
             });
     assertThat(
             errorConfig.snippets().stream().filter(e -> e.name().equals("SNIPPET_2")).findFirst())
@@ -223,7 +223,7 @@ public class ErrorConfigTest {
             s -> {
               assertThat(s.name()).isEqualTo("SNIPPET_2");
               assertThat(s.body()).isEqualTo("Snippet 2 body\n\nmulti line");
-              assertThat(errorConfig.getSnippetVars()).containsKey(s.name());
+              assertThat(errorConfig.getSnippetVars()).containsKey(s.variableName());
             });
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/MissingCtorException.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/MissingCtorException.java
@@ -1,5 +1,7 @@
 package io.stargate.sgv2.jsonapi.exception.playing;
 
+import java.util.Optional;
+
 /**
  * An exception that is missing the CTOR we need for the templating system.
  *
@@ -14,7 +16,9 @@ public class MissingCtorException extends TestRequestException {
 
   // This ctor is just here to make it compile
   public MissingCtorException() {
-    super(new ErrorInstance(null, ErrorFamily.REQUEST, SCOPE, "FAKE", "title", "body"));
+    super(
+        new ErrorInstance(
+            null, ErrorFamily.REQUEST, SCOPE, "FAKE", "title", "body", Optional.empty()));
   }
 
   // This is the CTOR that is missing, kept commented out to show what is missing

--- a/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/TestRequestException.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/exception/playing/TestRequestException.java
@@ -37,7 +37,8 @@ public class TestRequestException extends APIException {
 
   public enum Code implements ErrorCode<TestRequestException> {
     UNSCOPED_REQUEST_ERROR,
-    NO_VARIABLES_TEMPLATE;
+    NO_VARIABLES_TEMPLATE,
+    HTTP_OVERRIDE;
 
     private final ErrorTemplate<TestRequestException> template;
 

--- a/src/test/resources/test_errors.yaml
+++ b/src/test/resources/test_errors.yaml
@@ -31,3 +31,10 @@ request_errors:
     title: A body with no template variables
     body: |-
       Body with no variables.
+
+  - scope:
+    code: HTTP_OVERRIDE
+    http_response_override: 500
+    title: An error that overrides the HTTP response
+    body: |-
+      body with ${name} and ${value} in it


### PR DESCRIPTION
**What this PR does**:

When set it is passed through to the APIException creation and
set as a field on the exception that can be used later when we
start handling these errors and working out the response code.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [*] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [*] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
