### PR TITLE
Fix for insert many if any of the primary key column is null.

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/InsertAttemptPage.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/InsertAttemptPage.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
 import io.stargate.sgv2.jsonapi.config.constants.ErrorObjectV2Constants;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.TableBasedSchemaObject;
 import io.stargate.sgv2.jsonapi.service.shredding.DocRowIdentifer;
+import io.stargate.sgv2.jsonapi.service.shredding.tables.RowId;
 import java.util.*;
 
 /**
@@ -113,7 +114,8 @@ public class InsertAttemptPage<SchemaT extends TableBasedSchemaObject>
         seenErrors.add(cmdError);
       }
       results[attempt.position()] =
-          new InsertionResult(attempt.docRowID().orElseThrow(), InsertionStatus.ERROR, errorIdx);
+          new InsertionResult(
+              attempt.docRowID().orElse(RowId.EMPTY_ROWID), InsertionStatus.ERROR, errorIdx);
     }
 
     // And third, if any, skipped insertions; those that were not attempted (f.ex due

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowId.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowId.java
@@ -4,6 +4,7 @@ import io.stargate.sgv2.jsonapi.service.shredding.DocRowIdentifer;
 
 // TODO: AARON needs to hold all the values we identify as the parts of the PK for the row
 public record RowId(Object[] values) implements DocRowIdentifer {
+  public static final RowId EMPTY_ROWID = new RowId(new Object[0]);
 
   @Override
   public Object value() {


### PR DESCRIPTION
**What this PR does**:
Fix for insert many if any of the primary key column is null.

**Which issue(s) this PR fixes**:
Fixes #1702

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
