### PR TITLE
Fix a minor flaw in logging non-JsonApiException logging by CommandProcessor (missing stack trace)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
@@ -97,8 +97,8 @@ public class CommandProcessor {
               // But other exception types are unexpected, so log for now
               logger.warn(
                   String.format(
-                      "Command '%s' failed with %s",
-                      command.getClass().getSimpleName(), t.getClass().getSimpleName()),
+                      "Command '%s' failed with %s: %s",
+                      command.getClass().getSimpleName(), t.getClass().getName(), t.getMessage()),
                   t);
               return new ThrowableCommandResultSupplier(t);
             })

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
@@ -14,6 +14,7 @@ import io.stargate.sgv2.jsonapi.service.operation.Operation;
 import io.stargate.sgv2.jsonapi.service.resolver.CommandResolverService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,10 +96,11 @@ public class CommandProcessor {
                 return jsonApiException;
               }
               // But other exception types are unexpected, so log for now
+              final String message = Optional.ofNullable(t.getMessage()).orElse("[no message]");
               logger.warn(
                   String.format(
                       "Command '%s' failed with %s: %s",
-                      command.getClass().getSimpleName(), t.getClass().getName(), t.getMessage()),
+                      command.getClass().getSimpleName(), t.getClass().getName(), message),
                   t);
               return new ThrowableCommandResultSupplier(t);
             })

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
@@ -96,7 +96,10 @@ public class CommandProcessor {
               }
               // But other exception types are unexpected, so log for now
               logger.warn(
-                  "Command '{}' failed with exception", command.getClass().getSimpleName(), t);
+                  String.format(
+                      "Command '%s' failed with %s",
+                      command.getClass().getSimpleName(), t.getClass().getSimpleName()),
+                  t);
               return new ThrowableCommandResultSupplier(t);
             })
 


### PR DESCRIPTION
**What this PR does**:

Fixes a flaw in CommandProcessor logging of unhandled exceptions: was not including stack trace

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
