### PR TITLE
Do not publish json-api image to dockerhub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,11 +175,6 @@ jobs:
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true  -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}} -Dquarkus.container-image.name=data-api ${{ matrix.profile }}
 
-      - name: Build data-api image and push (Docker Hub)
-        if: ${{ !inputs.skipPublish }}
-        run: |
-          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true  -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}} -Dquarkus.container-image.name=jsonapi ${{ matrix.profile }}
-
   # publishes the docker image to ecr
   publish-image-ecr:
     name: Publish docker image to ecr


### PR DESCRIPTION
JSON API was renamed to Data API 9 months ago, it's time to stop publishing the jsonapi images to [Docker hub](https://hub.docker.com/r/stargateio/jsonapi), especially since they are the same as the data-api images.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
