### PR TITLE
remove http override for unknown server error

### DIFF
--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -1187,7 +1187,6 @@ server-errors:
   # UNSCOPED server errors
   - scope:
     code: UNEXPECTED_SERVER_ERROR
-    http-status-override: 500
     title: Unexpected server error
     body: |-
       An unexpected server error occurred while processing the request. 


### PR DESCRIPTION
The base for new Driver error handling returns a server unknown error and the config was turning this into a HTTP 500. I think may have been there just to show we can do that, and we will want to for some errors.

But we should be returning the basic 200 and the error in the response.

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #1719

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
