### PR TITLE
Fix #1597: upgrade Jackson 2.17->2.18; Quarkus to latest patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
   <version>1.0.19-SNAPSHOT</version>
   <properties>
     <stargate.version>2.1.0-BETA-19</stargate.version>
-    <!-- 17-May-2023, tatu: [json-api#172] Need at least Jackson 2.15.x -->
     <!-- 16-Aug-2024, tatu: Quarkus depends on 2.17 already, but keep explicit -->
-    <jackson.version>2.17.2</jackson.version>
+    <!-- 23-Oct-2024, tatu: For latest FP optimizations let's get 2.18 -->
+    <jackson.version>2.18.0</jackson.version>
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.13.2</quarkus.platform.version>
+    <quarkus.platform.version>3.13.3</quarkus.platform.version>
     <!-- miscellaneous -->
     <wiremock.version>3.4.2</wiremock.version>
     <mockito.version>5.12.0</mockito.version>


### PR DESCRIPTION
**What this PR does**:

Updates Jackson dependency from 2.17.2 to 2.18.0 for performance optimizations.
Also Quarkus patch from 3.13.2 to 3.13.3 (minor fixes).

**Which issue(s) this PR fixes**:
Fixes #1597

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
