### PR TITLE
remove diver config for global page size setting

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -49,8 +49,8 @@ datastax-java-driver {
     }
   }
   basic.request.timeout = 20 seconds
-  // setting this at the global and the profile level
-  basic.request.page-size = 20
+
+
   profiles {
 
     create {


### PR DESCRIPTION
This setting is affecting collection count command, only reads to 20. And that is not what we want.
fixes:
#1708 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
