### PR TITLE
Fix Table updateCommand, does not allow empty update operation assignments

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/UpdateException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/UpdateException.java
@@ -15,6 +15,7 @@ public class UpdateException extends RequestException {
 
   public enum Code implements ErrorCode<UpdateException> {
     MISSING_UPDATE_OPERATIONS,
+    MISSING_UPDATE_OPERATION_ASSIGNMENTS,
     UNKNOWN_TABLE_COLUMNS,
     UNSUPPORTED_UPDATE_FOR_PRIMARY_KEY_COLUMNS,
     UNSUPPORTED_UPDATE_OPERATIONS_FOR_TABLE,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/query/DefaultUpdateValuesCQLClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/query/DefaultUpdateValuesCQLClause.java
@@ -18,6 +18,8 @@ public class DefaultUpdateValuesCQLClause implements UpdateValuesCQLClause {
   private final List<ColumnAssignment> assignments;
 
   public DefaultUpdateValuesCQLClause(List<ColumnAssignment> assignments) {
+    // Keep the assertions, assignments won't be null and empty, they are been checked in
+    // TableUpdateResolver
     this.assignments = Objects.requireNonNull(assignments, "assignments must not be null");
     if (assignments.isEmpty()) {
       throw new IllegalArgumentException("assignments must not be empty");

--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -387,6 +387,14 @@ request-errors:
       Resend the command using at least one update operation.
 
   - scope: UPDATE
+    code: MISSING_UPDATE_OPERATION_ASSIGNMENTS
+    title: Update operation assignments can not be empty
+    body: |-
+      The command include update operations ${emptyAssignmentsOperator} that have empty assignments.
+      
+      Resend the command using non-empty assignments update operation.
+
+  - scope: UPDATE
     code: UNSUPPORTED_UPDATE_OPERATIONS_FOR_TABLE
     title: Update operation not supported by Tables
     body: |-

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UpdateTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UpdateTableIntegrationTest.java
@@ -9,10 +9,14 @@ import io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders;
 import io.stargate.sgv2.jsonapi.exception.FilterException;
 import io.stargate.sgv2.jsonapi.exception.UpdateException;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusIntegrationTest
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
@@ -310,6 +314,28 @@ public class UpdateTableIntegrationTest extends AbstractTableIntegrationTestBase
         .updateOne(FULL_PRIMARY_KEY_FILTER_DEFAULT_ROW, updateClauseJSON)
         .hasSingleApiError(
             UpdateException.Code.UNSUPPORTED_UPDATE_FOR_PRIMARY_KEY_COLUMNS, UpdateException.class)
+        .hasNoWarnings();
+  }
+
+  // ==================================================================================================================
+  // Update with empty assignments update operation
+  // ==================================================================================================================
+
+  private static Stream<Arguments> EMPTY_ASSIGNMENTS() {
+    return Stream.of(
+        Arguments.of("{\"$set\":{}}"),
+        Arguments.of("{\"$unset\":{}}"),
+        Arguments.of("{\"$set\":{}, \"$unset\":{}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("EMPTY_ASSIGNMENTS")
+  public void emptyAssignments(String updateClauseJSON) {
+    DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_COMPLEX_PRIMARY_KEY)
+        .templated()
+        .updateOne(FULL_PRIMARY_KEY_FILTER_DEFAULT_ROW, updateClauseJSON)
+        .hasSingleApiError(
+            UpdateException.Code.MISSING_UPDATE_OPERATION_ASSIGNMENTS, UpdateException.class)
         .hasNoWarnings();
   }
 


### PR DESCRIPTION
does not allow empty update operation assignments

So, these examples will fail with API exception MISSING_UPDATE_OPERATION_ASSIGNMENTS
-     {"$set":{}}
-     {"$unset":{}}
-     {"$set":{}, "$unset":{}"}

**Which issue(s) this PR fixes**:
Fixes #1727

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
