### PR TITLE
Fix #1383: map most recognized SERVER_ errors to 504 or 502, leave 500 for unrecognized

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -90,7 +90,7 @@ public final class ThrowableToErrorMapper {
     } else if (throwable instanceof ClosedConnectionException) {
       return ErrorCode.SERVER_CLOSED_CONNECTION
           .toApiException("(DriverException/ClosedConnectionException) %s", message)
-          .getCommandResultError(Response.Status.GATEWAY_TIMEOUT);
+          .getCommandResultError(Response.Status.BAD_GATEWAY);
     } else if (throwable instanceof CoordinatorException) {
       return handleCoordinatorException((CoordinatorException) throwable, message);
     } else if (throwable instanceof DriverTimeoutException) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperationTest.java
@@ -3018,15 +3018,15 @@ public class FindCollectionOperationTest extends OperationTestBase {
           ThrowableToErrorMapper.getMapperWithMessageFunction()
               .apply(failure, failure.getMessage());
       AssertionsForClassTypes.assertThat(error).isNotNull();
-      AssertionsForClassTypes.assertThat(error.message())
-          .isEqualTo(
-              "Database read failed: root cause: (com.datastax.oss.driver.api.core.servererrors.ReadFailureException) Cassandra failure during read query at consistency ONE (0 responses were required but only 1 replica responded, 1 failed)");
       AssertionsForClassTypes.assertThat(error.fields().get("errorCode"))
           .isEqualTo("SERVER_READ_FAILED");
       AssertionsForClassTypes.assertThat(error.fields().get("exceptionClass"))
           .isEqualTo("JsonApiException");
-      AssertionsForClassTypes.assertThat(error.status())
-          .isEqualTo(Response.Status.INTERNAL_SERVER_ERROR);
+      AssertionsForClassTypes.assertThat(error.status()).isEqualTo(Response.Status.BAD_GATEWAY);
+      AssertionsForClassTypes.assertThat(error.message())
+          .startsWith("Database read failed")
+          .endsWith(
+              "Cassandra failure during read query at consistency ONE (0 responses were required but only 1 replica responded, 1 failed)");
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Maps most former 500 http failures to 504 or 502, to indicate these are recognized failures with backend DB; 500 remains for unknown/unrecognized exceptions

**Which issue(s) this PR fixes**:
Fixes #1383

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
