### PR TITLE
Fixes #1428: support "not a number" values for 'float', 'double' columns

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -257,6 +257,33 @@ public record JSONCodec<JavaT, CqlT>(
       throw new ArithmeticException(
           String.format("Underflow, value too small for %s", targetCQLType));
     }
+
+    static Double doubleFromString(DataType targetCQLType, String value)
+        throws ToCQLCodecException {
+      return switch (value) {
+        case "NaN" -> Double.NaN;
+        case "Infinity" -> Double.POSITIVE_INFINITY;
+        case "-Infinity" -> Double.NEGATIVE_INFINITY;
+        default ->
+            throw new ToCQLCodecException(
+                value,
+                targetCQLType,
+                "Unsupported String value: only \"NaN\", \"Infinity\" and \"-Infinity\" supported");
+      };
+    }
+
+    static Float floatFromString(DataType targetCQLType, String value) throws ToCQLCodecException {
+      return switch (value) {
+        case "NaN" -> Float.NaN;
+        case "Infinity" -> Float.POSITIVE_INFINITY;
+        case "-Infinity" -> Float.NEGATIVE_INFINITY;
+        default ->
+            throw new ToCQLCodecException(
+                value,
+                targetCQLType,
+                "Unsupported String value: only \"NaN\", \"Infinity\" and \"-Infinity\" supported");
+      };
+    }
   }
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -260,23 +260,32 @@ public record JSONCodec<JavaT, CqlT>(
 
     static Double doubleFromString(DataType targetCQLType, String value)
         throws ToCQLCodecException {
-      return switch (value) {
-        case "NaN" -> Double.NaN;
-        case "Infinity" -> Double.POSITIVE_INFINITY;
-        case "-Infinity" -> Double.NEGATIVE_INFINITY;
-        default ->
-            throw new ToCQLCodecException(
-                value,
-                targetCQLType,
-                "Unsupported String value: only \"NaN\", \"Infinity\" and \"-Infinity\" supported");
+      return switch (notANumber(targetCQLType, value)) {
+        case NAN -> Double.NaN;
+        case POSITIVE_INFINITY -> Double.POSITIVE_INFINITY;
+        case NEGATIVE_INFINITY -> Double.NEGATIVE_INFINITY;
       };
     }
 
     static Float floatFromString(DataType targetCQLType, String value) throws ToCQLCodecException {
+      return switch (notANumber(targetCQLType, value)) {
+        case NAN -> Float.NaN;
+        case POSITIVE_INFINITY -> Float.POSITIVE_INFINITY;
+        case NEGATIVE_INFINITY -> Float.NEGATIVE_INFINITY;
+      };
+    }
+
+    enum NotANumber {
+      NAN,
+      POSITIVE_INFINITY,
+      NEGATIVE_INFINITY
+    }
+
+    static NotANumber notANumber(DataType targetCQLType, String value) throws ToCQLCodecException {
       return switch (value) {
-        case "NaN" -> Float.NaN;
-        case "Infinity" -> Float.POSITIVE_INFINITY;
-        case "-Infinity" -> Float.NEGATIVE_INFINITY;
+        case "NaN" -> NotANumber.NAN;
+        case "Infinity" -> NotANumber.POSITIVE_INFINITY;
+        case "-Infinity" -> NotANumber.NEGATIVE_INFINITY;
         default ->
             throw new ToCQLCodecException(
                 value,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistries.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistries.java
@@ -35,9 +35,11 @@ public abstract class JSONCodecRegistries {
               JSONCodecs.DOUBLE_FROM_BIG_DECIMAL,
               JSONCodecs.DOUBLE_FROM_BIG_INTEGER,
               JSONCodecs.DOUBLE_FROM_LONG,
+              JSONCodecs.DOUBLE_FROM_STRING,
               JSONCodecs.FLOAT_FROM_BIG_DECIMAL,
               JSONCodecs.FLOAT_FROM_BIG_INTEGER,
               JSONCodecs.FLOAT_FROM_LONG,
+              JSONCodecs.FLOAT_FROM_STRING,
               // Text Codecs
               JSONCodecs.ASCII,
               JSONCodecs.TEXT,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecs.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecs.java
@@ -91,6 +91,14 @@ public abstract class JSONCodecs {
           JSONCodec.ToCQL.safeNumber(Long::doubleValue),
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
+  // Codec needed to support "not-a-number" values: encoded as Strings in JSON
+  public static final JSONCodec<String, Double> DOUBLE_FROM_STRING =
+      new JSONCodec<>(
+          GenericType.STRING,
+          DataTypes.DOUBLE,
+          JSONCodec.ToCQL::doubleFromString,
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
   public static final JSONCodec<BigDecimal, Float> FLOAT_FROM_BIG_DECIMAL =
       new JSONCodec<>(
           GenericType.BIG_DECIMAL,
@@ -113,6 +121,14 @@ public abstract class JSONCodecs {
           // TODO: bounds checks (over/underflow)?
           DataTypes.FLOAT,
           JSONCodec.ToCQL.safeNumber(Long::floatValue),
+          JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
+
+  // Codec needed to support "not-a-number" values: encoded as Strings in JSON
+  public static final JSONCodec<String, Float> FLOAT_FROM_STRING =
+      new JSONCodec<>(
+          GenericType.STRING,
+          DataTypes.FLOAT,
+          JSONCodec.ToCQL::floatFromString,
           JSONCodec.ToJSON.unsafeNodeFactory(JsonNodeFactory.instance::numberNode));
 
   public static final JSONCodec<BigDecimal, Integer> INT_FROM_BIG_DECIMAL =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.TestClassOrder;
 public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestBase {
   static final String TABLE_WITH_TEXT_COLUMNS = "findOneTextColumnsTable";
   static final String TABLE_WITH_INT_COLUMNS = "findOneIntColumnsTable";
+  static final String TABLE_WITH_FP_COLUMNS = "findOneFpColumnsTable";
 
   @BeforeAll
   public final void createDefaultTables() {
@@ -47,6 +48,18 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
             Map.of("type", "tinyint"),
             "bigIntegerValue",
             Map.of("type", "varint")),
+        "id");
+    createTableWithColumns(
+        TABLE_WITH_FP_COLUMNS,
+        Map.of(
+            "id",
+            Map.of("type", "text"),
+            "floatValue",
+            Map.of("type", "float"),
+            "doubleValue",
+            Map.of("type", "double"),
+            "decimalValue",
+            Map.of("type", "decimal")),
         "id");
   }
 
@@ -103,12 +116,12 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
     @Test
     void insertWithIntColumnsZeroFractional() {
       // In goes 5.00
-      insertOneInTable(TABLE_WITH_INT_COLUMNS, numDoc("zero-fraction", "5.00"));
+      insertOneInTable(TABLE_WITH_INT_COLUMNS, intDoc("zero-fraction", "5.00"));
       // and out comes 5
       DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_INT_COLUMNS)
           .postFindOne("{ \"filter\": { \"id\": \"zero-fraction\" } }")
           .hasNoErrors()
-          .hasJSONField("data.document", numDoc("zero-fraction", "5"));
+          .hasJSONField("data.document", intDoc("zero-fraction", "5"));
     }
 
     // [data-api#1429]: Test to verify that scientific is allowed for int types if  (and only if)
@@ -116,12 +129,12 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
     @Test
     void insertWithIntColumnsScientificNotation() {
       // In goes 1.23E+02
-      insertOneInTable(TABLE_WITH_INT_COLUMNS, numDoc("scientific-but-int", "1.23E+02"));
+      insertOneInTable(TABLE_WITH_INT_COLUMNS, intDoc("scientific-but-int", "1.23E+02"));
       // and out comes 123
       DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_INT_COLUMNS)
           .postFindOne("{ \"filter\": { \"id\": \"scientific-but-int\" } }")
           .hasNoErrors()
-          .hasJSONField("data.document", numDoc("scientific-but-int", "123"));
+          .hasJSONField("data.document", intDoc("scientific-but-int", "123"));
     }
 
     // [data-api#1429]: Test to verify that should there be real fraction, insert fails
@@ -129,14 +142,14 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
     void failWithNonZeroFractionPlain() {
       // Try with 12.5, should fail
       DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_INT_COLUMNS)
-          .postInsertOne(numDoc("non-zero-fraction", "12.5"))
+          .postInsertOne(intDoc("non-zero-fraction", "12.5"))
           .hasSingleApiError(
               DocumentException.Code.INVALID_COLUMN_VALUES,
               DocumentException.class,
               "Root cause: Rounding necessary");
     }
 
-    private String numDoc(String id, String num) {
+    private String intDoc(String id, String num) {
       return
           """
                                             {
@@ -149,6 +162,44 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
                                             }
                                             """
           .formatted(id, num, num, num, num, num);
+    }
+  }
+
+  @Nested
+  @Order(3)
+  class InsertFPColumns {
+    @Test
+    void insertWithPlainFPValues() {
+      final String docJSON = fpDoc("fpRegular", "0.25", "-2.5", "0.75");
+      insertOneInTable(TABLE_WITH_FP_COLUMNS, docJSON);
+      DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_FP_COLUMNS)
+          .postFindOne("{ \"filter\": { \"id\": \"fpRegular\" } }")
+          .hasNoErrors()
+          .hasJSONField("data.document", docJSON);
+    }
+
+    // [data-api#1428]: Test to verify Not-a-Number handling
+    @Test
+    void insertWithNaNsOk() {
+      final String docJSON = fpDoc("nans", "\"NaN\"", "\"NaN\"", "0.5");
+      insertOneInTable(TABLE_WITH_FP_COLUMNS, docJSON);
+      DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_FP_COLUMNS)
+          .postFindOne("{ \"filter\": { \"id\": \"nans\" } }")
+          .hasNoErrors()
+          .hasJSONField("data.document", docJSON);
+    }
+
+    private String fpDoc(String id, String floatValue, String doubleValue, String bigDecValue) {
+      return
+          """
+            {
+                "id": "%s",
+                "floatValue": %s,
+                "doubleValue": %s,
+                "decimalValue": %s
+            }
+            """
+          .formatted(id, floatValue, doubleValue, bigDecValue);
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
@@ -61,9 +61,18 @@ public class DataApiResponseValidator {
         .body("errors[0].errorCode", is(errorCode.toString()));
   }
 
+  /**
+   * @param errorCode Error code to check for
+   * @param errorClass Error class to check for
+   * @param messageSnippet Set of pieces of error message to check: ALL must match
+   */
   public <T extends APIException> DataApiResponseValidator hasSingleApiError(
-      ErrorCode<T> errorCode, Class<T> errorClass, String messageSnippet) {
-    return hasSingleApiError(errorCode, errorClass, containsString(messageSnippet));
+      ErrorCode<T> errorCode, Class<T> errorClass, String... messageSnippet) {
+    DataApiResponseValidator validator = hasSingleApiError(errorCode, errorClass);
+    for (String snippet : messageSnippet) {
+      validator = validator.body("errors[0].message", containsString(snippet));
+    }
+    return validator;
   }
 
   public <T extends APIException> DataApiResponseValidator hasSingleApiError(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -106,7 +106,7 @@ public class JSONCodecRegistryTest {
         Arguments.of(
             DataTypes.VARINT, BigDecimal.valueOf(123456789.0), BigInteger.valueOf(123456789)),
 
-        // Floating-point types:
+        // Floating-point types: regular
         Arguments.of(DataTypes.DECIMAL, 123L, BigDecimal.valueOf(123L)),
         Arguments.of(DataTypes.DECIMAL, BigInteger.valueOf(34567L), BigDecimal.valueOf(34567L)),
         Arguments.of(DataTypes.DECIMAL, BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.25)),
@@ -116,6 +116,13 @@ public class JSONCodecRegistryTest {
         Arguments.of(DataTypes.FLOAT, 123L, Float.valueOf(123L)),
         Arguments.of(DataTypes.FLOAT, BigInteger.valueOf(34567L), Float.valueOf(34567L)),
         Arguments.of(DataTypes.FLOAT, BigDecimal.valueOf(0.25), Float.valueOf(0.25f)),
+        // Floating-point types: not-a-numbers
+        Arguments.of(DataTypes.DOUBLE, "NaN", Double.NaN),
+        Arguments.of(DataTypes.DOUBLE, "Infinity", Double.POSITIVE_INFINITY),
+        Arguments.of(DataTypes.DOUBLE, "-Infinity", Double.NEGATIVE_INFINITY),
+        Arguments.of(DataTypes.FLOAT, "NaN", Float.NaN),
+        Arguments.of(DataTypes.FLOAT, "Infinity", Float.POSITIVE_INFINITY),
+        Arguments.of(DataTypes.FLOAT, "-Infinity", Float.NEGATIVE_INFINITY),
 
         // Textual types: ASCII, TEXT (VARCHAR is an alias for TEXT).
         Arguments.of(DataTypes.ASCII, TEST_DATA.STRING_ASCII_SAFE, TEST_DATA.STRING_ASCII_SAFE),


### PR DESCRIPTION
**What this PR does**:

Add support, tests, for NaN/FP values.

**Which issue(s) this PR fixes**:
Fixes #1428

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
