### PR TITLE
Minor refactoring: hide type, name fields of SchemaObject

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
@@ -178,9 +178,9 @@ public record CommandContext<T extends SchemaObject>(
 
   private void checkSchemaObjectType(SchemaObject.SchemaObjectType expectedType) {
     Preconditions.checkArgument(
-        schemaObject().type == expectedType,
+        schemaObject().type() == expectedType,
         "SchemaObject type actual was %s expected was %s ",
-        schemaObject().type,
+        schemaObject().type(),
         expectedType);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/InvertibleCommandClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/InvertibleCommandClause.java
@@ -29,7 +29,7 @@ public interface InvertibleCommandClause {
     if (invertible == null) {
       return;
     }
-    switch (commandContext.schemaObject().type) {
+    switch (commandContext.schemaObject().type()) {
       case COLLECTION:
         invertible.invertForCollectionCommand(commandContext.asCollectionContext());
         break;
@@ -38,7 +38,7 @@ public interface InvertibleCommandClause {
         break;
       default:
         throw new UnsupportedOperationException(
-            String.format("Unsupported schema type: %s", commandContext.schemaObject().type));
+            String.format("Unsupported schema type: %s", commandContext.schemaObject().type()));
     }
   }
 
@@ -57,7 +57,7 @@ public interface InvertibleCommandClause {
     throw new UnsupportedOperationException(
         String.format(
             "%s Clause does not support invert for Collections, target was %s",
-            getClass().getSimpleName(), commandContext.schemaObject().name));
+            getClass().getSimpleName(), commandContext.schemaObject().name()));
   }
 
   /**
@@ -75,6 +75,6 @@ public interface InvertibleCommandClause {
     throw new UnsupportedOperationException(
         String.format(
             "%s Clause does not support invert for Tables, target was %s",
-            getClass().getSimpleName(), commandContext.schemaObject().name));
+            getClass().getSimpleName(), commandContext.schemaObject().name()));
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/ValidatableCommandClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/ValidatableCommandClause.java
@@ -35,7 +35,7 @@ public interface ValidatableCommandClause {
       return;
     }
 
-    switch (commandContext.schemaObject().type) {
+    switch (commandContext.schemaObject().type()) {
       case COLLECTION:
         validatable.validateCollectionCommand(commandContext.asCollectionContext());
         break;
@@ -50,7 +50,7 @@ public interface ValidatableCommandClause {
         break;
       default:
         throw new UnsupportedOperationException(
-            String.format("Unsupported schema type: %s", commandContext.schemaObject().type));
+            String.format("Unsupported schema type: %s", commandContext.schemaObject().type()));
     }
   }
 
@@ -69,7 +69,7 @@ public interface ValidatableCommandClause {
     throw new UnsupportedOperationException(
         String.format(
             "validateCollectionCommand: %s Clause does not support validating for Collections, target was %s",
-            getClass().getSimpleName(), commandContext.schemaObject().name));
+            getClass().getSimpleName(), commandContext.schemaObject().name()));
   }
 
   /**
@@ -87,7 +87,7 @@ public interface ValidatableCommandClause {
     throw new UnsupportedOperationException(
         String.format(
             "validateTableCommand: %s Clause does not support validating for Tables, target was %s",
-            getClass().getSimpleName(), commandContext.schemaObject().name));
+            getClass().getSimpleName(), commandContext.schemaObject().name()));
   }
 
   /**
@@ -105,7 +105,7 @@ public interface ValidatableCommandClause {
     throw new UnsupportedOperationException(
         String.format(
             "validateNamespaceCommand: %s Clause does not support validating for Namespaces, target was %s",
-            getClass().getSimpleName(), commandContext.schemaObject().name));
+            getClass().getSimpleName(), commandContext.schemaObject().name()));
   }
 
   /**
@@ -123,6 +123,6 @@ public interface ValidatableCommandClause {
     throw new UnsupportedOperationException(
         String.format(
             "validateDatabaseCommand: %s Clause does not support validating for Databases, target was %s",
-            getClass().getSimpleName(), commandContext.schemaObject().name));
+            getClass().getSimpleName(), commandContext.schemaObject().name()));
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -191,7 +191,7 @@ public class CollectionResource {
                 final ApiFeatures apiFeatures =
                     ApiFeatures.fromConfigAndRequest(
                         apiFeatureConfig, dataApiRequestInfo.getHttpHeaders());
-                if ((schemaObject.type == SchemaObject.SchemaObjectType.TABLE)
+                if ((schemaObject.type() == SchemaObject.SchemaObjectType.TABLE)
                     && !apiFeatures.isFeatureEnabled(ApiFeature.TABLES)) {
                   return Uni.createFrom()
                       .failure(ErrorCodeV1.TABLE_FEATURE_NOT_ENABLED.toApiException());

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorFormatters.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorFormatters.java
@@ -86,9 +86,9 @@ public abstract class ErrorFormatters {
   public static Map<String, String> errVars(
       SchemaObject schemaObject, Consumer<Map<String, String>> consumer) {
     Map<String, String> map = new HashMap<>();
-    map.put(TemplateVars.SCHEMA_TYPE, schemaObject.type.name());
-    map.put(TemplateVars.KEYSPACE, schemaObject.name.keyspace());
-    map.put(TemplateVars.TABLE, schemaObject.name.table());
+    map.put(TemplateVars.SCHEMA_TYPE, schemaObject.type().name());
+    map.put(TemplateVars.KEYSPACE, schemaObject.name().keyspace());
+    map.put(TemplateVars.TABLE, schemaObject.name().table());
     if (consumer != null) {
       consumer.accept(map);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/SchemaObject.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/SchemaObject.java
@@ -12,12 +12,20 @@ public abstract class SchemaObject {
     DATABASE
   }
 
-  public final SchemaObjectType type;
-  public final SchemaObjectName name;
+  protected final SchemaObjectType type;
+  protected final SchemaObjectName name;
 
   protected SchemaObject(SchemaObjectType type, SchemaObjectName name) {
     this.type = type;
     this.name = name;
+  }
+
+  public SchemaObjectType type() {
+    return type;
+  }
+
+  public SchemaObjectName name() {
+    return name;
   }
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
@@ -96,7 +96,7 @@ public class DataVectorizer {
       if (!vectorizeTexts.isEmpty()) {
         if (embeddingProvider == null) {
           throw ErrorCodeV1.EMBEDDING_SERVICE_NOT_CONFIGURED.toApiException(
-              schemaObject.name.table());
+              schemaObject.name().table());
         }
         Uni<List<float[]>> vectors =
             embeddingProvider
@@ -196,7 +196,7 @@ public class DataVectorizer {
         String text = expression.vectorize();
         if (embeddingProvider == null) {
           throw ErrorCodeV1.EMBEDDING_SERVICE_NOT_CONFIGURED.toApiException(
-              schemaObject.name.table());
+              schemaObject.name().table());
         }
         Uni<List<float[]>> vectors =
             embeddingProvider

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CountCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CountCollectionOperation.java
@@ -56,8 +56,8 @@ public record CountCollectionOperation(
               .count()
               .as("count")
               .from(
-                  commandContext.schemaObject().name.keyspace(),
-                  commandContext.schemaObject().name.table())
+                  commandContext.schemaObject().name().keyspace(),
+                  commandContext.schemaObject().name().table())
               .where(expressions.get(0))
               .build();
     } else {
@@ -66,8 +66,8 @@ public record CountCollectionOperation(
               .select()
               .column("key")
               .from(
-                  commandContext.schemaObject().name.keyspace(),
-                  commandContext.schemaObject().name.table())
+                  commandContext.schemaObject().name().keyspace(),
+                  commandContext.schemaObject().name().table())
               .where(expressions.get(0))
               .limit(limit + 1)
               .build();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/DeleteCollectionCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/DeleteCollectionCollectionOperation.java
@@ -29,7 +29,7 @@ public record DeleteCollectionCollectionOperation(
   public Uni<Supplier<CommandResult>> execute(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     logger.info("Executing DeleteCollectionCollectionOperation for {}", name);
-    String cql = DROP_TABLE_CQL.formatted(context.schemaObject().name.keyspace(), name);
+    String cql = DROP_TABLE_CQL.formatted(context.schemaObject().name().keyspace(), name);
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute
     return queryExecutor

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/DeleteCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/DeleteCollectionOperation.java
@@ -167,8 +167,8 @@ public record DeleteCollectionOperation(
     String delete = "DELETE FROM \"%s\".\"%s\" WHERE key = ? IF tx_id = ?";
     return String.format(
         delete,
-        commandContext.schemaObject().name.keyspace(),
-        commandContext.schemaObject().name.table());
+        commandContext.schemaObject().name().keyspace(),
+        commandContext.schemaObject().name().table());
   }
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/EstimatedDocumentCountCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/EstimatedDocumentCountCollectionOperation.java
@@ -34,9 +34,9 @@ public record EstimatedDocumentCountCollectionOperation<T extends SchemaObject>(
     return selectFrom("system", "size_estimates")
         .all()
         .whereColumn("keyspace_name")
-        .isEqualTo(literal(commandContext.schemaObject().name.keyspace()))
+        .isEqualTo(literal(commandContext.schemaObject().name().keyspace()))
         .whereColumn("table_name")
-        .isEqualTo(literal(commandContext.schemaObject().name.table()))
+        .isEqualTo(literal(commandContext.schemaObject().name().table()))
         .build();
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperation.java
@@ -307,7 +307,7 @@ public record FindCollectionOperation(
       return Uni.createFrom()
           .failure(
               ErrorCodeV1.VECTOR_SEARCH_NOT_SUPPORTED.toApiException(
-                  "%s", commandContext().schemaObject().name.table()));
+                  "%s", commandContext().schemaObject().name().table()));
     }
     // get FindResponse
     return getDocuments(dataApiRequestInfo, queryExecutor, pageState(), null)
@@ -456,8 +456,8 @@ public record FindCollectionOperation(
                             ? documentColumns
                             : documentKeyColumns)
                     .from(
-                        commandContext.schemaObject().name.keyspace(),
-                        commandContext.schemaObject().name.table())
+                        commandContext.schemaObject().name().keyspace(),
+                        commandContext.schemaObject().name().table())
                     .where(expression)
                     .limit(limit)
                     .build();
@@ -483,8 +483,8 @@ public record FindCollectionOperation(
               DocumentConstants.Fields.VECTOR_SEARCH_INDEX_COLUMN_NAME,
               commandContext().schemaObject().similarityFunction())
           .from(
-              commandContext.schemaObject().name.keyspace(),
-              commandContext.schemaObject().name.table())
+              commandContext.schemaObject().name().keyspace(),
+              commandContext.schemaObject().name().table())
           .where(expression)
           .limit(limit)
           .vsearch(DocumentConstants.Fields.VECTOR_SEARCH_INDEX_COLUMN_NAME, vector())
@@ -494,8 +494,8 @@ public record FindCollectionOperation(
           .select()
           .column(CollectionReadType.DOCUMENT == readType ? documentColumns : documentKeyColumns)
           .from(
-              commandContext.schemaObject().name.keyspace(),
-              commandContext.schemaObject().name.table())
+              commandContext.schemaObject().name().keyspace(),
+              commandContext.schemaObject().name().table())
           .where(expression)
           .limit(limit)
           .vsearch(DocumentConstants.Fields.VECTOR_SEARCH_INDEX_COLUMN_NAME, vector())
@@ -532,8 +532,8 @@ public record FindCollectionOperation(
                   .select()
                   .column(columnsToAdd)
                   .from(
-                      commandContext.schemaObject().name.keyspace(),
-                      commandContext.schemaObject().name.table())
+                      commandContext.schemaObject().name().keyspace(),
+                      commandContext.schemaObject().name().table())
                   .where(expression)
                   .limit(maxSortReadLimit())
                   .build();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionsCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionsCollectionOperation.java
@@ -60,13 +60,13 @@ public record FindCollectionsCollectionOperation(
             .getSession(dataApiRequestInfo)
             .getMetadata()
             .getKeyspaces()
-            .get(CqlIdentifier.fromInternal(commandContext.schemaObject().name.keyspace()));
+            .get(CqlIdentifier.fromInternal(commandContext.schemaObject().name().keyspace()));
     if (keyspaceMetadata == null) {
       return Uni.createFrom()
           .failure(
               ErrorCodeV1.NAMESPACE_DOES_NOT_EXIST.toApiException(
                   "Unknown namespace '%s', you must create it first",
-                  commandContext.schemaObject().name.keyspace()));
+                  commandContext.schemaObject().name().keyspace()));
     }
     return Uni.createFrom()
         .item(
@@ -106,7 +106,7 @@ public record FindCollectionsCollectionOperation(
         return new CommandResult(statuses);
       } else {
         List<String> tables =
-            collections.stream().map(schemaObject -> schemaObject.name.table()).toList();
+            collections.stream().map(schemaObject -> schemaObject.name().table()).toList();
         Map<CommandStatus, Object> statuses = Map.of(CommandStatus.EXISTING_COLLECTIONS, tables);
         return new CommandResult(statuses);
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/InsertCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/InsertCollectionOperation.java
@@ -75,7 +75,7 @@ public record InsertCollectionOperation(
     final boolean vectorEnabled = commandContext().schemaObject().isVectorEnabled();
     if (!vectorEnabled && insertions.stream().anyMatch(insertion -> insertion.hasVectorValues())) {
       throw ErrorCodeV1.VECTOR_SEARCH_NOT_SUPPORTED.toApiException(
-          commandContext().schemaObject().name.table());
+          commandContext().schemaObject().name().table());
     }
     // create json doc write metrics
     if (commandContext.jsonProcessingMetricsReporter() != null) {
@@ -233,8 +233,8 @@ public record InsertCollectionOperation(
       // IF NOT EXISTS clause
       return String.format(
           insertWithVector,
-          commandContext.schemaObject().name.keyspace(),
-          commandContext.schemaObject().name.table());
+          commandContext.schemaObject().name().keyspace(),
+          commandContext.schemaObject().name().table());
     } else {
       String insert =
           "INSERT INTO \"%s\".\"%s\""
@@ -246,8 +246,8 @@ public record InsertCollectionOperation(
       // IF NOT EXISTS clause
       return String.format(
           insert,
-          commandContext.schemaObject().name.keyspace(),
-          commandContext.schemaObject().name.table());
+          commandContext.schemaObject().name().keyspace(),
+          commandContext.schemaObject().name().table());
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperation.java
@@ -287,8 +287,8 @@ public record ReadAndUpdateCollectionOperation(
               + "            tx_id = ?";
       return String.format(
           update,
-          commandContext.schemaObject().name.keyspace(),
-          commandContext.schemaObject().name.table());
+          commandContext.schemaObject().name().keyspace(),
+          commandContext.schemaObject().name().table());
     } else {
       String update =
           "UPDATE \"%s\".\"%s\" "
@@ -309,8 +309,8 @@ public record ReadAndUpdateCollectionOperation(
               + "            tx_id = ?";
       return String.format(
           update,
-          commandContext.schemaObject().name.keyspace(),
-          commandContext.schemaObject().name.table());
+          commandContext.schemaObject().name().keyspace(),
+          commandContext.schemaObject().name().table());
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/TruncateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/TruncateCollectionOperation.java
@@ -25,10 +25,10 @@ public record TruncateCollectionOperation(CommandContext<CollectionSchemaObject>
   @Override
   public Uni<Supplier<CommandResult>> execute(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
-    logger.info("Executing TruncateCollectionOperation for {}", context.schemaObject().name);
+    logger.info("Executing TruncateCollectionOperation for {}", context.schemaObject().name());
     String cql =
         TRUNCATE_TABLE_CQL.formatted(
-            context.schemaObject().name.keyspace(), context.schemaObject().name.table());
+            context.schemaObject().name().keyspace(), context.schemaObject().name().table());
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute
     return queryExecutor

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/AddIndexOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/AddIndexOperation.java
@@ -33,15 +33,15 @@ public record AddIndexOperation(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     logger.info(
         "Executing AddIndexOperation for {} {} {} {}",
-        context.schemaObject().name.keyspace(),
-        context.schemaObject().name.table(),
+        context.schemaObject().name().keyspace(),
+        context.schemaObject().name().table(),
         columnName,
         indexName);
     String cql =
         ADD_INDEX_TEMPLATE.formatted(
             indexName,
-            context.schemaObject().name.keyspace(),
-            context.schemaObject().name.table(),
+            context.schemaObject().name().keyspace(),
+            context.schemaObject().name().table(),
             columnName);
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/CreateTableOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/CreateTableOperation.java
@@ -58,7 +58,7 @@ public class CreateTableOperation implements Operation {
   public Uni<Supplier<CommandResult>> execute(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     CqlIdentifier keyspaceIdentifier =
-        CqlIdentifier.fromInternal(commandContext.schemaObject().name.keyspace());
+        CqlIdentifier.fromInternal(commandContext.schemaObject().name().keyspace());
     CqlIdentifier tableIdentifier = CqlIdentifier.fromInternal(tableName);
     CreateTableStart create = createTable(keyspaceIdentifier, tableIdentifier).ifNotExists();
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/DropIndexOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/DropIndexOperation.java
@@ -30,10 +30,10 @@ public record DropIndexOperation(CommandContext<TableSchemaObject> context, Stri
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     logger.info(
         "Executing AddIndexOperation for {} {} {}",
-        context.schemaObject().name.keyspace(),
-        context.schemaObject().name.table(),
+        context.schemaObject().name().keyspace(),
+        context.schemaObject().name().table(),
         indexName);
-    String cql = DROP_INDEX_TEMPLATE.formatted(context.schemaObject().name.keyspace(), indexName);
+    String cql = DROP_INDEX_TEMPLATE.formatted(context.schemaObject().name().keyspace(), indexName);
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute
     return queryExecutor

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/DropTableOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/DropTableOperation.java
@@ -29,7 +29,7 @@ public record DropTableOperation(CommandContext<KeyspaceSchemaObject> context, S
   public Uni<Supplier<CommandResult>> execute(
       DataApiRequestInfo dataApiRequestInfo, QueryExecutor queryExecutor) {
     logger.info("Executing DropTableOperation for {}", name);
-    String cql = DROP_TABLE_CQL.formatted(context.schemaObject().name.keyspace(), name);
+    String cql = DROP_TABLE_CQL.formatted(context.schemaObject().name().keyspace(), name);
     SimpleStatement query = SimpleStatement.newInstance(cql);
     // execute
     return queryExecutor

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -101,7 +101,7 @@ public class MeteredCommandProcessor {
       DataApiRequestInfo dataApiRequestInfo, CommandContext<U> commandContext, T command) {
     Timer.Sample sample = Timer.start(meterRegistry);
     // use MDC to populate logs as needed(namespace,collection,tenantId)
-    commandContext.schemaObject().name.addToMDC();
+    commandContext.schemaObject().name().addToMDC();
 
     MDC.put("tenantId", dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE));
     // start by resolving the command, get resolver
@@ -141,9 +141,9 @@ public class MeteredCommandProcessor {
         new CommandLog(
             command.getClass().getSimpleName(),
             dataApiRequestInfo.getTenantId().orElse(UNKNOWN_VALUE),
-            commandContext.schemaObject().name.keyspace(),
-            commandContext.schemaObject().name.table(),
-            commandContext.schemaObject().type.name(),
+            commandContext.schemaObject().name().keyspace(),
+            commandContext.schemaObject().name().table(),
+            commandContext.schemaObject().type().name(),
             getIncomingDocumentsCount(command),
             getOutgoingDocumentsCount(result),
             result != null ? result.errors() : Collections.emptyList());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolver.java
@@ -60,7 +60,7 @@ public interface CommandResolver<C extends Command> {
     Objects.requireNonNull(commandContext, "commandContext must not be null");
     Objects.requireNonNull(command, "command must not be null");
 
-    return switch (commandContext.schemaObject().type) {
+    return switch (commandContext.schemaObject().type()) {
       case COLLECTION -> resolveCollectionCommand(commandContext.asCollectionContext(), command);
       case TABLE -> resolveTableCommand(commandContext.asTableContext(), command);
       case KEYSPACE -> resolveKeyspaceCommand(commandContext.asKeyspaceContext(), command);
@@ -80,7 +80,7 @@ public interface CommandResolver<C extends Command> {
     // throw error as a fallback to make sure method is implemented, commands are tested well
     throw ErrorCodeV1.SERVER_INTERNAL_ERROR.toApiException(
         "%s Command does not support operating on Collections, target was %s",
-        command.getClass().getSimpleName(), ctx.schemaObject().name);
+        command.getClass().getSimpleName(), ctx.schemaObject().name());
   }
   ;
 
@@ -95,7 +95,7 @@ public interface CommandResolver<C extends Command> {
     // throw error as a fallback to make sure method is implemented, commands are tested well
     throw ErrorCodeV1.SERVER_INTERNAL_ERROR.toApiException(
         "%s Command does not support operating on Tables, target was %s",
-        command.getClass().getSimpleName(), ctx.schemaObject().name);
+        command.getClass().getSimpleName(), ctx.schemaObject().name());
   }
 
   /**
@@ -109,7 +109,7 @@ public interface CommandResolver<C extends Command> {
     // throw error as a fallback to make sure method is implemented, commands are tested well
     throw ErrorCodeV1.SERVER_INTERNAL_ERROR.toApiException(
         "%s Command does not support operating on Keyspaces, target was %s",
-        command.getClass().getSimpleName(), ctx.schemaObject().name);
+        command.getClass().getSimpleName(), ctx.schemaObject().name());
   }
 
   /**
@@ -123,7 +123,7 @@ public interface CommandResolver<C extends Command> {
     // throw error as a fallback to make sure method is implemented, commands are tested well
     throw ErrorCodeV1.SERVER_INTERNAL_ERROR.toApiException(
         "%s Command does not support operating on Databases, target was %s",
-        command.getClass().getSimpleName(), ctx.schemaObject().name);
+        command.getClass().getSimpleName(), ctx.schemaObject().name());
   }
 
   static final String UNKNOWN_VALUE = "unknown";

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
@@ -163,7 +163,7 @@ public class CommandResolverWithVectorizerTest {
                 assertThat(exception.getMessage())
                     .isEqualTo(
                         "Unable to vectorize data, embedding service not configured for the collection : "
-                            + VECTOR_COMMAND_CONTEXT.schemaObject().name.table());
+                            + VECTOR_COMMAND_CONTEXT.schemaObject().name().table());
                 assertThat(exception.getErrorCode())
                     .isEqualTo(ErrorCodeV1.EMBEDDING_SERVICE_NOT_CONFIGURED);
               });
@@ -345,7 +345,7 @@ public class CommandResolverWithVectorizerTest {
                 assertThat(exception.getMessage())
                     .isEqualTo(
                         "Unable to vectorize data, embedding service not configured for the collection : "
-                            + VECTOR_COMMAND_CONTEXT.schemaObject().name.table());
+                            + VECTOR_COMMAND_CONTEXT.schemaObject().name().table());
                 assertThat(exception.getErrorCode())
                     .isEqualTo(ErrorCodeV1.EMBEDDING_SERVICE_NOT_CONFIGURED);
               });
@@ -562,7 +562,7 @@ public class CommandResolverWithVectorizerTest {
                 assertThat(exception.getMessage())
                     .isEqualTo(
                         "Unable to vectorize data, embedding service not configured for the collection : "
-                            + VECTOR_COMMAND_CONTEXT.schemaObject().name.table());
+                            + VECTOR_COMMAND_CONTEXT.schemaObject().name().table());
                 assertThat(exception.getErrorCode())
                     .isEqualTo(ErrorCodeV1.EMBEDDING_SERVICE_NOT_CONFIGURED);
               });


### PR DESCRIPTION
**What this PR does**:

Refactoring to avoid direct field access

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
