### PR TITLE
Fix #1417: optimize/improve codec lookup handling

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/catchable/ToCQLCodecException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/catchable/ToCQLCodecException.java
@@ -31,7 +31,7 @@ public class ToCQLCodecException extends CheckedApiException {
       Object value, DataType targetCQLType, String rootCauseMessage) {
     return String.format(
         "Error trying to convert to targetCQLType `%s` from value.class `%s`, value %s. Root cause: %s",
-        targetCQLType, value.getClass().getName(), valueDesc(value), rootCauseMessage);
+        targetCQLType, className(value), valueDesc(value), rootCauseMessage);
   }
 
   // Add a place to slightly massage value; can be further improved
@@ -43,5 +43,12 @@ public class ToCQLCodecException extends CheckedApiException {
       return "\"" + value + "\"";
     }
     return String.valueOf(value);
+  }
+
+  private static String className(Object value) {
+    if (value == null) {
+      return "null";
+    }
+    return value.getClass().getName();
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -70,10 +70,16 @@ public record JSONCodec<JavaT, CqlT>(
    * @return True if the codec can convert the value into the type needed for the column.
    */
   public boolean testToCQL(DataType toCQLType, Object value) {
+    return handlesCQLType(toCQLType) && handlesJavaValue(value);
+  }
 
+  public boolean handlesCQLType(DataType toCQLType) {
+    return this.targetCQLType.equals(toCQLType);
+  }
+
+  public boolean handlesJavaValue(Object value) {
     // java value tests comes from TypeCodec.accepts(Object value) in the driver
-    return this.targetCQLType.equals(toCQLType)
-        && (value == null || javaType.getRawType().isAssignableFrom(value.getClass()));
+    return (value == null) || javaType.getRawType().isAssignableFrom(value.getClass());
   }
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistries.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistries.java
@@ -10,7 +10,7 @@ import java.util.List;
 public abstract class JSONCodecRegistries {
 
   public static final JSONCodecRegistry DEFAULT_REGISTRY =
-      new JSONCodecRegistry(
+      JSONCodecRegistry.create(
           List.of(
               // Numeric Codecs, integer types
               JSONCodecs.BIGINT_FROM_BIG_DECIMAL,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
@@ -27,8 +27,12 @@ public class JSONCodecRegistry {
 
   private final List<JSONCodec<?, ?>> codecs;
 
-  JSONCodecRegistry(List<JSONCodec<?, ?>> codecs) {
+  private JSONCodecRegistry(List<JSONCodec<?, ?>> codecs) {
     this.codecs = Objects.requireNonNull(codecs, "codecs must not be null");
+  }
+
+  public static JSONCodecRegistry create(List<JSONCodec<?, ?>> codecs) {
+    return new JSONCodecRegistry(codecs);
   }
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistry.java
@@ -30,10 +30,9 @@ import java.util.Objects;
 public class JSONCodecRegistry {
 
   private final Map<DataType, List<JSONCodec<?, ?>>> codecsByCQLType;
-  private final List<JSONCodec<?, ?>> codecs;
 
   private JSONCodecRegistry(List<JSONCodec<?, ?>> codecs) {
-    this.codecs = Objects.requireNonNull(codecs, "codecs must not be null");
+    Objects.requireNonNull(codecs, "codecs must not be null");
     this.codecsByCQLType = new HashMap<>();
     for (JSONCodec<?, ?> codec : codecs) {
       codecsByCQLType.computeIfAbsent(codec.targetCQLType(), k -> new ArrayList<>()).add(codec);
@@ -115,17 +114,14 @@ public class JSONCodecRegistry {
     return codec;
   }
 
-  public <JavaT, CqlT> JSONCodec<JavaT, CqlT> codecToJSON(DataType targetCQLType) {
-    return JSONCodec.unchecked(internalCodecForToJSON(targetCQLType));
-  }
-
   /**
-   * Internal only method to find a codec for the specified CQL Type, converting from Java to JSON
+   * Method to find a codec for the specified CQL Type, converting from Java to JSON
    *
    * @param fromCQLType
    * @return Codec to use for conversion, or `null` if none found.
    */
-  private JSONCodec<?, ?> internalCodecForToJSON(DataType fromCQLType) {
-    return codecs.stream().filter(codec -> codec.testToJSON(fromCQLType)).findFirst().orElse(null);
+  public <JavaT, CqlT> JSONCodec<JavaT, CqlT> codecToJSON(DataType fromCQLType) {
+    List<JSONCodec<?, ?>> candidates = codecsByCQLType.get(fromCQLType);
+    return (candidates == null) ? null : JSONCodec.unchecked(candidates.get(0));
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -261,9 +261,10 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
       DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_FP_COLUMNS)
           .postInsertOne(fpDoc("decimalUnknownString", "0.5", "1.0", "\"Bazillion\""))
           .hasSingleApiError(
-              DocumentException.Code.UNSUPPORTED_COLUMN_TYPES,
+              DocumentException.Code.INVALID_COLUMN_VALUES,
               DocumentException.class,
-              "following columns that have unsupported data types",
+              "Only values that are supported by the column data type can be included when inserting",
+              "no codec matching value type",
               "\"decimalValue\"");
     }
 


### PR DESCRIPTION
**What this PR does**:

Changes linear-scan lookup into map-based lookup (one- or two-phase depending on direction). Also improves error messages for partial misses where we support CQL type but not particular coercion (like Boolean from Integer) to indicate it's Java value mismatch and not (fully) unsupported type.

**Which issue(s) this PR fixes**:
Fixes #1417

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
