### PR TITLE
Fix #1787: add "bad" JSON along with "bad doc id" to help troubleshoting

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResultBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResultBuilder.java
@@ -145,7 +145,7 @@ public class CommandResultBuilder {
       cmdStatus.put(CommandStatus.WARNINGS, warnings);
     }
 
-    // null out values that are empty, the CommandResult serialiser will ignore them when the JSON
+    // null out values that are empty, the CommandResult serializer will ignore them when the JSON
     // is built
     var finalStatus = cmdStatus.isEmpty() ? null : cmdStatus;
     var finalErrors = cmdErrors.isEmpty() ? null : cmdErrors;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.jsonapi.api.model.command;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Enum with it's json property name which is returned in api response inside status */
+/** Enum with its json property name which is returned in api response inside status */
 public enum CommandStatus {
   /** The element has the count of document */
   @JsonProperty("count")

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
@@ -25,7 +25,7 @@ import io.stargate.sgv2.jsonapi.service.schema.tables.ApiVectorType;
 import java.util.*;
 
 /**
- * Utility class to execute embedding serive to get vector embeddings for the text fields in the
+ * Utility class to execute embedding service to get vector embeddings for the text fields in the
  * '$vectorize' field. The class has three utility methods to handle vectorization in json
  * documents, sort clause and update clause.
  */

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/InsertOperationPage.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/InsertOperationPage.java
@@ -47,7 +47,7 @@ public class InsertOperationPage<SchemaT extends TableBasedSchemaObject>
   // Created in the Ctor
   private final APIExceptionCommandErrorBuilder apiExceptionToError;
 
-  /** Create an instance that has debug false and useErrorIbhectV2 false */
+  /** Create an instance that has debug false and useErrorObjectV2 false */
   public InsertOperationPage(
       List<? extends InsertAttempt<SchemaT>> allAttemptedInsertions,
       boolean returnDocumentResponses) {
@@ -107,7 +107,7 @@ public class InsertOperationPage<SchemaT extends TableBasedSchemaObject>
   }
 
   /**
-   * Returns a insert command result in the newer style of detailed results per document
+   * Returns an insert command result in the newer style of detailed results per document
    *
    * <p>aaron - 3 sept -2024 - code moved from the get() method
    *
@@ -158,7 +158,7 @@ public class InsertOperationPage<SchemaT extends TableBasedSchemaObject>
   }
 
   /**
-   * Returns a insert command result in the original style, without detailed document responses.
+   * Returns an insert command result in the original style, without detailed document responses.
    *
    * <p>aaron - 3 sept -2024 - code moved from the get() method
    *

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/InsertManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/InsertManyCommandResolver.java
@@ -1,6 +1,5 @@
 package io.stargate.sgv2.jsonapi.service.resolver;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertManyCommand;
 import io.stargate.sgv2.jsonapi.config.DebugModeConfig;
@@ -18,7 +17,6 @@ import io.stargate.sgv2.jsonapi.service.shredding.collections.DocumentShredder;
 import io.stargate.sgv2.jsonapi.service.shredding.tables.RowShredder;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.List;
 
 /** Resolves the {@link InsertManyCommand}. */
 @ApplicationScoped
@@ -45,7 +43,6 @@ public class InsertManyCommandResolver implements CommandResolver<InsertManyComm
     final InsertManyCommand.Options options = command.options();
     final boolean ordered = (null != options) && options.ordered();
     final boolean returnDocumentResponses = (null != options) && options.returnDocumentResponses();
-    final List<JsonNode> inputDocs = command.documents();
 
     var builder =
         new CollectionInsertAttemptBuilder(ctx.schemaObject(), documentShredder, ctx.commandName());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentId.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentId.java
@@ -82,8 +82,8 @@ public interface DocumentId extends DocRowIdentifer {
             "unrecognized JSON extension type '%s'", node.fieldNames().next());
     }
     throw ErrorCodeV1.SHRED_BAD_DOCID_TYPE.toApiException(
-        "Document Id must be a JSON String, Number, Boolean, EJSON-Encoded Date Object or NULL instead got %s",
-        node.getNodeType());
+        "Document Id must be a JSON String, Number, Boolean, EJSON-Encoded Date Object or NULL instead got %s: %s",
+        node.getNodeType(), node.toString());
   }
 
   static DocumentId fromDatabase(int typeId, String documentIdAsText) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
@@ -331,10 +331,23 @@ public class DocumentShredderTest {
           catchThrowable(() -> documentShredder.shred(objectMapper.readTree("{ \"_id\" : [ ] }")));
 
       assertThat(t)
-          .isNotNull()
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_BAD_DOCID_TYPE)
           .hasMessage(
-              "Bad type for '_id' property: Document Id must be a JSON String, Number, Boolean, EJSON-Encoded Date Object or NULL instead got ARRAY")
-          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_BAD_DOCID_TYPE);
+              "Bad type for '_id' property: Document Id must be a JSON String, Number, Boolean, EJSON-Encoded Date Object or NULL instead got ARRAY: []");
+    }
+
+    @Test
+    public void docBadDocIdTypeObjectNotEJSON() {
+      Throwable t =
+          catchThrowable(
+              () ->
+                  documentShredder.shred(
+                      objectMapper.readTree("{ \"_id\" : { \"foo\": \"bar\" } }")));
+
+      assertThat(t)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_BAD_DOCID_TYPE)
+          .hasMessage(
+              "Bad type for '_id' property: Document Id must be a JSON String, Number, Boolean, EJSON-Encoded Date Object or NULL instead got OBJECT: {\"foo\":\"bar\"}");
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Includes actual JSON value that is not valid Doc `_id` for Collections (not just type like `OBJECT`). This to address a problem seen by on-call for a user who had 1000+ `SHRED_BAD_DOCID_TYPE` failures, to know what exactly went wrong.

NOTE: only one instance of error value needed changing, other 4 cases already have enough information.

**Which issue(s) this PR fixes**:
Fixes #1787

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
