### PR TITLE
Fix #1498: enable access/request log by default

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,6 +76,11 @@ quarkus:
 
   # HTTP settings
   http:
+    # access log format, must be explicitly enabled
+    access-log:
+      enabled: true
+      pattern: "%h %l %t \"%r\" %s %b"
+
     # every /v1 path is authenticated by default
     # adapt if changing the authentication mechanism
     auth:
@@ -86,10 +91,6 @@ quarkus:
         default:
           paths: /v1/*
           policy: authenticated
-
-    # access log format, must be explicitly enabled
-    access-log:
-      pattern: "%h %l %t \"%r\" %s %b"
 
     limits:
       # Let's limit low-level maximum HTTP request size to 20 megs: stricter

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -116,6 +116,8 @@ quarkus:
         level: ERROR
       'com.datastax.oss.driver':
         level: WARN
+      'io.quarkus.http.access-log':
+        level: INFO
       'io.stargate':
         level: WARN
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,7 +5,7 @@ stargate:
 # change test port from 8081 (used by other SG services)
 quarkus:
   http:
-    # access log format, disable for tests to reduce noise
+    # access log format, disabled for tests to reduce noise
     access-log:
       enabled: false
     test-port: 9080

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,4 +5,7 @@ stargate:
 # change test port from 8081 (used by other SG services)
 quarkus:
   http:
+    # access log format, disable for tests to reduce noise
+    access-log:
+      enabled: false
     test-port: 9080


### PR DESCRIPTION
**What this PR does**:

Enables Quarkus HTTP access/request log by default

**Which issue(s) this PR fixes**:
Fixes #1498

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
