### PR TITLE
fixes #1700 default limit for ANN find now 1k

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/OperationAttempt.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/OperationAttempt.java
@@ -580,7 +580,6 @@ public abstract class OperationAttempt<
         var floatPos = start;
         for (int i = 0; i < 5; i++) {
           var nextPos = cql.indexOf(",", floatPos + 1, end);
-          System.out.println(nextPos);
           if (nextPos > -1) {
             floatPos = nextPos;
           } else {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/query/OrderByCqlClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/query/OrderByCqlClause.java
@@ -36,4 +36,17 @@ public interface OrderByCqlClause extends Function<Select, Select>, CQLClause {
   default boolean fullyCoversCommand() {
     return false;
   }
+
+  /**
+   * Called to get the default limit for the query when using this order by.
+   *
+   * <p>ANN order by has a different default that regular queries to limit the number of rows in
+   * consideration.
+   *
+   * @return Default returns {@link Integer#MAX_VALUE} so queries can read all the rows in the
+   *     table.
+   */
+  default Integer getDefaultLimit() {
+    return Integer.MAX_VALUE;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/TableOrderByANNCqlClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/TableOrderByANNCqlClause.java
@@ -17,11 +17,13 @@ public class TableOrderByANNCqlClause implements OrderByCqlClause {
 
   private final ApiColumnDef apiColumnDef;
   private final CqlVector<Float> vector;
+  private final Integer defaultLimit;
 
-  public TableOrderByANNCqlClause(ApiColumnDef apiColumnDef, CqlVector<Float> vector) {
+  public TableOrderByANNCqlClause(
+      ApiColumnDef apiColumnDef, CqlVector<Float> vector, Integer defaultLimit) {
     this.apiColumnDef = Objects.requireNonNull(apiColumnDef, "apiColumnDef must not be null");
     this.vector = Objects.requireNonNull(vector, "vector must not be null");
-
+    this.defaultLimit = Objects.requireNonNull(defaultLimit, "defaultLimit must not be null");
     // sanity check
     if (apiColumnDef.type().typeName() != ApiTypeName.VECTOR) {
       throw new IllegalArgumentException(
@@ -37,5 +39,10 @@ public class TableOrderByANNCqlClause implements OrderByCqlClause {
   @Override
   public boolean fullyCoversCommand() {
     return true;
+  }
+
+  @Override
+  public Integer getDefaultLimit() {
+    return defaultLimit;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/ReadCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/ReadCommandResolver.java
@@ -74,7 +74,8 @@ class ReadCommandResolver<
 
     // if the user did not provide a limit,we read all the possible rows. Paging is then handled
     // by the driver pagination
-    int commandLimit = command.limit().orElseGet(() -> Integer.MAX_VALUE);
+    int commandLimit =
+        command.limit().orElseGet(() -> orderByWithWarnings.target().getDefaultLimit());
 
     int commandSkip = command.skip().orElse(0);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/sort/TableCqlSortClauseResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/sort/TableCqlSortClauseResolver.java
@@ -251,7 +251,10 @@ public class TableCqlSortClauseResolver<CmdT extends Command & Sortable & Window
         "Vector sorting on column {}", cqlIdentifierToMessageString(vectorSortColumn.name()));
     var cqlVector = CqlVectorUtil.floatsToCqlVector(vectorSortExpression.vector());
     return WithWarnings.of(
-        new TableOrderByANNCqlClause(vectorSortColumn, cqlVector),
+        new TableOrderByANNCqlClause(
+            vectorSortColumn,
+            cqlVector,
+            commandContext.getConfig(OperationsConfig.class).maxVectorSearchLimit()),
         List.of(WarningException.Code.ZERO_FILTER_OPERATIONS));
   }
 


### PR DESCRIPTION
using the same configured AN find limit as collections, which is currently 1k


**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #1700

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
