### PR TITLE
Fix #1714: check for `null` value for "provider" parameter (seen in Prod)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/VectorizeConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/VectorizeConfig.java
@@ -48,22 +48,24 @@ public record VectorizeConfig(
       String modelName,
       Map<String, String> authentication,
       Map<String, Object> parameters) {
+    if (provider == null) {
+      throw ErrorCodeV1.INVALID_CREATE_COLLECTION_OPTIONS.toApiException("'provider' is required");
+    }
     this.provider = provider;
     // HuggingfaceDedicated does not need user to specify model explicitly
     // If user specifies modelName other than endpoint-defined-model, will error out
     // By default, huggingfaceDedicated provider use endpoint-defined-model as placeholder
-    if (provider.equals(ProviderConstants.HUGGINGFACE_DEDICATED)) {
-      if (modelName != null
-          && !modelName.equals(ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL)) {
+    if (ProviderConstants.HUGGINGFACE_DEDICATED.equals(provider)) {
+      if (modelName == null) {
+        modelName = ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL;
+      } else if (!modelName.equals(ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL)) {
         throw ErrorCodeV1.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
             "'modelName' is not needed for provider %s explicitly, only '%s' is accepted",
             ProviderConstants.HUGGINGFACE_DEDICATED,
             ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL);
       }
-      this.modelName = ProviderConstants.HUGGINGFACE_DEDICATED_DEFINED_MODEL;
-    } else {
-      this.modelName = modelName;
     }
+    this.modelName = modelName;
     if (authentication != null && !authentication.isEmpty()) {
       Map<String, String> updatedAuth = new HashMap<>();
       for (Map.Entry<String, String> userAuth : authentication.entrySet()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
@@ -163,6 +163,10 @@ public class DataVectorizer {
    * @return Uni<float[]> - result vector float array
    */
   public Uni<float[]> vectorize(String vectorizeContent) {
+    if (embeddingProvider == null) {
+      throw ErrorCodeV1.EMBEDDING_SERVICE_NOT_CONFIGURED.toApiException(
+          schemaObject.name().table());
+    }
     Uni<List<float[]>> vectors =
         embeddingProvider
             .vectorize(


### PR DESCRIPTION
**What this PR does**:

Prevents NPE when "provider" is missing or `null` for VectorConfig parameter of CreateCollection

**Which issue(s) this PR fixes**:
Fixes #1714

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
