### PR TITLE
Fix #1404: failing addIndex with case-sensitive name

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/AddIndexOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/AddIndexOperation.java
@@ -26,7 +26,7 @@ public record AddIndexOperation(
   private static final Logger logger = LoggerFactory.getLogger(AddIndexOperation.class);
 
   private static final String ADD_INDEX_TEMPLATE =
-      "CREATE CUSTOM INDEX IF NOT EXISTS \"%s\" ON  %s.%s (%s) USING 'StorageAttachedIndex'";
+      "CREATE CUSTOM INDEX IF NOT EXISTS \"%s\" ON  %s.%s (\"%s\") USING 'StorageAttachedIndex'";
 
   @Override
   public Uni<Supplier<CommandResult>> execute(

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
@@ -9,39 +9,27 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import java.util.Map;
 import org.junit.jupiter.api.*;
 
 @QuarkusIntegrationTest
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
-// TODO, it is currently called AddIndex, do we want to change to createIndex
 class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   String simpleTableName = "simpleTableForAddIndexTest";
 
   @BeforeAll
   public final void createSimpleTable() {
-    String tableJson =
-            """
-                          {
-                                  "name": "%s",
-                                  "definition": {
-                                      "columns": {
-                                          "id": {
-                                              "type": "text"
-                                          },
-                                          "age": {
-                                              "type": "int"
-                                          },
-                                          "name": {
-                                              "type": "text"
-                                          }
-                                      },
-                                      "primaryKey": "id"
-                                  }
-                          }
-                    """
-            .formatted(simpleTableName);
-    createTable(tableJson);
+    createTableWithColumns(
+        simpleTableName,
+        Map.of(
+            "id",
+            Map.of("type", "text"),
+            "age",
+            Map.of("type", "int"),
+            "name",
+            Map.of("type", "text")),
+        "id");
   }
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
@@ -25,6 +25,8 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
             Map.of("type", "text"),
             "age",
             Map.of("type", "int"),
+            "vehicleId",
+            Map.of("type", "text"),
             "name",
             Map.of("type", "text")),
         "id");
@@ -35,8 +37,7 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   class AddIndexSuccess {
 
     @Test
-    @Order(1)
-    public void addIndex() {
+    public void addIndexBasic() {
       DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
           .postCommand(
               "addIndex",
@@ -46,6 +47,21 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
                           "indexName": "age_index"
                   }
                   """)
+          .hasNoErrors()
+          .body("status.ok", is(1));
+    }
+
+    @Test
+    public void addIndexCaseSensitive() {
+      DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
+          .postCommand(
+              "addIndex",
+              """
+                          {
+                                  "column": "vehicleId",
+                                  "indexName": "vehicleId_idx"
+                          }
+                          """)
           .hasNoErrors()
           .body("status.ok", is(1));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
@@ -1,13 +1,11 @@
 package io.stargate.sgv2.jsonapi.api.v1.tables;
 
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.containsString;
 
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.restassured.http.ContentType;
-import io.stargate.sgv2.jsonapi.api.v1.CollectionResource;
+import io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders;
+import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import java.util.Map;
 import org.junit.jupiter.api.*;
@@ -39,23 +37,16 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
     @Test
     @Order(1)
     public void addIndex() {
-      String json =
-          """
-                      {
-                          "addIndex": {
-                              "column": "age",
-                              "indexName": "age_index"
-                          }
-                      }
-                      """;
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceName, simpleTableName)
-          .then()
-          .statusCode(200)
+      DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
+          .postCommand(
+              "addIndex",
+              """
+                  {
+                          "column": "age",
+                          "indexName": "age_index"
+                  }
+                  """)
+          .hasNoErrors()
           .body("status.ok", is(1));
     }
   }
@@ -64,29 +55,17 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   @Order(2)
   class AddIndexFailure {
     @Test
-    public void addIndex() {
-      String json =
-          """
+    public void tryAddIndexMissingColumn() {
+      DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
+          .postCommand(
+              "addIndex",
+              """
                       {
-                          "addIndex": {
                               "column": "city",
                               "indexName": "city_index"
-                          }
                       }
-                      """;
-      given()
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceName, simpleTableName)
-          .then()
-          .statusCode(200)
-          .body("errors", is(notNullValue()))
-          .body("errors", hasSize(1))
-          .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_QUERY"))
-          .body("errors[0].message", containsString("Undefined column name city"));
+                      """)
+          .hasSingleApiError(ErrorCodeV1.INVALID_QUERY, "Undefined column name city");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/AddTableIndexIntegrationTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.*;
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
-  String simpleTableName = "simpleTableForAddIndexTest";
+  String testTableName = "tableForAddIndexTest";
 
   @BeforeAll
   public final void createSimpleTable() {
     createTableWithColumns(
-        simpleTableName,
+        testTableName,
         Map.of(
             "id",
             Map.of("type", "text"),
@@ -38,7 +38,7 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
 
     @Test
     public void addIndexBasic() {
-      DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
+      DataApiCommandSenders.assertTableCommand(keyspaceName, testTableName)
           .postCommand(
               "addIndex",
               """
@@ -53,7 +53,7 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
 
     @Test
     public void addIndexCaseSensitive() {
-      DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
+      DataApiCommandSenders.assertTableCommand(keyspaceName, testTableName)
           .postCommand(
               "addIndex",
               """
@@ -72,7 +72,7 @@ class AddTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   class AddIndexFailure {
     @Test
     public void tryAddIndexMissingColumn() {
-      DataApiCommandSenders.assertTableCommand(keyspaceName, simpleTableName)
+      DataApiCommandSenders.assertTableCommand(keyspaceName, testTableName)
           .postCommand(
               "addIndex",
               """


### PR DESCRIPTION
**What this PR does**:

Fixes issue with name case-sensitivity for "addIndex()" command

**Which issue(s) this PR fixes**:
Fixes #1404

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
