### PR TITLE
Fix #1763: use right profile for Table truncate

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CommandQueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CommandQueryExecutor.java
@@ -14,8 +14,6 @@ import io.stargate.sgv2.jsonapi.util.CqlIdentifierUtil;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Configured to execute queries for a specific command that relies on drive profiles MORE TODO
@@ -57,8 +55,6 @@ public class CommandQueryExecutor {
       this.profileSuffix = name().toLowerCase();
     }
   }
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(CommandQueryExecutor.class);
 
   private final CQLSessionCache cqlSessionCache;
   private final RequestContext requestContext;
@@ -133,7 +129,7 @@ public class CommandQueryExecutor {
   public Uni<AsyncResultSet> executeTruncate(SimpleStatement statement) {
     Objects.requireNonNull(statement, "statement must not be null");
 
-    statement = withExecutionProfile(statement, QueryType.WRITE);
+    statement = withExecutionProfile(statement, QueryType.TRUNCATE);
     return executeAndWrap(statement);
   }
 


### PR DESCRIPTION
**What this PR does**:

Fixes minor copy-paste bug that caused #1763 (wrong timeout for Table truncate)

**Which issue(s) this PR fixes**:
Fixes #1763

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
