### PR TITLE
fix tests, from dash to underscore.

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/fixtures/testdata/TestDataNames.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/fixtures/testdata/TestDataNames.java
@@ -6,79 +6,79 @@ import java.util.List;
 public class TestDataNames {
 
   public final CqlIdentifier KEYSPACE_NAME =
-      CqlIdentifier.fromInternal("keyspace-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("keyspace_" + System.currentTimeMillis());
 
   public final CqlIdentifier TABLE_NAME =
-      CqlIdentifier.fromInternal("table-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("table_" + System.currentTimeMillis());
 
   public final CqlIdentifier INDEX_NAME_1 =
-      CqlIdentifier.fromInternal("index-1-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("index_1_" + System.currentTimeMillis());
 
   public final CqlIdentifier COL_PARTITION_KEY_1 =
-      CqlIdentifier.fromInternal("partition-key-1-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("partition_key_1_" + System.currentTimeMillis());
   public final CqlIdentifier COL_PARTITION_KEY_2 =
-      CqlIdentifier.fromInternal("partition-key-2-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("partition_key_2_" + System.currentTimeMillis());
   public final CqlIdentifier COL_CLUSTERING_KEY_1 =
-      CqlIdentifier.fromInternal("clustering-key-1-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("clustering_key_1_" + System.currentTimeMillis());
   public final CqlIdentifier COL_CLUSTERING_KEY_2 =
-      CqlIdentifier.fromInternal("clustering-key-2-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("clustering_key_2_" + System.currentTimeMillis());
   public final CqlIdentifier COL_CLUSTERING_KEY_3 =
-      CqlIdentifier.fromInternal("clustering-key-3-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("clustering_key_3_" + System.currentTimeMillis());
 
   public final CqlIdentifier COL_REGULAR_1 =
-      CqlIdentifier.fromInternal("regular-1-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("regular_1_" + System.currentTimeMillis());
   public final CqlIdentifier COL_REGULAR_2 =
-      CqlIdentifier.fromInternal("regular-2-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("regular_2_" + System.currentTimeMillis());
 
   public final CqlIdentifier COL_INDEXED_1 =
-      CqlIdentifier.fromInternal("indexed-1-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("indexed_1_" + System.currentTimeMillis());
 
   // DO NOT ADD TO A TABLE
   public final CqlIdentifier COL_UNKNOWN_1 =
-      CqlIdentifier.fromInternal("unknown-1-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("unknown_1_" + System.currentTimeMillis());
 
   // ==================================================================================================================
   // Primitive(Scalar) dataTypes
   // ==================================================================================================================
 
   public final CqlIdentifier CQL_TEXT_COLUMN =
-      CqlIdentifier.fromInternal("text-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("text_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_ASCII_COLUMN =
-      CqlIdentifier.fromInternal("ascii-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("ascii_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_BLOB_COLUMN =
-      CqlIdentifier.fromInternal("blob-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("blob_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DURATION_COLUMN =
-      CqlIdentifier.fromInternal("duration-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("duration_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_BOOLEAN_COLUMN =
-      CqlIdentifier.fromInternal("boolean-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("boolean_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_BIGINT_COLUMN =
-      CqlIdentifier.fromInternal("bigint-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("bigint_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DECIMAL_COLUMN =
-      CqlIdentifier.fromInternal("decimal-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("decimal_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DOUBLE_COLUMN =
-      CqlIdentifier.fromInternal("double-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("double_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_FLOAT_COLUMN =
-      CqlIdentifier.fromInternal("float-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("float_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_INT_COLUMN =
-      CqlIdentifier.fromInternal("int-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("int_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_SMALLINT_COLUMN =
-      CqlIdentifier.fromInternal("smallint-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("smallint_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_VARINT_COLUMN =
-      CqlIdentifier.fromInternal("varint-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("varint_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TINYINT_COLUMN =
-      CqlIdentifier.fromInternal("tinyint-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("tinyint_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TIMESTAMP_COLUMN =
-      CqlIdentifier.fromInternal("timestamp-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("timestamp_column" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DATE_COLUMN =
-      CqlIdentifier.fromInternal("date-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("date_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TIME_COLUMN =
-      CqlIdentifier.fromInternal("time-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("time_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_INET_COLUMN =
-      CqlIdentifier.fromInternal("inet-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("inet_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_UUID_COLUMN =
-      CqlIdentifier.fromInternal("uuid-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("uuid_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TIMEUUID_COLUMN =
-      CqlIdentifier.fromInternal("timeuuid-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("timeuuid_column_" + System.currentTimeMillis());
 
   public final List<CqlIdentifier> ALL_SCALAR_DATATYPE_COLUMNS =
       List.of(
@@ -107,62 +107,62 @@ public class TestDataNames {
 
   // All column datatypes index name, (Blob,Duration can NOT be indexed)
   public final CqlIdentifier CQL_TEXT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("text-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("text_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_ASCII_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("ascii-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("ascii_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_BOOLEAN_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("boolean-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("boolean_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_BIGINT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("bigint-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("bigint_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DECIMAL_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("decimal-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("decimal_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DOUBLE_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("double-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("double_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_FLOAT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("float-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("float_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_INT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("int-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("int_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_SMALLINT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("smallint-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("smallint_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_VARINT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("varint-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("varint_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TINYINT_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("tinyint-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("tinyint_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TIMESTAMP_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("timestamp-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("timestamp_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_DATE_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("date-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("date_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TIME_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("time-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("time_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_INET_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("inet-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("inet_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_UUID_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("uuid-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("uuid_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_TIMEUUID_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("timeuuid-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("timeuuid_column_index_" + System.currentTimeMillis());
 
   // ==================================================================================================================
   // Collection(set, map, list, vector) dataTypes
   // ==================================================================================================================
 
   public final CqlIdentifier CQL_MAP_COLUMN =
-      CqlIdentifier.fromInternal("map-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("map_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_LIST_COLUMN =
-      CqlIdentifier.fromInternal("list-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("list_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_SET_COLUMN =
-      CqlIdentifier.fromInternal("set-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("set_column_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_VECTOR_COLUMN =
-      CqlIdentifier.fromInternal("vector-column-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("vector_column_" + System.currentTimeMillis());
 
   public final List<CqlIdentifier> ALL_COLLECTION_DATATYPE_COLUMNS =
       List.of(CQL_MAP_COLUMN, CQL_LIST_COLUMN, CQL_SET_COLUMN, CQL_VECTOR_COLUMN);
 
   public final CqlIdentifier CQL_MAP_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("map-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("map_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_LIST_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("list-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("list_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_SET_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("set-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("set_column_index_" + System.currentTimeMillis());
   public final CqlIdentifier CQL_VECTOR_COLUMN_INDEX =
-      CqlIdentifier.fromInternal("vector-column-index-" + System.currentTimeMillis());
+      CqlIdentifier.fromInternal("vector_column_index_" + System.currentTimeMillis());
 }


### PR DESCRIPTION
With listIndex changes in, this [regex](https://github.com/stargate/data-api/blob/main/src/main/java/io/stargate/sgv2/jsonapi/service/schema/tables/CQLSAIIndex.java#L109) will try to match index column name from indexMetaData options.
Unit tests we have for mocked indexMetaData use '-', and it is invalid, this causes debug log explodes.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
