### PR TITLE
Fix `$binary` to Support 4096 Vector Dimensions in Collections

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -27,6 +27,9 @@ public interface DocumentConstants {
     /** Document field name that will have text value for which vectorize method in called */
     String VECTOR_EMBEDDING_TEXT_FIELD = "$vectorize";
 
+    /** Document field name that will have text value for which vectorize method in called */
+    String BINARY_VECTOR_TEXT_FIELD = "$binary";
+
     /** Field name used in projection clause to get similarity score in response. */
     String VECTOR_FUNCTION_SIMILARITY_FIELD = "$similarity";
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -549,8 +549,9 @@ public class DocumentShredder {
     }
 
     private void validateStringValue(String referringPropertyName, String value) {
-      if (DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(referringPropertyName)) {
-        // `$vectorize` field are not checked for length
+      if (DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD.equals(referringPropertyName)
+          || DocumentConstants.Fields.BINARY_VECTOR_TEXT_FIELD.equals(referringPropertyName)) {
+        // `$vectorize` and `$binary` field are not checked for length
         return;
       }
       OptionalInt encodedLength =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix `$binary` to Support 4096 Vector Dimensions in Collections

**Which issue(s) this PR fixes**:
Fixes #1710 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
