### PR TITLE
Fix #1460, handle CQL nulls to  JSON gracefully

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodec.java
@@ -128,6 +128,10 @@ public record JSONCodec<JavaT, CqlT>(
    *     should convert this into the appropriate exception for the use case.
    */
   public JsonNode toJSON(ObjectMapper objectMapper, CqlT value) throws ToJSONCodecException {
+    // First: if caller passes nulls, convert to JSON Null so converter need to do null checks
+    if (value == null) {
+      return objectMapper.nullNode();
+    }
     return toJSON.apply(objectMapper, targetCQLType, value);
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/TableRowProjection.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/TableRowProjection.java
@@ -73,7 +73,14 @@ public record TableRowProjection(
             "Column '%s' has unsupported type '%s'", columnName, column.getType().toString());
       }
       try {
-        result.put(columnName, codec.toJSON(objectMapper, row.getObject(i)));
+        final Object columnValue = row.getObject(i);
+        // We have a choice here: convert into JSON null (explicit) or drop (save space)?
+        // For now, do former: may change or make configurable later.
+        if (columnValue == null) {
+          result.putNull(columnName);
+        } else {
+          result.put(columnName, codec.toJSON(objectMapper, columnValue));
+        }
       } catch (ToJSONCodecException e) {
         throw ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM.toApiException(
             e,


### PR DESCRIPTION
**What this PR does**:

Ensures that CQL `null` from Driver gets safely translated into JSON responses (currently as explicit JSON null)

**Which issue(s) this PR fixes**:
Fixes #1460

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
