### PR TITLE
Add publicCommandName for command interface, add PublicCommandName enum

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -32,7 +32,7 @@ public interface Command {
   /**
    * commandName that refers to the public command name
    *
-   * <p>e.g. FindKeyspacesCommand publicCommandName -> findKeyspaces CreateCollectionCommand
+   * <p>e.g. FindKeyspacesCommand publicCommandName -> findKeyspaces. CreateCollectionCommand
    * publicCommandName -> createCollection
    */
   PublicCommandName publicCommandName();

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -30,15 +30,15 @@ import io.stargate.sgv2.jsonapi.service.resolver.CommandResolver;
 public interface Command {
 
   /**
-   * commandName that refers to the public command name
+   * commandName that refers to the api command name
    *
    * <p>e.g. FindKeyspacesCommand publicCommandName -> findKeyspaces. CreateCollectionCommand
    * publicCommandName -> createCollection
    */
-  PublicCommandName publicCommandName();
+  CommandName commandName();
 
-  /** Enum class for API public command name. This is what user uses for command json body. */
-  enum PublicCommandName {
+  /** Enum class for API command name. This is what user uses for command json body. */
+  enum CommandName {
     ADD_INDEX("addIndex"),
     COUNT_DOCUMENTS("countDocuments"),
     CREATE_COLLECTION("createCollection"),
@@ -64,14 +64,14 @@ public interface Command {
     UPDATE_MANY("updateMany"),
     UPDATE_ONE("updateOne");
 
-    private final String publicCommandName;
+    private final String apiName;
 
-    PublicCommandName(String publicCommandName) {
-      this.publicCommandName = publicCommandName;
+    CommandName(String apiName) {
+      this.apiName = apiName;
     }
 
-    public String getPublicCommandName() {
-      return publicCommandName;
+    public String getApiName() {
+      return apiName;
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -37,32 +37,32 @@ public interface Command {
    */
   PublicCommandName publicCommandName();
 
-  /** Enum class for API public command name This is what user uses for command json body. */
+  /** Enum class for API public command name. This is what user uses for command json body. */
   enum PublicCommandName {
-    addIndex("addIndex"),
-    countDocuments("countDocuments"),
-    createCollection("createCollection"),
-    createNamespace("createNamespace"),
-    createTable("createTable"),
-    deleteCollection("deleteCollection"),
-    deleteMany("deleteMany"),
-    deleteOne("deleteOne"),
-    dropIndex("dropIndex"),
-    dropNamespace("dropNamespace"),
-    dropTable("dropTable"),
-    estimatedDocumentCount("estimatedDocumentCount"),
-    findCollections("findCollections"),
-    find("find"),
-    findEmbeddingProviders("findEmbeddingProviders"),
-    findNamespaces("findNamespaces"),
-    findOneAndDelete("findOneAndDelete"),
-    findOneAndReplace("findOneAndReplace"),
-    findOneAndUpdate("findOneAndUpdate"),
-    findOne("findOne"),
-    insertMany("insertMany"),
-    insertOne("insertOne"),
-    updateMany("updateMany"),
-    updateOne("updateOne");
+    ADD_INDEX("addIndex"),
+    COUNT_DOCUMENTS("countDocuments"),
+    CREATE_COLLECTION("createCollection"),
+    CREATE_NAMESPACE("createNamespace"),
+    CREATE_TABLE("createTable"),
+    DELETE_COLLECTION("deleteCollection"),
+    DELETE_MANY("deleteMany"),
+    DELETE_ONE("deleteOne"),
+    DROP_INDEX("dropIndex"),
+    DROP_NAMESPACE("dropNamespace"),
+    DROP_TABLE("dropTable"),
+    ESTIMATED_DOCUMENT_COUNT("estimatedDocumentCount"),
+    FIND_COLLECTIONS("findCollections"),
+    FIND("find"),
+    FIND_EMBEDDING_PROVIDERS("findEmbeddingProviders"),
+    FIND_NAMESPACES("findNamespaces"),
+    FIND_ONE_AND_DELETE("findOneAndDelete"),
+    FIND_ONE_AND_REPLACE("findOneAndReplace"),
+    FIND_ONE_AND_UPDATE("findOneAndUpdate"),
+    FIND_ONE("findOne"),
+    INSERT_MANY("insertMany"),
+    INSERT_ONE("insertOne"),
+    UPDATE_MANY("updateMany"),
+    UPDATE_ONE("updateOne");
 
     private final String publicCommandName;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -27,4 +27,51 @@ import io.stargate.sgv2.jsonapi.service.resolver.CommandResolver;
   @JsonSubTypes.Type(value = GeneralCommand.class),
   @JsonSubTypes.Type(value = CollectionCommand.class),
 })
-public interface Command {}
+public interface Command {
+
+  /**
+   * commandName that refers to the public command name
+   *
+   * <p>e.g. FindKeyspacesCommand publicCommandName -> findKeyspaces CreateCollectionCommand
+   * publicCommandName -> createCollection
+   */
+  PublicCommandName publicCommandName();
+
+  /** Enum class for API public command name This is what user uses for command json body. */
+  enum PublicCommandName {
+    addIndex("addIndex"),
+    countDocuments("countDocuments"),
+    createCollection("createCollection"),
+    createNamespace("createNamespace"),
+    createTable("createTable"),
+    deleteCollection("deleteCollection"),
+    deleteMany("deleteMany"),
+    deleteOne("deleteOne"),
+    dropIndex("dropIndex"),
+    dropNamespace("dropNamespace"),
+    dropTable("dropTable"),
+    estimatedDocumentCount("estimatedDocumentCount"),
+    findCollections("findCollections"),
+    find("find"),
+    findEmbeddingProviders("findEmbeddingProviders"),
+    findNamespaces("findNamespaces"),
+    findOneAndDelete("findOneAndDelete"),
+    findOneAndReplace("findOneAndReplace"),
+    findOneAndUpdate("findOneAndUpdate"),
+    findOne("findOne"),
+    insertMany("insertMany"),
+    insertOne("insertOne"),
+    updateMany("updateMany"),
+    updateOne("updateOne");
+
+    private final String publicCommandName;
+
+    PublicCommandName(String publicCommandName) {
+      this.publicCommandName = publicCommandName;
+    }
+
+    public String getPublicCommandName() {
+      return publicCommandName;
+    }
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/AddIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/AddIndexCommand.java
@@ -28,6 +28,6 @@ public record AddIndexCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.addIndex;
+    return PublicCommandName.ADD_INDEX;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/AddIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/AddIndexCommand.java
@@ -23,4 +23,11 @@ public record AddIndexCommand(
         @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
         @Schema(description = "Unique name for the index.")
         String indexName)
-    implements NoOptionsCommand, CollectionCommand {}
+    implements NoOptionsCommand, CollectionCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.addIndex;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/AddIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/AddIndexCommand.java
@@ -27,7 +27,7 @@ public record AddIndexCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.ADD_INDEX;
+  public CommandName commandName() {
+    return CommandName.ADD_INDEX;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommand.java
@@ -14,4 +14,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
         "Command that returns count of documents in a collection based on the collection.")
 @JsonTypeName("countDocuments")
 public record CountDocumentsCommand(@Valid @JsonProperty("filter") FilterClause filterClause)
-    implements ReadCommand, NoOptionsCommand, Filterable {}
+    implements ReadCommand, NoOptionsCommand, Filterable {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.countDocuments;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommand.java
@@ -19,6 +19,6 @@ public record CountDocumentsCommand(@Valid @JsonProperty("filter") FilterClause 
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.countDocuments;
+    return PublicCommandName.COUNT_DOCUMENTS;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommand.java
@@ -18,7 +18,7 @@ public record CountDocumentsCommand(@Valid @JsonProperty("filter") FilterClause 
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.COUNT_DOCUMENTS;
+  public CommandName commandName() {
+    return CommandName.COUNT_DOCUMENTS;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -281,7 +281,7 @@ public record CreateCollectionCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.CREATE_COLLECTION;
+  public CommandName commandName() {
+    return CommandName.CREATE_COLLECTION;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -282,6 +282,6 @@ public record CreateCollectionCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.createCollection;
+    return PublicCommandName.CREATE_COLLECTION;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -278,4 +278,10 @@ public record CreateCollectionCommand(
       this.indexing = indexing;
     }
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.createCollection;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
@@ -61,7 +61,7 @@ public record CreateNamespaceCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.CREATE_NAMESPACE;
+  public CommandName commandName() {
+    return CommandName.CREATE_NAMESPACE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
@@ -58,4 +58,10 @@ public record CreateNamespaceCommand(
       return strategyOptions;
     }
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.createNamespace;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
@@ -62,6 +62,6 @@ public record CreateNamespaceCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.createNamespace;
+    return PublicCommandName.CREATE_NAMESPACE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTableCommand.java
@@ -36,4 +36,10 @@ public record CreateTableCommand(
               anyOf = {String.class, PrimaryKey.class})
           @JsonInclude(JsonInclude.Include.NON_NULL)
           PrimaryKey primaryKey) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.createTable;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTableCommand.java
@@ -39,7 +39,7 @@ public record CreateTableCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.CREATE_TABLE;
+  public CommandName commandName() {
+    return CommandName.CREATE_TABLE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTableCommand.java
@@ -40,6 +40,6 @@ public record CreateTableCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.createTable;
+    return PublicCommandName.CREATE_TABLE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
@@ -21,4 +21,11 @@ public record DeleteCollectionCommand(
         @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
         @Schema(description = "Name of the collection")
         String name)
-    implements CollectionOnlyCommand, NoOptionsCommand {}
+    implements CollectionOnlyCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.deleteCollection;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
@@ -25,7 +25,7 @@ public record DeleteCollectionCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.DELETE_COLLECTION;
+  public CommandName commandName() {
+    return CommandName.DELETE_COLLECTION;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
@@ -26,6 +26,6 @@ public record DeleteCollectionCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.deleteCollection;
+    return PublicCommandName.DELETE_COLLECTION;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteManyCommand.java
@@ -30,7 +30,7 @@ public record DeleteManyCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.DELETE_MANY;
+  public CommandName commandName() {
+    return CommandName.DELETE_MANY;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteManyCommand.java
@@ -26,4 +26,11 @@ public record DeleteManyCommand(
         @Valid
         @JsonProperty("filter")
         FilterClause filterClause)
-    implements ModifyCommand, NoOptionsCommand, Filterable {}
+    implements ModifyCommand, NoOptionsCommand, Filterable {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.deleteMany;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteManyCommand.java
@@ -31,6 +31,6 @@ public record DeleteManyCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.deleteMany;
+    return PublicCommandName.DELETE_MANY;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
@@ -33,7 +33,7 @@ public record DeleteOneCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.DELETE_ONE;
+  public CommandName commandName() {
+    return CommandName.DELETE_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
@@ -29,4 +29,11 @@ public record DeleteOneCommand(
         @JsonProperty("filter")
         FilterClause filterClause,
     @Valid @JsonProperty("sort") SortClause sortClause)
-    implements ModifyCommand, NoOptionsCommand, Filterable, Sortable {}
+    implements ModifyCommand, NoOptionsCommand, Filterable, Sortable {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.deleteOne;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
@@ -34,6 +34,6 @@ public record DeleteOneCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.deleteOne;
+    return PublicCommandName.DELETE_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropIndexCommand.java
@@ -22,7 +22,7 @@ public record DropIndexCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.DROP_INDEX;
+  public CommandName commandName() {
+    return CommandName.DROP_INDEX;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropIndexCommand.java
@@ -18,4 +18,11 @@ public record DropIndexCommand(
         @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
         @Schema(description = "Unique name for the index.")
         String indexName)
-    implements NoOptionsCommand, CollectionCommand {}
+    implements NoOptionsCommand, CollectionCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.dropIndex;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropIndexCommand.java
@@ -23,6 +23,6 @@ public record DropIndexCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.dropIndex;
+    return PublicCommandName.DROP_INDEX;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
@@ -21,6 +21,6 @@ public record DropNamespaceCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.dropNamespace;
+    return PublicCommandName.DROP_NAMESPACE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
@@ -20,7 +20,7 @@ public record DropNamespaceCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.DROP_NAMESPACE;
+  public CommandName commandName() {
+    return CommandName.DROP_NAMESPACE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
@@ -16,4 +16,11 @@ public record DropNamespaceCommand(
         @Size(min = 1, max = 48)
         @Schema(description = "Name of the namespace")
         String name)
-    implements GeneralCommand, NoOptionsCommand {}
+    implements GeneralCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.dropNamespace;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
@@ -27,7 +27,7 @@ public record DropTableCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.DROP_TABLE;
+  public CommandName commandName() {
+    return CommandName.DROP_TABLE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
@@ -23,4 +23,11 @@ public record DropTableCommand(
         @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
         @Schema(description = "Name of the table")
         String name)
-    implements TableOnlyCommand, NoOptionsCommand {}
+    implements TableOnlyCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.dropTable;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
@@ -28,6 +28,6 @@ public record DropTableCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.dropTable;
+    return PublicCommandName.DROP_TABLE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/EstimatedDocumentCountCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/EstimatedDocumentCountCommand.java
@@ -14,6 +14,6 @@ public record EstimatedDocumentCountCommand() implements ReadCommand, NoOptionsC
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.estimatedDocumentCount;
+    return PublicCommandName.ESTIMATED_DOCUMENT_COUNT;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/EstimatedDocumentCountCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/EstimatedDocumentCountCommand.java
@@ -13,7 +13,7 @@ public record EstimatedDocumentCountCommand() implements ReadCommand, NoOptionsC
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.ESTIMATED_DOCUMENT_COUNT;
+  public CommandName commandName() {
+    return CommandName.ESTIMATED_DOCUMENT_COUNT;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/EstimatedDocumentCountCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/EstimatedDocumentCountCommand.java
@@ -9,4 +9,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
     description =
         "Command that returns estimated count of documents in a collection based on the collection.")
 @JsonTypeName("estimatedDocumentCount")
-public record EstimatedDocumentCountCommand() implements ReadCommand, NoOptionsCommand {}
+public record EstimatedDocumentCountCommand() implements ReadCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.estimatedDocumentCount;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCollectionsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCollectionsCommand.java
@@ -19,6 +19,6 @@ public record FindCollectionsCommand(Options options) implements CollectionOnlyC
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findCollections;
+    return PublicCommandName.FIND_COLLECTIONS;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCollectionsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCollectionsCommand.java
@@ -15,4 +15,10 @@ public record FindCollectionsCommand(Options options) implements CollectionOnlyC
               type = SchemaType.BOOLEAN,
               implementation = Boolean.class)
           boolean explain) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findCollections;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCollectionsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCollectionsCommand.java
@@ -18,7 +18,7 @@ public record FindCollectionsCommand(Options options) implements CollectionOnlyC
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_COLLECTIONS;
+  public CommandName commandName() {
+    return CommandName.FIND_COLLECTIONS;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -70,7 +70,7 @@ public record FindCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.find;
+  public CommandName commandName() {
+    return CommandName.FIND;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -67,4 +67,10 @@ public record FindCommand(
               description = "Return vector embedding used for ANN sorting.",
               type = SchemaType.BOOLEAN)
           boolean includeSortVector) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.find;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindEmbeddingProvidersCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindEmbeddingProvidersCommand.java
@@ -11,7 +11,7 @@ public record FindEmbeddingProvidersCommand() implements GeneralCommand, NoOptio
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_EMBEDDING_PROVIDERS;
+  public CommandName commandName() {
+    return CommandName.FIND_EMBEDDING_PROVIDERS;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindEmbeddingProvidersCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindEmbeddingProvidersCommand.java
@@ -12,6 +12,6 @@ public record FindEmbeddingProvidersCommand() implements GeneralCommand, NoOptio
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findEmbeddingProviders;
+    return PublicCommandName.FIND_EMBEDDING_PROVIDERS;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindEmbeddingProvidersCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindEmbeddingProvidersCommand.java
@@ -7,4 +7,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Command that lists all available vector providers.")
 @JsonTypeName("findEmbeddingProviders")
-public record FindEmbeddingProvidersCommand() implements GeneralCommand, NoOptionsCommand {}
+public record FindEmbeddingProvidersCommand() implements GeneralCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findEmbeddingProviders;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
@@ -7,4 +7,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Command that lists all available namespaces.")
 @JsonTypeName("findNamespaces")
-public record FindNamespacesCommand() implements GeneralCommand, NoOptionsCommand {}
+public record FindNamespacesCommand() implements GeneralCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findNamespaces;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
@@ -11,7 +11,7 @@ public record FindNamespacesCommand() implements GeneralCommand, NoOptionsComman
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_NAMESPACES;
+  public CommandName commandName() {
+    return CommandName.FIND_NAMESPACES;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
@@ -12,6 +12,6 @@ public record FindNamespacesCommand() implements GeneralCommand, NoOptionsComman
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findNamespaces;
+    return PublicCommandName.FIND_NAMESPACES;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
@@ -20,4 +20,11 @@ public record FindOneAndDeleteCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
     @Valid @JsonProperty("sort") SortClause sortClause,
     @JsonProperty("projection") JsonNode projectionDefinition)
-    implements ModifyCommand, Filterable, Projectable, Sortable {}
+    implements ModifyCommand, Filterable, Projectable, Sortable {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findOneAndDelete;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
@@ -24,7 +24,7 @@ public record FindOneAndDeleteCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_ONE_AND_DELETE;
+  public CommandName commandName() {
+    return CommandName.FIND_ONE_AND_DELETE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
@@ -25,6 +25,6 @@ public record FindOneAndDeleteCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findOneAndDelete;
+    return PublicCommandName.FIND_ONE_AND_DELETE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
@@ -50,6 +50,6 @@ public record FindOneAndReplaceCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findOneAndReplace;
+    return PublicCommandName.FIND_ONE_AND_REPLACE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
@@ -46,4 +46,10 @@ public record FindOneAndReplaceCommand(
                   "When `true`, if no documents match the `filter` clause the command will create a new _empty_ document and apply all _id filter and replacement document to the empty document.",
               defaultValue = "false")
           boolean upsert) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findOneAndReplace;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
@@ -49,7 +49,7 @@ public record FindOneAndReplaceCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_ONE_AND_REPLACE;
+  public CommandName commandName() {
+    return CommandName.FIND_ONE_AND_REPLACE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
@@ -50,7 +50,7 @@ public record FindOneAndUpdateCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_ONE_AND_UPDATE;
+  public CommandName commandName() {
+    return CommandName.FIND_ONE_AND_UPDATE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
@@ -51,6 +51,6 @@ public record FindOneAndUpdateCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findOneAndUpdate;
+    return PublicCommandName.FIND_ONE_AND_UPDATE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
@@ -47,4 +47,10 @@ public record FindOneAndUpdateCommand(
                   "When `true`, if no documents match the `filter` clause the command will create a new _empty_ document and apply the `update` clause and all equality filters to the empty document.",
               defaultValue = "false")
           boolean upsert) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findOneAndUpdate;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
@@ -35,4 +35,10 @@ public record FindOneCommand(
               description = "Return vector embedding used for ANN sorting.",
               type = SchemaType.BOOLEAN)
           boolean includeSortVector) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.findOne;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
@@ -38,7 +38,7 @@ public record FindOneCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.FIND_ONE;
+  public CommandName commandName() {
+    return CommandName.FIND_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
@@ -39,6 +39,6 @@ public record FindOneCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.findOne;
+    return PublicCommandName.FIND_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -51,7 +51,7 @@ public record InsertManyCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.INSERT_MANY;
+  public CommandName commandName() {
+    return CommandName.INSERT_MANY;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -52,6 +52,6 @@ public record InsertManyCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.insertMany;
+    return PublicCommandName.INSERT_MANY;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -48,4 +48,10 @@ public record InsertManyCommand(
                       + " status is `ERROR` and contains the index of the error in the main `errors` array.",
               defaultValue = "false")
           boolean returnDocumentResponses) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.insertMany;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
@@ -27,7 +27,7 @@ public record InsertOneCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.INSERT_ONE;
+  public CommandName commandName() {
+    return CommandName.INSERT_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
@@ -23,4 +23,11 @@ public record InsertOneCommand(
             implementation = Object.class,
             type = SchemaType.OBJECT)
         JsonNode document)
-    implements ModifyCommand, NoOptionsCommand {}
+    implements ModifyCommand, NoOptionsCommand {
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.insertOne;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
@@ -28,6 +28,6 @@ public record InsertOneCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.insertOne;
+    return PublicCommandName.INSERT_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateManyCommand.java
@@ -39,4 +39,10 @@ public record UpdateManyCommand(
           @JsonProperty("pageState")
           @JsonAlias("pagingState") // old name, 1.0.0-BETA-3 and prior
           String pageState) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.updateMany;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateManyCommand.java
@@ -43,6 +43,6 @@ public record UpdateManyCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.updateMany;
+    return PublicCommandName.UPDATE_MANY;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateManyCommand.java
@@ -42,7 +42,7 @@ public record UpdateManyCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.UPDATE_MANY;
+  public CommandName commandName() {
+    return CommandName.UPDATE_MANY;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
@@ -32,4 +32,10 @@ public record UpdateOneCommand(
                   "When `true`, if no documents match the `filter` clause the command will create a new _empty_ document and apply the `update` clause and all equality filters to the empty document.",
               defaultValue = "false")
           boolean upsert) {}
+
+  /** {@inheritDoc} */
+  @Override
+  public PublicCommandName publicCommandName() {
+    return PublicCommandName.updateOne;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
@@ -36,6 +36,6 @@ public record UpdateOneCommand(
   /** {@inheritDoc} */
   @Override
   public PublicCommandName publicCommandName() {
-    return PublicCommandName.updateOne;
+    return PublicCommandName.UPDATE_ONE;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
@@ -35,7 +35,7 @@ public record UpdateOneCommand(
 
   /** {@inheritDoc} */
   @Override
-  public PublicCommandName publicCommandName() {
-    return PublicCommandName.UPDATE_ONE;
+  public CommandName commandName() {
+    return CommandName.UPDATE_ONE;
   }
 }


### PR DESCRIPTION
Separated from #1397, this PR is adding a new method for command interface, which returns the public command name for the implementation command class.
e.g.
FindKeyspacesCommand publicCommandName -> findKeyspaces 
CreateCollectionCommand publicCommandName -> createCollection


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
