### PR TITLE
Improve info log line for CqlProxyRetryPolicy on WriteTimeout

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlProxyRetryPolicy.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlProxyRetryPolicy.java
@@ -68,9 +68,9 @@ public class CqlProxyRetryPolicy implements RetryPolicy {
     }
     if (LOG.isInfoEnabled()) {
       LOG.info(
-          "Write timeout for request write type : {}, retryCount: {}, consistency level: {} -> retry decision is: {}",
+          "Write timeout for request writeType : {}, retryCount: {}, consistency level: {} -> retry decision is: {}",
           writeType,
-          retryCount + 1,
+          retryCount,
           cl,
           retryDecision);
     }


### PR DESCRIPTION
We have max retry set as 3 for CAS WriteTimeout

E.G.
driver retries 3 times, they all CAS timeout out. And for the 4th, the retry decision will be RETHROW.
```
INFO  [default_tenant-io-1] 2024-12-06 09:58:35,138 CqlProxyRetryPolicy.java:70 - Write timeout for request write type : CAS, retryCount: 0, consistency level: LOCAL_SERIAL,  -> retry decision is: RETRY_SAME
INFO  [default_tenant-io-1] 2024-12-06 09:58:35,152 CqlProxyRetryPolicy.java:70 - Write timeout for request write type : CAS, retryCount: 1, consistency level: LOCAL_QUORUM,  -> retry decision is: RETRY_SAME
INFO  [default_tenant-io-1] 2024-12-06 09:58:35,174 CqlProxyRetryPolicy.java:70 - Write timeout for request write type : CAS, retryCount: 2, consistency level: LOCAL_SERIAL,  -> retry decision is: RETRY_SAME
INFO  [default_tenant-io-1] 2024-12-06 09:58:35,189 CqlProxyRetryPolicy.java:70 - Write timeout for request write type : CAS, retryCount: 3, consistency level: LOCAL_SERIAL,  -> retry decision is: RETHROW
```










**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
