### PR TITLE
use stargate-v2.1.0-BETA-18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>sgv2-jsonapi</artifactId>
   <version>1.0.17-SNAPSHOT</version>
   <properties>
-    <stargate.version>v2.1.0-BETA-17</stargate.version>
+    <stargate.version>2.1.0-BETA-18</stargate.version>
     <!-- 17-May-2023, tatu: [json-api#172] Need at least Jackson 2.15.x -->
     <!-- 16-Aug-2024, tatu: Quarkus depends on 2.17 already, but keep explicit -->
     <jackson.version>2.17.2</jackson.version>
@@ -29,7 +29,7 @@
     <!-- from Stargate persistence, latest as of 2024-01-24: -->
     <stargate.int-test.cassandra.image-tag>${cassandra.version}</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-dse-next</stargate.int-test.coordinator.image>
-    <stargate.int-test.coordinator.image-tag>${stargate.version}</stargate.int-test.coordinator.image-tag>
+    <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>dse-next-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
     <stargate.int-test.cluster.persistence>persistence-dse-next</stargate.int-test.cluster.persistence>
     <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>


### PR DESCRIPTION
Use stargate v2.1.0-BETA-18
Remove the version prefix 'v' to make the pom file compatible of bump_version.script

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
