### PR TITLE
(WIP) Fix #1396: allow use of `_id` column for tables

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AbstractTableIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AbstractTableIntegrationTestBase.java
@@ -40,6 +40,14 @@ public class AbstractTableIntegrationTestBase extends AbstractNamespaceIntegrati
         .body("status.ok", is(1));
   }
 
+  protected DataApiResponseValidator deleteTable(String tableName) {
+    // 09-Sep-2024, tatu: No separate "deleteTable" command, so use "deleteCollection":
+    return DataApiCommandSenders.assertNamespaceCommand(namespaceName)
+        .postCommand("deleteCollection", "{\"name\": \"%s\"}".formatted(tableName))
+        .hasNoErrors()
+        .body("status.ok", is(1));
+  }
+
   protected void insertOneInTable(String tableName, String documentJSON) {
     DataApiCommandSenders.assertTableCommand(namespaceName, tableName)
         .postInsertOne(documentJSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIntegrationTest.java
@@ -1,13 +1,7 @@
 package io.stargate.sgv2.jsonapi.api.v1.tables;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.is;
-
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.restassured.http.ContentType;
-import io.stargate.sgv2.jsonapi.api.v1.AbstractNamespaceIntegrationTestBase;
-import io.stargate.sgv2.jsonapi.api.v1.NamespaceResource;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
@@ -18,16 +12,15 @@ import org.junit.jupiter.api.TestClassOrder;
 @QuarkusIntegrationTest
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
-class CreateTableIntegrationTest extends AbstractNamespaceIntegrationTestBase {
+class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
   @Nested
   @Order(1)
-  class CreateTable {
+  class CreateTableOk {
     @Test
     public void primaryKeyAsString() {
-      String json =
+      String tableDef =
           """
                             {
-                                 "createTable": {
                                      "name": "primaryKeyAsStringTable",
                                      "definition": {
                                          "columns": {
@@ -43,28 +36,19 @@ class CreateTableIntegrationTest extends AbstractNamespaceIntegrationTestBase {
                                          },
                                          "primaryKey": "id"
                                      }
-                                 }
                              }
                     """;
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(NamespaceResource.BASE_PATH, namespaceName)
-          .then()
-          .statusCode(200)
-          .body("status.ok", is(1));
+      // createTable() validates command succeeds and response is OK:
+      createTable(tableDef);
       deleteTable("primaryKeyAsStringTable");
     }
 
     @Test
     public void primaryKeyAsJsonObject() {
 
-      String json =
+      String tableDef =
           """
                         {
-                            "createTable": {
                                 "name": "primaryKeyAsJsonObjectTable",
                                 "definition": {
                                     "columns": {
@@ -87,39 +71,10 @@ class CreateTableIntegrationTest extends AbstractNamespaceIntegrationTestBase {
                                         }
                                     }
                                 }
-                            }
                         }
                     """;
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(NamespaceResource.BASE_PATH, namespaceName)
-          .then()
-          .statusCode(200)
-          .body("status.ok", is(1));
+      createTable(tableDef);
       deleteTable("primaryKeyAsJsonObjectTable");
     }
-  }
-
-  private void deleteTable(String tableName) {
-    given()
-        .headers(getHeaders())
-        .contentType(ContentType.JSON)
-        .body(
-                """
-                                {
-                                  "deleteCollection": {
-                                    "name": "%s"
-                                  }
-                                }
-                                """
-                .formatted(tableName))
-        .when()
-        .post(NamespaceResource.BASE_PATH, namespaceName)
-        .then()
-        .statusCode(200)
-        .body("status.ok", is(1));
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds test(s) for, fixes issue #1396: problem with `_id` for `createTable` command

**Which issue(s) this PR fixes**:
Fixes #1396

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
