### PR TITLE
Ajm/fix 1720 bad order inserted return

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/TableInsertAttempt.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/tables/TableInsertAttempt.java
@@ -44,8 +44,7 @@ public class TableInsertAttempt extends InsertAttempt<TableSchemaObject> {
       return Optional.empty();
     }
 
-    var apiColumns =
-        schemaObject.apiTableDef().allColumns().filterBy(row.keyColumns().getIdentifiers());
+    var apiColumns = schemaObject.apiTableDef().primaryKeys();
     if (!apiColumns.filterByUnsupported().isEmpty()) {
       throw new IllegalStateException(
           "Unsupported columns primary key: %s" + apiColumns.filterByUnsupported());

--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -64,13 +64,13 @@ snippets:
     body: |-
       The query was executed without taking advantage of the primary key or indexes on the table, this can have performance implications on large tables.
       
-      See documentation at XXXX for best practices for filtering.
+      See documentation for best practices for filtering.
 
   - name: INEFFICIENT_SORT
     body: |-
       The command was executed using in memory sorting rather than taking advantage of the partition sorting on disk. This can have performance implications on large tables.
       
-      See documentation at XXXX for best practices for sorting.
+      See documentation for best practices for sorting.
 
   - name: RESEND_USING_ONLY_DEFINED_COLUMNS
     body: |-


### PR DESCRIPTION
fixes #1720 bad order for inserted return

the return for insert one and many 

wrong order for the primary key schema and for the 
primary key values 


**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #1720 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
