### PR TITLE
Add one IT for binary vector support

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -459,7 +459,7 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
       // Convert the byte array to a float array
       float[] decodedVector = decodeBase64BinaryVectorToFloatArray(base64VectorFromResponse);
 
-      // Step 7: Verify that the decoded float array is equal to the expected vector
+      // Verify that the decoded float array is equal to the expected vector
       Assertions.assertArrayEquals(expectedVector, decodedVector, 0.0001f);
     }
 
@@ -576,6 +576,38 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
               "errors[0].message",
               is(
                   "Bad binary vector value to shred: Invalid content in EJSON $binary wrapper: decoded value is not a multiple of 4 bytes long (3 bytes)"));
+    }
+
+    @Test
+    public void insertBinaryVectorWithUnmatchedVectorDimension() {
+      final float[] wrongVectorDimension = new float[] {0.25f, -1.5f, 0.00f};
+      final String base64Vector = generateBase64EncodedBinaryVector(wrongVectorDimension);
+      String doc =
+              """
+                  {
+                    "name": "aaron",
+                    "$vector": {"$binary": "%s"}
+                  }
+              """
+              .formatted(base64Vector);
+
+      given()
+          .headers(getHeaders())
+          .contentType(ContentType.JSON)
+          .body("{ \"insertOne\": { \"document\": %s }}".formatted(doc))
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds[0]", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body("errors", is(notNullValue()))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("VECTOR_SIZE_MISMATCH"))
+          .body(
+              "errors[0].message",
+              is(
+                  "Length of vector parameter different from declared '$vector' dimension: root cause = (InvalidQueryException) Not enough bytes to read a vector<float, 5>"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -464,7 +464,7 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
     }
 
     @Test
-    public void insertBinaryVectorWithInvalidBinaryString() {
+    public void failToInsertBinaryVectorWithInvalidBinaryString() {
       final String invalidBinaryString = "@#$%^&*()";
       String doc =
               """
@@ -495,7 +495,7 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
     }
 
     @Test
-    public void insertBinaryVectorWithInvalidBinaryValue() {
+    public void failToInsertBinaryVectorWithInvalidBinaryValue() {
       String doc =
           """
                   {
@@ -523,7 +523,7 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
     }
 
     @Test
-    public void insertBinaryVectorWithInvalidVectorObject() {
+    public void failToInsertBinaryVectorWithInvalidVectorObject() {
       String doc =
           """
                   {
@@ -551,7 +551,7 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
     }
 
     @Test
-    public void insertBinaryVectorWithInvalidDecodedValue() {
+    public void failToInsertBinaryVectorWithInvalidDecodedValue() {
       String doc =
           """
                       {
@@ -579,7 +579,7 @@ public class VectorSearchIntegrationTest extends AbstractKeyspaceIntegrationTest
     }
 
     @Test
-    public void insertBinaryVectorWithUnmatchedVectorDimension() {
+    public void failToInsertBinaryVectorWithUnmatchedVectorDimension() {
       final float[] wrongVectorDimension = new float[] {0.25f, -1.5f, 0.00f};
       final String base64Vector = generateBase64EncodedBinaryVector(wrongVectorDimension);
       String doc =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
In the previous PR #1506, one suggestion was verifying whether the decoded vector dimension matched the vector definition. I thought we needed to explicitly verify it somewhere in the code but was not sure where was the best place. So I merged that PR first and tried to figure it out later. Then I realized we can defer the vector dimension verification to DB - the same as the normal vector array value. 

So I don't add any code but add one Integration test to make sure it works.

**Which issue(s) this PR fixes**:
Fixes #1494 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
