### PR TITLE
add props overrides for docker-image-publish.yaml to fix Astra Data API openapi spec

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -61,10 +61,26 @@ jobs:
           mask-password: 'true'
 
       - name: Build and push (Amazon ECR)
+        env:
+          QUARKUS_APPLICATION_NAME: 'Astra DB Serverless Data API'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_DESCRIPTION: 'The Astra DB Serverless Data API modifies and queries data stored as unstructured JSON documents in collections. See the [documentation site](https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api.html) for additional information.'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_TERMS_OF_SERVICE: 'https://www.datastax.com/legal'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_NAME: 'DataStax'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_URL: 'https://www.datastax.com/contact-us'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_LICENSE_NAME: ''
+          QUARKUS_SMALLRYE_OPENAPI_INFO_LICENSE_URL: ''
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' ${{ matrix.profile }}
 
       - name: Build and push image for profiling (Amazon ECR)
+        env:
+          QUARKUS_APPLICATION_NAME: 'Astra DB Serverless Data API'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_DESCRIPTION: 'The Astra DB Serverless Data API modifies and queries data stored as unstructured JSON documents in collections. See the [documentation site](https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api.html) for additional information.'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_TERMS_OF_SERVICE: 'https://www.datastax.com/legal'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_NAME: 'DataStax'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_URL: 'https://www.datastax.com/contact-us'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_LICENSE_NAME: ''
+          QUARKUS_SMALLRYE_OPENAPI_INFO_LICENSE_URL: ''
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm ${{ matrix.profile }}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -152,7 +152,7 @@ quarkus:
     path: /api/json/openapi
     info-title: ${quarkus.application.name}
     info-version: ${quarkus.application.version:}
-    info-description:
+    info-description: 123
     info-terms-of-service:
     info-contact-name: Stargate
     info-contact-url: https://stargate.io


### PR DESCRIPTION
Data API 1.0.20-DEC-HOT-FIX image surfaces a problem for Data API openapi spec and docs.
For this version, we did NOT create a release for it, instead it is just the HOT-FIX image we published from a branch.
In the release workflow, there is a [props override ](https://github.com/stargate/data-api/blob/main/.github/workflows/release.yaml#L237)which overrides ‘Stargate DATA API’ to ‘Astra DB Serverless Data API’.
What riptano astra-api-docs [github workflow ](https://github.com/riptano/astra-api-docs/blob/main/.github/workflows/generate-pr-dataapi.yml#L66) does is to download the Data API openapi spec from a prod [DB](https://flightdeck.prod.cloud-tools.datastax.com/database/b570392a-846d-4f6a-8d76-4ddda71e1fe3)created by Ronnie Miller. It is prod, so the title is not been override.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
