### PR TITLE
Fixes #1365: add integral number codecs, tests

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/NativeTypeTableFilter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/NativeTypeTableFilter.java
@@ -113,8 +113,7 @@ public abstract class NativeTypeTableFilter<CqlT> extends TableFilter {
     } catch (UnknownColumnException e) {
       throw ErrorCode.TABLE_COLUMN_UNKNOWN.toApiException(e.getMessage());
     } catch (MissingJSONCodecException e) {
-      // TODO AARON - Handle error
-      throw new RuntimeException(e);
+      throw ErrorCode.TABLE_COLUMN_TYPE_UNSUPPORTED.toApiException(e.getMessage());
     } catch (ToCQLCodecException e) {
       // TODO AARON - Handle error
       throw new RuntimeException(e);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/NumberTableFilter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/NumberTableFilter.java
@@ -1,11 +1,9 @@
 package io.stargate.sgv2.jsonapi.service.operation.filters.table;
 
-import java.math.BigDecimal;
-
 /** Filter to use any JSON number against a table column. */
-public class NumberTableFilter extends NativeTypeTableFilter<BigDecimal> {
+public class NumberTableFilter extends NativeTypeTableFilter<Number> {
 
-  public NumberTableFilter(String path, Operator operator, BigDecimal value) {
+  public NumberTableFilter(String path, Operator operator, Number value) {
     super(path, operator, value);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.operation.filters.table.codecs;
 
 import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -166,6 +167,45 @@ public record JSONCodec<JavaT, CqlT>(
           throw new ToCQLCodecException(value, toCQLType, e);
         }
       };
+    }
+
+    static Integer safeLongToInt(Long value) {
+      long l = value.longValue();
+      if (l < Integer.MIN_VALUE) {
+        throwUnderflow(DataTypes.INT, value);
+      } else if (l > Integer.MAX_VALUE) {
+        throwOverflow(DataTypes.INT, value);
+      }
+      return (int) l;
+    }
+
+    static Short safeLongToSmallint(Long value) {
+      long l = value.longValue();
+      if (l < Short.MIN_VALUE) {
+        throwUnderflow(DataTypes.SMALLINT, value);
+      } else if (l > Short.MAX_VALUE) {
+        throwOverflow(DataTypes.SMALLINT, value);
+      }
+      return (short) l;
+    }
+
+    static Byte safeLongToTinyint(Long value) {
+      long l = value.longValue();
+      if (l < Byte.MIN_VALUE) {
+        throwUnderflow(DataTypes.TINYINT, value);
+      } else if (l > Byte.MAX_VALUE) {
+        throwOverflow(DataTypes.TINYINT, value);
+      }
+      return (byte) l;
+    }
+
+    static void throwOverflow(DataType targetCQLType, Number value) {
+      throw new ArithmeticException(String.format("Overflow, value too big for %s", targetCQLType));
+    }
+
+    static void throwUnderflow(DataType targetCQLType, Number value) {
+      throw new ArithmeticException(
+          String.format("Underflow, value too small for %s", targetCQLType));
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -105,7 +105,7 @@ public record JSONCodec<JavaT, CqlT>(
   }
 
   /**
-   * Function interface that is used by the codec to convert the Java value to the value CQL
+   * Functional interface that is used by the codec to convert the Java value to the value CQL
    * expects.
    *
    * <p>The interface is used so the conversation function can throw the checked {@link
@@ -170,7 +170,7 @@ public record JSONCodec<JavaT, CqlT>(
   }
 
   /**
-   * Function interface that is used by the codec to convert value returned by CQL into a {@link
+   * Functional interface that is used by the codec to convert value returned by CQL into a {@link
    * JsonNode} that can be used to construct the response document for a row.
    *
    * <p>The interface is used so the conversation function can throw the checked {@link

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -228,7 +228,7 @@ public record JSONCodec<JavaT, CqlT>(
    * <p>The interface is used so the conversation function can throw the checked {@link
    * ToJSONCodecException}, it is also given the CQL data type to make better exceptions.
    *
-   * <p>Use the static constructors on the interface to get instances, see it's use in the {@link
+   * <p>Use the static constructors on the interface to get instances, see its use in the {@link
    * JSONCodecRegistry}
    *
    * @param <CqlT> The type Java object the CQL driver expects

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
@@ -127,7 +127,7 @@ public class JSONCodecRegistry {
   }
 
   // Boolean
-  public static final JSONCodec<Boolean, Boolean> BOOLEAN =
+  private static final JSONCodec<Boolean, Boolean> BOOLEAN =
       new JSONCodec<>(
           GenericType.BOOLEAN,
           DataTypes.BOOLEAN,
@@ -135,21 +135,21 @@ public class JSONCodecRegistry {
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::booleanNode));
 
   // Numeric Codecs
-  public static final JSONCodec<BigDecimal, Long> BIGINT_FROM_BIG_DECIMAL =
+  private static final JSONCodec<BigDecimal, Long> BIGINT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
           DataTypes.BIGINT,
           JSONCodec.ToCQL.safeNumber(BigDecimal::longValueExact),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  public static final JSONCodec<BigInteger, Long> BIGINT_FROM_BIG_INTEGER =
+  private static final JSONCodec<BigInteger, Long> BIGINT_FROM_BIG_INTEGER =
       new JSONCodec<>(
           GenericType.BIG_INTEGER,
           DataTypes.BIGINT,
           JSONCodec.ToCQL.safeNumber(BigInteger::longValueExact),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  public static final JSONCodec<Long, Long> BIGINT_FROM_LONG =
+  private static final JSONCodec<Long, Long> BIGINT_FROM_LONG =
       new JSONCodec<>(
           GenericType.LONG,
           DataTypes.BIGINT,
@@ -177,11 +177,25 @@ public class JSONCodecRegistry {
           JSONCodec.ToCQL.safeNumber(BigDecimal::floatValue),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  public static final JSONCodec<BigDecimal, Integer> INT =
+  public static final JSONCodec<BigDecimal, Integer> INT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
           DataTypes.INT,
           JSONCodec.ToCQL.safeNumber(BigDecimal::intValueExact),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<BigInteger, Integer> INT_FROM_BIG_INTEGER =
+      new JSONCodec<>(
+          GenericType.BIG_INTEGER,
+          DataTypes.INT,
+          JSONCodec.ToCQL.safeNumber(BigInteger::intValueExact),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<Long, Integer> INT_FROM_LONG =
+      new JSONCodec<>(
+          GenericType.LONG,
+          DataTypes.INT,
+          JSONCodec.ToCQL.safeNumber(Long::intValue),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   public static final JSONCodec<BigDecimal, Short> SMALLINT =
@@ -231,7 +245,9 @@ public class JSONCodecRegistry {
             DECIMAL,
             DOUBLE,
             FLOAT,
-            INT,
+            INT_FROM_BIG_DECIMAL,
+            INT_FROM_BIG_INTEGER,
+            INT_FROM_LONG,
             SMALLINT,
             TINYINT,
             VARINT,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
@@ -135,17 +135,26 @@ public class JSONCodecRegistry {
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::booleanNode));
 
   // Numeric Codecs
-  public static final JSONCodec<BigDecimal, Long> BIGINT =
+  public static final JSONCodec<BigDecimal, Long> BIGINT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
           DataTypes.BIGINT,
           JSONCodec.ToCQL.safeNumber(BigDecimal::longValueExact),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  // TODO Tatu For performance reasons we could also consider only converting FP values into
-  // BigDecimal JsonNode -- but converting CQL integer values into long-valued JsonNode.
-  //  I think our internal handling can deal with Integer and Long valued JsonNodes and this avoids
-  // some of BigDecimal overhead (avoids conversion overhead, serialization is faster).
+  public static final JSONCodec<BigInteger, Long> BIGINT_FROM_BIG_INTEGER =
+      new JSONCodec<>(
+          GenericType.BIG_INTEGER,
+          DataTypes.BIGINT,
+          JSONCodec.ToCQL.safeNumber(BigInteger::longValueExact),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<Long, Long> BIGINT_FROM_LONG =
+      new JSONCodec<>(
+          GenericType.LONG,
+          DataTypes.BIGINT,
+          JSONCodec.ToCQL.unsafeIdentity(),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   public static final JSONCodec<BigDecimal, BigDecimal> DECIMAL =
       new JSONCodec<>(
@@ -215,6 +224,18 @@ public class JSONCodecRegistry {
   static {
     CODECS =
         List.of(
-            BOOLEAN, BIGINT, DECIMAL, DOUBLE, FLOAT, INT, SMALLINT, TINYINT, VARINT, ASCII, TEXT);
+            BOOLEAN,
+            BIGINT_FROM_BIG_DECIMAL,
+            BIGINT_FROM_BIG_INTEGER,
+            BIGINT_FROM_LONG,
+            DECIMAL,
+            DOUBLE,
+            FLOAT,
+            INT,
+            SMALLINT,
+            TINYINT,
+            VARINT,
+            ASCII,
+            TEXT);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
@@ -195,7 +195,7 @@ public class JSONCodecRegistry {
       new JSONCodec<>(
           GenericType.LONG,
           DataTypes.INT,
-          JSONCodec.ToCQL.safeNumber(Long::intValue),
+          JSONCodec.ToCQL.safeNumber(JSONCodec.ToCQL::safeLongToInt),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   public static final JSONCodec<BigDecimal, Short> SMALLINT_FROM_BIG_DECIMAL =
@@ -216,7 +216,7 @@ public class JSONCodecRegistry {
       new JSONCodec<>(
           GenericType.LONG,
           DataTypes.SMALLINT,
-          JSONCodec.ToCQL.safeNumber(Long::shortValue),
+          JSONCodec.ToCQL.safeNumber(JSONCodec.ToCQL::safeLongToSmallint),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   public static final JSONCodec<BigDecimal, Byte> TINYINT_FROM_BIG_DECIMAL =
@@ -237,7 +237,7 @@ public class JSONCodecRegistry {
       new JSONCodec<>(
           GenericType.LONG,
           DataTypes.TINYINT,
-          JSONCodec.ToCQL.safeNumber(Long::byteValue),
+          JSONCodec.ToCQL.safeNumber(JSONCodec.ToCQL::safeLongToTinyint),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   public static final JSONCodec<BigDecimal, BigInteger> VARINT_FROM_BIG_DECIMAL =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
@@ -198,25 +198,67 @@ public class JSONCodecRegistry {
           JSONCodec.ToCQL.safeNumber(Long::intValue),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  public static final JSONCodec<BigDecimal, Short> SMALLINT =
+  public static final JSONCodec<BigDecimal, Short> SMALLINT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
           DataTypes.SMALLINT,
           JSONCodec.ToCQL.safeNumber(BigDecimal::shortValueExact),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  public static final JSONCodec<BigDecimal, Byte> TINYINT =
+  public static final JSONCodec<BigInteger, Short> SMALLINT_FROM_BIG_INTEGER =
+      new JSONCodec<>(
+          GenericType.BIG_INTEGER,
+          DataTypes.SMALLINT,
+          JSONCodec.ToCQL.safeNumber(BigInteger::shortValueExact),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<Long, Short> SMALLINT_FROM_LONG =
+      new JSONCodec<>(
+          GenericType.LONG,
+          DataTypes.SMALLINT,
+          JSONCodec.ToCQL.safeNumber(Long::shortValue),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<BigDecimal, Byte> TINYINT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
           DataTypes.TINYINT,
           JSONCodec.ToCQL.safeNumber(BigDecimal::byteValueExact),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
-  public static final JSONCodec<BigDecimal, BigInteger> VARINT =
+  public static final JSONCodec<BigInteger, Byte> TINYINT_FROM_BIG_INTEGER =
+      new JSONCodec<>(
+          GenericType.BIG_INTEGER,
+          DataTypes.TINYINT,
+          JSONCodec.ToCQL.safeNumber(BigInteger::byteValueExact),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<Long, Byte> TINYINT_FROM_LONG =
+      new JSONCodec<>(
+          GenericType.LONG,
+          DataTypes.TINYINT,
+          JSONCodec.ToCQL.safeNumber(Long::byteValue),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<BigDecimal, BigInteger> VARINT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
           DataTypes.VARINT,
           JSONCodec.ToCQL.safeNumber(BigDecimal::toBigIntegerExact),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<BigInteger, BigInteger> VARINT_FROM_BIG_INTEGER =
+      new JSONCodec<>(
+          GenericType.BIG_INTEGER,
+          DataTypes.VARINT,
+          JSONCodec.ToCQL.unsafeIdentity(),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  public static final JSONCodec<Long, BigInteger> VARINT_FROM_LONG =
+      new JSONCodec<>(
+          GenericType.LONG,
+          DataTypes.VARINT,
+          JSONCodec.ToCQL.safeNumber(BigInteger::valueOf),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   // Text Codecs
@@ -238,20 +280,30 @@ public class JSONCodecRegistry {
   static {
     CODECS =
         List.of(
-            BOOLEAN,
+            // Numeric Codecs, integer types
             BIGINT_FROM_BIG_DECIMAL,
             BIGINT_FROM_BIG_INTEGER,
             BIGINT_FROM_LONG,
-            DECIMAL,
-            DOUBLE,
-            FLOAT,
             INT_FROM_BIG_DECIMAL,
             INT_FROM_BIG_INTEGER,
             INT_FROM_LONG,
-            SMALLINT,
-            TINYINT,
-            VARINT,
+            SMALLINT_FROM_BIG_DECIMAL,
+            SMALLINT_FROM_BIG_INTEGER,
+            SMALLINT_FROM_LONG,
+            TINYINT_FROM_BIG_DECIMAL,
+            TINYINT_FROM_BIG_INTEGER,
+            TINYINT_FROM_LONG,
+            VARINT_FROM_BIG_DECIMAL,
+            VARINT_FROM_BIG_INTEGER,
+            VARINT_FROM_LONG,
+            // Numeric Codecs, floating-point types
+            DECIMAL,
+            DOUBLE,
+            FLOAT,
+            // Text Codecs
             ASCII,
-            TEXT);
+            TEXT,
+            // Other codecs
+            BOOLEAN);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/ToCQLCodecException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/ToCQLCodecException.java
@@ -16,8 +16,8 @@ public class ToCQLCodecException extends Exception {
   public ToCQLCodecException(Object value, DataType targetCQLType, Exception cause) {
     super(
         String.format(
-            "Error trying to convert to targetCQLType `%s` from value.class `%s` and value: %s",
-            targetCQLType, value.getClass().getName(), value),
+            "Error trying to convert to targetCQLType `%s` from value.class `%s`, value %s. Root cause: %s",
+            targetCQLType, value.getClass().getName(), value, cause.getMessage()),
         cause);
     this.value = value;
     this.targetCQLType = targetCQLType;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/matcher/TableFilterResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/matcher/TableFilterResolver.java
@@ -12,7 +12,6 @@ import io.stargate.sgv2.jsonapi.service.operation.filters.table.NumberTableFilte
 import io.stargate.sgv2.jsonapi.service.operation.filters.table.TextTableFilter;
 import io.stargate.sgv2.jsonapi.service.operation.query.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.shredding.collections.DocumentId;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -104,7 +103,7 @@ public class TableFilterResolver<CmdT extends Command & Filterable>
                 captureExpression.path(),
                 NativeTypeTableFilter.Operator.from(
                     (ValueComparisonOperator) filterOperation.operator()),
-                (BigDecimal) rhsValue));
+                (Number) rhsValue));
       } else if (captureExpression.marker() == DYNAMIC_DOCID_GROUP) {
         Object actualValue = ((DocumentId) rhsValue).value();
         if (actualValue instanceof String) {
@@ -114,13 +113,13 @@ public class TableFilterResolver<CmdT extends Command & Filterable>
                   NativeTypeTableFilter.Operator.from(
                       (ValueComparisonOperator) filterOperation.operator()),
                   (String) actualValue));
-        } else if (actualValue instanceof BigDecimal) {
+        } else if (actualValue instanceof Number) {
           filters.add(
               new NumberTableFilter(
                   captureExpression.path(),
                   NativeTypeTableFilter.Operator.from(
                       (ValueComparisonOperator) filterOperation.operator()),
-                  (BigDecimal) actualValue));
+                  (Number) actualValue));
         } else {
           throw new UnsupportedOperationException(
               "Unsupported DocumentId type: " + rhsValue.getClass().getName());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
@@ -13,7 +13,13 @@ import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
-/** AARON TODO shreds docs for rows */
+/**
+ * AARON TODO shreds docs for rows
+ *
+ * <p>Note: logic in {@link #shredValue(JsonNode)} and {@link #shredNumber} needs to be kept in sync
+ * with code in {@link io.stargate.sgv2.jsonapi.service.operation.filters.table.codecs.JSONCodec}:
+ * types shredded here must be supported by the codec.
+ */
 @ApplicationScoped
 public class RowShredder {
 
@@ -74,20 +80,22 @@ public class RowShredder {
   }
 
   /**
-   * Function that will convert a JSONNode value, e.g. '1' into the correct Java type expected when
-   * processing tables, e.g. BigDecimal.
+   * Function that will convert a JSONNode value, e.g. '1.25' into plain Java type expected when
+   * processing tables, e.g. {@link String}, {@link Boolean}, {@link java.math.BigDecimal} and so
+   * on.
    *
    * <p>The types returned here are types that are expected by the {@link
    * io.stargate.sgv2.jsonapi.service.operation.filters.table.codecs.JSONCodecRegistry} so we know
    * how to convert them into the correct Java types expected by the CQL driver.
    *
-   * <p>The main difference here is that we convert all numbers to BigDecimal, and then defer
+   * <p>The main difference here is that we convert all numbers to one of 3 types ({@link
+   * java.math.BigDecimal}, {@link java.lang.Long}, {@link java.math.BigInteger}) and then defer
    * conversion into the type defined by the CQL Column until we are building the CQL statement
    * (e.g. insert, or select) where we bind to the column in the table and use the codec to sort it
    * out.
    *
-   * @param value
-   * @return
+   * @param value JSON value to convert ("shred")
+   * @return the value as a "plain" Java type
    */
   public static Object shredValue(JsonNode value) {
     return switch (value.getNodeType()) {
@@ -95,10 +103,13 @@ public class RowShredder {
       case STRING -> value.textValue();
       case BOOLEAN -> value.booleanValue();
       case NULL -> null;
-      default -> throw new RuntimeException("Unsupported type");
+      default -> throw new IllegalArgumentException("Unsupported type: " + value.getNodeType());
     };
   }
 
+  // NOTE! This method must be kept in sync with the logic in {@code JSONCodecRegistry}:
+  // specifically,
+  // types shredded here must be supported by the codec.
   private static Object shredNumber(JsonNode number) {
     if (number.isIntegralNumber()) {
       // Return as BigInteger if one required (won't fit in 64-bit Long)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
@@ -91,11 +91,24 @@ public class RowShredder {
    */
   public static Object shredValue(JsonNode value) {
     return switch (value.getNodeType()) {
-      case NUMBER -> value.decimalValue();
+      case NUMBER -> shredNumber(value);
       case STRING -> value.textValue();
       case BOOLEAN -> value.booleanValue();
       case NULL -> null;
       default -> throw new RuntimeException("Unsupported type");
     };
+  }
+
+  private static Object shredNumber(JsonNode number) {
+    if (number.isIntegralNumber()) {
+      // Return as BigInteger if one required (won't fit in 64-bit Long)
+      if (number.isBigInteger()) {
+        return number.bigIntegerValue();
+      }
+      // Otherwise as Long (possibly upgrading from Integer)
+      return number.longValue();
+    }
+    // But all FPs are returned as BigDecimal
+    return number.decimalValue();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AbstractTableIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AbstractTableIntegrationTestBase.java
@@ -33,14 +33,14 @@ public class AbstractTableIntegrationTestBase extends AbstractNamespaceIntegrati
   }
 
   protected void createTable(String tableDefAsJSON) {
-    DataApiCommandSenders.namespaceCommand(namespaceName)
+    DataApiCommandSenders.assertNamespaceCommand(namespaceName)
         .postCreateTable(tableDefAsJSON)
         .hasNoErrors()
         .body("status.ok", is(1));
   }
 
   protected void insertOneInTable(String tableName, String documentJSON) {
-    DataApiCommandSenders.tableCommand(namespaceName, tableName)
+    DataApiCommandSenders.assertTableCommand(namespaceName, tableName)
         .postInsertOne(documentJSON)
         .hasNoErrors()
         .body("status.insertedIds", hasSize(1));

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
@@ -23,7 +23,6 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
     String tableJson =
             """
                           {
-                              "createTable": {
                                   "name": "%s",
                                   "definition": {
                                       "columns": {
@@ -39,7 +38,6 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
                                       },
                                       "primaryKey": "id"
                                   }
-                              }
                           }
                     """
             .formatted(simpleTableName);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIndexIntegrationTest.java
@@ -22,7 +22,6 @@ class DropTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
     String tableJson =
             """
                               {
-                                  "createTable": {
                                       "name": "%s",
                                       "definition": {
                                           "columns": {
@@ -38,8 +37,7 @@ class DropTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
                                           },
                                           "primaryKey": "id"
                                       }
-                                  }
-                              }
+                            }
                         """
             .formatted(simpleTableName);
     createTable(tableJson);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindOneTableIntegrationTest.java
@@ -39,7 +39,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
   class FindOneOnEmpty {
     @Test
     public void findOnEmptyNoFilter() {
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
           .postFindOne("{ }")
           .hasNoErrors()
           .hasNoField("data.document");
@@ -47,7 +47,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
 
     @Test
     public void findOnEmptyNonMatchingFilter() {
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
           .postFindOne(
               """
                                   {
@@ -87,7 +87,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
                           """;
       insertOneInTable(TABLE_WITH_STRING_ID_AGE_NAME, DOC_B_JSON);
 
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
           .postFindOne(
               """
                           {
@@ -125,7 +125,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
                               """;
       insertOneInTable(TABLE_NAME, DOC_B_JSON);
 
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_NAME)
           .postFindOne(
               """
               {
@@ -177,7 +177,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
                                   """;
       insertOneInTable(TABLE_NAME, DOC_B_JSON);
 
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_NAME)
           .postFindOne(
               """
                                           {
@@ -197,7 +197,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
     @Test
     @Order(1)
     public void failOnUnknownColumn() {
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
           .postFindOne(
               """
                           {
@@ -215,7 +215,7 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
     @Test
     @Order(2)
     public void failOnNonKeyColumn() {
-      DataApiCommandSenders.tableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
+      DataApiCommandSenders.assertTableCommand(namespaceName, TABLE_WITH_STRING_ID_AGE_NAME)
           .postFindOne(
               """
               {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindOneTableIntegrationTest.java
@@ -158,7 +158,17 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
     public void findOneDocIdKey() {
       final String TABLE_NAME = "findOneDocIdKeyTable";
       createTableWithColumns(
-          TABLE_NAME, Map.of("_id", Map.of("type", "int"), "value", Map.of("type", "text")), "_id");
+          TABLE_NAME,
+          Map.of(
+              "_id",
+              Map.of("type", "int"),
+              "desc",
+              Map.of("type", "text"),
+              "valueLong",
+              Map.of("type", "bigint"),
+              "valueDouble",
+              Map.of("type", "double")),
+          "_id");
 
       // First, insert 2 documents:
       insertOneInTable(
@@ -166,14 +176,18 @@ public class FindOneTableIntegrationTest extends AbstractTableIntegrationTestBas
           """
                               {
                                   "_id": 1,
-                                  "value": "a"
+                                  "desc": "a",
+                                  "valueLong": 1234567890,
+                                  "valueDouble": -1.25
                               }
                               """);
       final String DOC_B_JSON =
           """
                               {
                                   "_id": 2,
-                                  "value": "b"
+                                  "desc": "b",
+                                  "valueLong": 42,
+                                  "valueDouble": 0.5
                               }
                                   """;
       insertOneInTable(TABLE_NAME, DOC_B_JSON);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindOneTableIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.stargate.sgv2.jsonapi.api.v1.tables;
 
-
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenderBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenderBase.java
@@ -6,6 +6,7 @@ import static io.stargate.sgv2.jsonapi.api.v1.util.IntegrationTestUtils.getCassa
 
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.test.CustomITEmbeddingProvider;
+import jakarta.ws.rs.core.Response;
 import java.util.Base64;
 import java.util.Map;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -17,7 +18,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public abstract class DataApiCommandSenderBase<T extends DataApiCommandSenderBase> {
   protected final String namespace;
 
-  protected int expectedHttpStatus = 200;
+  protected Response.Status expectedHttpStatus = Response.Status.OK;
 
   protected DataApiCommandSenderBase(String namespace) {
     this.namespace = namespace;
@@ -29,7 +30,7 @@ public abstract class DataApiCommandSenderBase<T extends DataApiCommandSenderBas
    * @param expectedHttpStatus Status to expect
    * @return Type-safe "this" sender for call chaining
    */
-  public T expectHttpStatus(int expectedHttpStatus) {
+  public T expectHttpStatus(Response.Status expectedHttpStatus) {
     this.expectedHttpStatus = expectedHttpStatus;
     return _this();
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenders.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenders.java
@@ -2,6 +2,10 @@ package io.stargate.sgv2.jsonapi.api.v1.util;
 
 /** Helper class used for constructing and sending commands to the Data API */
 public class DataApiCommandSenders {
+  public static DataApiNamespaceCommandSender namespaceCommand(String namespace) {
+    return new DataApiNamespaceCommandSender(namespace);
+  }
+
   public static DataApiTableCommandSender tableCommand(String namespace, String tableName) {
     return new DataApiTableCommandSender(namespace, tableName);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenders.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenders.java
@@ -1,0 +1,8 @@
+package io.stargate.sgv2.jsonapi.api.v1.util;
+
+/** Helper class used for constructing and sending commands to the Data API */
+public class DataApiCommandSenders {
+  public static DataApiTableCommandSender tableCommand(String namespace, String tableName) {
+    return new DataApiTableCommandSender(namespace, tableName);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenders.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenders.java
@@ -2,11 +2,11 @@ package io.stargate.sgv2.jsonapi.api.v1.util;
 
 /** Helper class used for constructing and sending commands to the Data API */
 public class DataApiCommandSenders {
-  public static DataApiNamespaceCommandSender namespaceCommand(String namespace) {
+  public static DataApiNamespaceCommandSender assertNamespaceCommand(String namespace) {
     return new DataApiNamespaceCommandSender(namespace);
   }
 
-  public static DataApiTableCommandSender tableCommand(String namespace, String tableName) {
+  public static DataApiTableCommandSender assertTableCommand(String namespace, String tableName) {
     return new DataApiTableCommandSender(namespace, tableName);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
@@ -29,7 +29,7 @@ public class DataApiNamespaceCommandSender
             .when()
             .post(NamespaceResource.BASE_PATH, namespace)
             .then()
-            .statusCode(expectedHttpStatus);
+            .statusCode(expectedHttpStatus.getStatusCode());
     return new DataApiResponseValidator(response);
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
@@ -1,10 +1,7 @@
 package io.stargate.sgv2.jsonapi.api.v1.util;
 
-import static io.restassured.RestAssured.given;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
-import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
+import io.restassured.specification.RequestSpecification;
+import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
 
 public class DataApiNamespaceCommandSender
     extends DataApiCommandSenderBase<DataApiNamespaceCommandSender> {
@@ -12,28 +9,11 @@ public class DataApiNamespaceCommandSender
     super(namespace);
   }
 
-  /**
-   * "Untyped" method for sending a POST command to the Data API: caller is responsible for
-   * formatting the JSON body correctly.
-   *
-   * @param jsonBody JSON body to POST
-   * @return Response validator for further assertions
-   */
-  public DataApiResponseValidator postRaw(String jsonBody) {
-    ValidatableResponse response =
-        given()
-            .port(getTestPort())
-            .headers(getHeaders())
-            .contentType(ContentType.JSON)
-            .body(jsonBody)
-            .when()
-            .post(NamespaceResource.BASE_PATH, namespace)
-            .then()
-            .statusCode(expectedHttpStatus.getStatusCode());
-    return new DataApiResponseValidator(response);
+  protected io.restassured.response.Response postInternal(RequestSpecification request) {
+    return request.post(CollectionResource.BASE_PATH, namespace);
   }
 
   public DataApiResponseValidator postCreateTable(String tableDefAsJSON) {
-    return postRaw("{ \"createTable\": %s }".formatted(tableDefAsJSON));
+    return postCommand("createTable", tableDefAsJSON);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
@@ -1,7 +1,7 @@
 package io.stargate.sgv2.jsonapi.api.v1.util;
 
 import io.restassured.specification.RequestSpecification;
-import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
 
 public class DataApiNamespaceCommandSender
     extends DataApiCommandSenderBase<DataApiNamespaceCommandSender> {
@@ -10,7 +10,7 @@ public class DataApiNamespaceCommandSender
   }
 
   protected io.restassured.response.Response postInternal(RequestSpecification request) {
-    return request.post(CollectionResource.BASE_PATH, namespace);
+    return request.post(NamespaceResource.BASE_PATH, namespace);
   }
 
   public DataApiResponseValidator postCreateTable(String tableDefAsJSON) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiNamespaceCommandSender.java
@@ -1,0 +1,39 @@
+package io.stargate.sgv2.jsonapi.api.v1.util;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
+
+public class DataApiNamespaceCommandSender
+    extends DataApiCommandSenderBase<DataApiNamespaceCommandSender> {
+  protected DataApiNamespaceCommandSender(String namespace) {
+    super(namespace);
+  }
+
+  /**
+   * "Untyped" method for sending a POST command to the Data API: caller is responsible for
+   * formatting the JSON body correctly.
+   *
+   * @param jsonBody JSON body to POST
+   * @return Response validator for further assertions
+   */
+  public DataApiResponseValidator postRaw(String jsonBody) {
+    ValidatableResponse response =
+        given()
+            .port(getTestPort())
+            .headers(getHeaders())
+            .contentType(ContentType.JSON)
+            .body(jsonBody)
+            .when()
+            .post(NamespaceResource.BASE_PATH, namespace)
+            .then()
+            .statusCode(expectedHttpStatus);
+    return new DataApiResponseValidator(response);
+  }
+
+  public DataApiResponseValidator postCreateTable(String tableDefAsJSON) {
+    return postRaw("{ \"createTable\": %s }".formatted(tableDefAsJSON));
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
@@ -11,7 +11,7 @@ import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import org.hamcrest.Matcher;
 
 public class DataApiResponseValidator {
-  private ValidatableResponse response;
+  protected final ValidatableResponse response;
 
   public DataApiResponseValidator(ValidatableResponse response) {
     this.response = response;
@@ -24,8 +24,7 @@ public class DataApiResponseValidator {
   }
 
   public DataApiResponseValidator body(String path, Matcher<?> matcher, Object... args) {
-    response = response.body(path, matcher, args);
-    return this;
+    return new DataApiResponseValidator(response.body(path, matcher, args));
   }
 
   // // // API-aware validation: status, error codes // // //

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
@@ -1,0 +1,73 @@
+package io.stargate.sgv2.jsonapi.api.v1.util;
+
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.restassured.response.ValidatableResponse;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import org.hamcrest.Matcher;
+
+public class DataApiResponseValidator {
+  private ValidatableResponse response;
+
+  public DataApiResponseValidator(ValidatableResponse response) {
+    this.response = response;
+  }
+
+  // // // Access to Hamcrest Response Matchers // // //
+
+  public ValidatableResponse response() {
+    return response;
+  }
+
+  public DataApiResponseValidator body(String path, Matcher<?> matcher, Object... args) {
+    response = response.body(path, matcher, args);
+    return this;
+  }
+
+  // // // API-aware validation: status, error codes // // //
+
+  public DataApiResponseValidator hasNoStatus() {
+    return body("status", is(nullValue()));
+  }
+
+  public DataApiResponseValidator hasNoErrors() {
+    return body("errors", is(nullValue()));
+  }
+
+  public DataApiResponseValidator hasSingleApiError(ErrorCode errorCode) {
+    return body("errors", hasSize(1))
+        .body("errors[0].exceptionClass", is("JsonApiException"))
+        .body("errors[0].errorCode", is(errorCode.name()));
+  }
+
+  public DataApiResponseValidator hasSingleApiError(ErrorCode errorCode, String messageSnippet) {
+    return hasSingleApiError(errorCode, containsString(messageSnippet));
+  }
+
+  public DataApiResponseValidator hasSingleApiError(
+      ErrorCode errorCode, Matcher<String> messageMatcher) {
+    return hasSingleApiError(errorCode).body("errors[0].message", messageMatcher);
+  }
+
+  // // // API-aware validation: non-error content // // //
+
+  public DataApiResponseValidator hasNoField(String path) {
+    return body(path, is(nullValue()));
+  }
+
+  public DataApiResponseValidator hasData() {
+    return hasNoField("data");
+  }
+
+  public DataApiResponseValidator hasNoData() {
+    return body("data", is(nullValue()));
+  }
+
+  public DataApiResponseValidator hasJSONField(String path, String rawJson) {
+    return body(path, jsonEquals(rawJson));
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -35,6 +35,14 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
     return new DataApiResponseValidator(response);
   }
 
+  public DataApiResponseValidator postCommand(String command, String commandClause) {
+    return postRaw("{ \"%s\": %s }".formatted(command, commandClause));
+  }
+
+  public DataApiResponseValidator postDeleteMany(String deleteManyClause) {
+    return postCommand("deleteMany", deleteManyClause);
+  }
+
   /**
    * Partially typed method for sending a POST command to the Data API: caller is responsible for
    * formatting the clause to include as (JSON Object) argument of "finOne" command.
@@ -44,7 +52,7 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
    * @return Response validator for further assertions
    */
   public DataApiResponseValidator postFindOne(String findOneClause) {
-    return postRaw("{ \"findOne\": %s }".formatted(findOneClause));
+    return postCommand("findOne", findOneClause);
   }
 
   public DataApiResponseValidator postInsertOne(String docAsJSON) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -33,14 +33,6 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
   }
 
   public DataApiResponseValidator postInsertOne(String docAsJSON) {
-    return postRaw(
-            """
-            {
-              "insertOne": {
-                "document": %s
-              }
-            }
-            """
-            .formatted(docAsJSON));
+    return postCommand("insertOne", "{ \"document\": %s }".formatted(docAsJSON));
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -1,0 +1,49 @@
+package io.stargate.sgv2.jsonapi.api.v1.util;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+
+public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiTableCommandSender> {
+  private final String tableName;
+
+  protected DataApiTableCommandSender(String namespace, String tableName) {
+    super(namespace);
+    this.tableName = tableName;
+  }
+
+  /**
+   * "Untyped" method for sending a POST command to the Data API: caller is responsible for
+   * formatting the JSON body correctly.
+   *
+   * @param jsonBody JSON body to POST
+   * @return Response validator for further assertions
+   */
+  public DataApiResponseValidator postRaw(String jsonBody) {
+    ValidatableResponse response =
+        given()
+            .port(getTestPort())
+            .headers(getHeaders())
+            .contentType(ContentType.JSON)
+            .body(jsonBody)
+            .when()
+            .post(CollectionResource.BASE_PATH, namespace, tableName)
+            .then()
+            .statusCode(expectedHttpStatus);
+    return new DataApiResponseValidator(response);
+  }
+
+  /**
+   * Partially typed method for sending a POST command to the Data API: caller is responsible for
+   * formatting the clause to include as (JSON Object) argument of "finOne" command.
+   *
+   * @param findOneClause JSON clause to include in the "findOne" command: minimally empty JSON
+   *     Object ({@code { } })
+   * @return Response validator for further assertions
+   */
+  public DataApiResponseValidator postFindOne(String findOneClause) {
+    return postRaw("{ \"findOne\": %s }".formatted(findOneClause));
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -46,4 +46,16 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
   public DataApiResponseValidator postFindOne(String findOneClause) {
     return postRaw("{ \"findOne\": %s }".formatted(findOneClause));
   }
+
+  public DataApiResponseValidator postInsertOne(String docAsJSON) {
+    return postRaw(
+            """
+            {
+              "insertOne": {
+                "document": %s
+              }
+            }
+            """
+            .formatted(docAsJSON));
+  }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -31,7 +31,7 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
             .when()
             .post(CollectionResource.BASE_PATH, namespace, tableName)
             .then()
-            .statusCode(expectedHttpStatus);
+            .statusCode(expectedHttpStatus.getStatusCode());
     return new DataApiResponseValidator(response);
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -1,9 +1,6 @@
 package io.stargate.sgv2.jsonapi.api.v1.util;
 
-import static io.restassured.RestAssured.given;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
 import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
 
 public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiTableCommandSender> {
@@ -14,29 +11,9 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
     this.tableName = tableName;
   }
 
-  /**
-   * "Untyped" method for sending a POST command to the Data API: caller is responsible for
-   * formatting the JSON body correctly.
-   *
-   * @param jsonBody JSON body to POST
-   * @return Response validator for further assertions
-   */
-  public DataApiResponseValidator postRaw(String jsonBody) {
-    ValidatableResponse response =
-        given()
-            .port(getTestPort())
-            .headers(getHeaders())
-            .contentType(ContentType.JSON)
-            .body(jsonBody)
-            .when()
-            .post(CollectionResource.BASE_PATH, namespace, tableName)
-            .then()
-            .statusCode(expectedHttpStatus.getStatusCode());
-    return new DataApiResponseValidator(response);
-  }
-
-  public DataApiResponseValidator postCommand(String command, String commandClause) {
-    return postRaw("{ \"%s\": %s }".formatted(command, commandClause));
+  @Override
+  protected io.restassured.response.Response postInternal(RequestSpecification request) {
+    return request.post(CollectionResource.BASE_PATH, namespace, tableName);
   }
 
   public DataApiResponseValidator postDeleteMany(String deleteManyClause) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -61,7 +61,7 @@ public class JSONCodecRegistryTest {
    * @param expectedCqlValue The value we expect to pass to the CQL driver
    */
   @ParameterizedTest
-  @MethodSource("codecToCQLTestCases")
+  @MethodSource("validCodecToCQLTestCases")
   public void codecToCQL(DataType cqlType, Object fromValue, Object expectedCqlValue) {
 
     var codec = assertGetCodecToCQL(cqlType, fromValue);
@@ -81,7 +81,7 @@ public class JSONCodecRegistryTest {
         .isEqualTo(expectedCqlValue);
   }
 
-  private static Stream<Arguments> codecToCQLTestCases() {
+  private static Stream<Arguments> validCodecToCQLTestCases() {
     // Arguments: (CQL-type, from-caller, bound-by-driver-for-cql
     // Note: all Numeric types accept 3 Java types: Long, BigInteger, BigDecimal
     return Stream.of(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -177,7 +177,8 @@ public class JSONCodecRegistryTest {
             ToCQLCodecException.class,
             () -> codec.toCQL(valueToTest),
             String.format(
-                "Throw ToCQLCodecException for out of range `%s` %s", typeToTest, valueToTest));
+                "Throw ToCQLCodecException for out of range `%s` value: %s",
+                typeToTest, valueToTest));
 
     assertThat(error)
         .satisfies(
@@ -201,29 +202,31 @@ public class JSONCodecRegistryTest {
             DataTypes.BIGINT,
             TEST_DATA.OUT_OF_RANGE_FOR_BIGINT.toBigIntegerExact(),
             "BigInteger out of long range"),
-        // Arguments.of(DataTypes.BIGINT, TEST_DATA.OUT_OF_RANGE_FOR_BIGINT.longValueExact(),
-        // "Overflow"),
-        Arguments.of(DataTypes.INT, TEST_DATA.OUT_OF_RANGE_FOR_INT, "Overflow"),
+        Arguments.of(DataTypes.INT, TEST_DATA.OVERFLOW_FOR_INT, "Overflow"),
         Arguments.of(
             DataTypes.INT,
-            TEST_DATA.OUT_OF_RANGE_FOR_INT.toBigIntegerExact(),
+            TEST_DATA.OVERFLOW_FOR_INT.toBigIntegerExact(),
             "BigInteger out of int range"),
-        // Arguments.of(DataTypes.INT, TEST_DATA.OUT_OF_RANGE_FOR_INT.longValueExact(), "Overflow"),
-        Arguments.of(DataTypes.SMALLINT, TEST_DATA.OUT_OF_RANGE_FOR_SMALLINT, "Overflow"),
+        Arguments.of(DataTypes.INT, TEST_DATA.OVERFLOW_FOR_INT.longValueExact(), "Overflow"),
+        Arguments.of(DataTypes.INT, TEST_DATA.UNDERFLOW_FOR_INT.longValueExact(), "Underflow"),
+        Arguments.of(DataTypes.SMALLINT, TEST_DATA.OVERFLOW_FOR_SMALLINT, "Overflow"),
         Arguments.of(
             DataTypes.SMALLINT,
-            TEST_DATA.OUT_OF_RANGE_FOR_SMALLINT.toBigIntegerExact(),
+            TEST_DATA.OVERFLOW_FOR_SMALLINT.toBigIntegerExact(),
             "BigInteger out of short range"),
-        // Arguments.of(DataTypes.SMALLINT, TEST_DATA.OUT_OF_RANGE_FOR_SMALL_INT.longValueExact(),
-        // "Overflow"),
-        Arguments.of(DataTypes.TINYINT, TEST_DATA.OUT_OF_RANGE_FOR_TINYINT, "Overflow"),
+        Arguments.of(
+            DataTypes.SMALLINT, TEST_DATA.OVERFLOW_FOR_SMALLINT.longValueExact(), "Overflow"),
+        Arguments.of(
+            DataTypes.SMALLINT, TEST_DATA.UNDERFLOW_FOR_SMALLINT.longValueExact(), "Underflow"),
+        Arguments.of(DataTypes.TINYINT, TEST_DATA.OVERFLOW_FOR_TINYINT, "Overflow"),
         Arguments.of(
             DataTypes.TINYINT,
-            TEST_DATA.OUT_OF_RANGE_FOR_TINYINT.toBigIntegerExact(),
-            "BigInteger out of byte range")
-        // Arguments.of(DataTypes.TINYINT, TEST_DATA.OUT_OF_RANGE_FOR_TINY_INT.longValueExact()),
-        // "Overflow");
-        );
+            TEST_DATA.OVERFLOW_FOR_TINYINT.toBigIntegerExact(),
+            "BigInteger out of byte range"),
+        Arguments.of(
+            DataTypes.TINYINT, TEST_DATA.OVERFLOW_FOR_TINYINT.longValueExact(), "Overflow"),
+        Arguments.of(
+            DataTypes.TINYINT, TEST_DATA.UNDERFLOW_FOR_TINYINT.longValueExact(), "Underflow"));
   }
 
   @ParameterizedTest

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -236,7 +236,8 @@ public class JSONCodecRegistryTest {
             ToCQLCodecException.class,
             () -> codec.toCQL(valueToTest),
             String.format(
-                "Throw ToCQLCodecException for out of range `%s` %s", typeToTest, valueToTest));
+                "Throw ToCQLCodecException when attempting to convert `%s` from non-integer value %s",
+                typeToTest, valueToTest));
 
     assertThat(error)
         .satisfies(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -88,10 +88,21 @@ public class JSONCodecRegistryTest {
         // Integer types:
         Arguments.of(DataTypes.BIGINT, -456L, -456L),
         Arguments.of(DataTypes.BIGINT, BigInteger.valueOf(123), 123L),
-        Arguments.of(DataTypes.BIGINT, BigDecimal.valueOf(999), 999L),
-        Arguments.of(DataTypes.INT, -42L, -42), // second 42 is an int
-        Arguments.of(DataTypes.INT, BigInteger.valueOf(12), 12),
-        Arguments.of(DataTypes.INT, BigDecimal.valueOf(100), 100),
+        Arguments.of(DataTypes.BIGINT, BigDecimal.valueOf(999.0), 999L),
+        Arguments.of(DataTypes.INT, -42000L, -42000),
+        Arguments.of(DataTypes.INT, BigInteger.valueOf(19000), 19000),
+        Arguments.of(DataTypes.INT, BigDecimal.valueOf(23456.0), 23456),
+        Arguments.of(DataTypes.SMALLINT, -3999L, (short) -3999),
+        Arguments.of(DataTypes.SMALLINT, BigInteger.valueOf(1234), (short) 1234),
+        Arguments.of(DataTypes.SMALLINT, BigDecimal.valueOf(10911.0), (short) 10911),
+        Arguments.of(DataTypes.TINYINT, -39L, (byte) -39),
+        Arguments.of(DataTypes.TINYINT, BigInteger.valueOf(123), (byte) 123),
+        Arguments.of(DataTypes.TINYINT, BigDecimal.valueOf(109.0), (byte) 109),
+        Arguments.of(DataTypes.VARINT, -39999L, BigInteger.valueOf(-39999)),
+        Arguments.of(DataTypes.VARINT, BigInteger.valueOf(1), BigInteger.valueOf(1)),
+        Arguments.of(
+            DataTypes.VARINT, BigDecimal.valueOf(123456789.0), BigInteger.valueOf(123456789)),
+
         // Floating-point types:
         Arguments.of(DataTypes.DECIMAL, BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.25)));
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -93,8 +93,7 @@ public class JSONCodecRegistryTest {
         Arguments.of(DataTypes.INT, BigInteger.valueOf(12), 12),
         Arguments.of(DataTypes.INT, BigDecimal.valueOf(100), 100),
         // Floating-point types:
-        Arguments.of(DataTypes.DECIMAL, BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.25))
-    );
+        Arguments.of(DataTypes.DECIMAL, BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.25)));
   }
 
   @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -8,6 +8,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -82,12 +83,18 @@ public class JSONCodecRegistryTest {
 
   private static Stream<Arguments> codecToCQLTestCases() {
     // Arguments: (CQL-type, from-caller, bound-by-driver-for-cql
+    // Note: all Numeric types accept 3 Java types: Long, BigInteger, BigDecimal
     return Stream.of(
-        // Arguments.of(DataTypes.BIGINT, 123, 123L),
-        // Arguments.of(DataTypes.BIGINT, 999L, 999L),
+        // Integer types:
+        Arguments.of(DataTypes.BIGINT, -456L, -456L),
+        Arguments.of(DataTypes.BIGINT, BigInteger.valueOf(123), 123L),
         Arguments.of(DataTypes.BIGINT, BigDecimal.valueOf(999), 999L),
-        Arguments.of(DataTypes.INT, BigDecimal.valueOf(100), 100) // second 100 is an int
-        );
+        Arguments.of(DataTypes.INT, -42L, -42), // second 42 is an int
+        Arguments.of(DataTypes.INT, BigInteger.valueOf(12), 12),
+        Arguments.of(DataTypes.INT, BigDecimal.valueOf(100), 100),
+        // Floating-point types:
+        Arguments.of(DataTypes.DECIMAL, BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.25))
+    );
   }
 
   @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -81,7 +81,11 @@ public class JSONCodecRegistryTest {
   }
 
   private static Stream<Arguments> codecToCQLTestCases() {
+    // Arguments: (CQL-type, from-caller, bound-by-driver-for-cql
     return Stream.of(
+        // Arguments.of(DataTypes.BIGINT, 123, 123L),
+        // Arguments.of(DataTypes.BIGINT, 999L, 999L),
+        Arguments.of(DataTypes.BIGINT, BigDecimal.valueOf(999), 999L),
         Arguments.of(DataTypes.INT, BigDecimal.valueOf(100), 100) // second 100 is an int
         );
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTestData.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTestData.java
@@ -32,6 +32,8 @@ public class JSONCodecRegistryTestData {
   public final BigDecimal OUT_OF_RANGE_FOR_SMALLINT = BigDecimal.valueOf(Short.MAX_VALUE + 1L);
   public final BigDecimal OUT_OF_RANGE_FOR_TINYINT = BigDecimal.valueOf(Byte.MAX_VALUE + 1L);
 
+  public final BigDecimal NOT_EXACT_AS_INTEGER = new BigDecimal("1.25");
+
   /**
    * Returns a mocked {@link TableMetadata} that has a column of the specified type.
    *

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTestData.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTestData.java
@@ -26,7 +26,11 @@ public class JSONCodecRegistryTestData {
   public final String RANDOM_STRING = "random-" + System.currentTimeMillis();
   public final CqlIdentifier RANDOM_CQL_IDENTIFIER = CqlIdentifier.fromInternal(RANDOM_STRING);
 
-  public final BigDecimal OUT_OF_RANGE_FOR_TINY_INT = BigDecimal.valueOf(Short.MAX_VALUE + 1);
+  public final BigDecimal OUT_OF_RANGE_FOR_BIGINT =
+      BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+  public final BigDecimal OUT_OF_RANGE_FOR_INT = BigDecimal.valueOf(Integer.MAX_VALUE + 1L);
+  public final BigDecimal OUT_OF_RANGE_FOR_SMALLINT = BigDecimal.valueOf(Short.MAX_VALUE + 1L);
+  public final BigDecimal OUT_OF_RANGE_FOR_TINYINT = BigDecimal.valueOf(Byte.MAX_VALUE + 1L);
 
   /**
    * Returns a mocked {@link TableMetadata} that has a column of the specified type.

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTestData.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTestData.java
@@ -28,9 +28,13 @@ public class JSONCodecRegistryTestData {
 
   public final BigDecimal OUT_OF_RANGE_FOR_BIGINT =
       BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
-  public final BigDecimal OUT_OF_RANGE_FOR_INT = BigDecimal.valueOf(Integer.MAX_VALUE + 1L);
-  public final BigDecimal OUT_OF_RANGE_FOR_SMALLINT = BigDecimal.valueOf(Short.MAX_VALUE + 1L);
-  public final BigDecimal OUT_OF_RANGE_FOR_TINYINT = BigDecimal.valueOf(Byte.MAX_VALUE + 1L);
+
+  public final BigDecimal OVERFLOW_FOR_INT = BigDecimal.valueOf(Integer.MAX_VALUE + 1L);
+  public final BigDecimal UNDERFLOW_FOR_INT = BigDecimal.valueOf(Integer.MIN_VALUE - 1L);
+  public final BigDecimal OVERFLOW_FOR_SMALLINT = BigDecimal.valueOf(Short.MAX_VALUE + 1L);
+  public final BigDecimal UNDERFLOW_FOR_SMALLINT = BigDecimal.valueOf(Short.MIN_VALUE - 1L);
+  public final BigDecimal OVERFLOW_FOR_TINYINT = BigDecimal.valueOf(Byte.MAX_VALUE + 1L);
+  public final BigDecimal UNDERFLOW_FOR_TINYINT = BigDecimal.valueOf(Byte.MIN_VALUE - 1L);
 
   public final BigDecimal NOT_EXACT_AS_INTEGER = new BigDecimal("1.25");
 


### PR DESCRIPTION
**What this PR does**:

Changes table-shredding to convert JSON values (filter, insert) to use 3 types -- `Long`, `BigInteger`, `BigDecimal` -- instead of just `BigDecimal`, for less wasteful conversions (BigDecimal use for integral numbers is significant overhead).

Adds more CQL codecs to convert to/from CQL integral types; tests (Unit and Integration).

**Which issue(s) this PR fixes**:
Fixes #1365

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
