### PR TITLE
Fix #1811: fail cleanly on empty `name`

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
@@ -5,6 +5,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandName;
 import io.stargate.sgv2.jsonapi.api.model.command.KeyspaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.NoOptionsCommand;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -17,7 +18,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(description = "Command that drops a table if one exists.")
 @JsonTypeName(CommandName.Names.DROP_TABLE)
 public record DropTableCommand(
-    @NotNull @Schema(description = "Name of the table") String name,
+    @NotNull @Schema(description = "Name of the table") @NotEmpty // prevent error from empty String
+        String name,
     @Nullable @Schema(description = "Dropping table command option.", type = SchemaType.OBJECT)
         Options options)
     implements NoOptionsCommand, KeyspaceCommand {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropTableCommand.java
@@ -18,7 +18,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(description = "Command that drops a table if one exists.")
 @JsonTypeName(CommandName.Names.DROP_TABLE)
 public record DropTableCommand(
-    @NotNull @Schema(description = "Name of the table") @NotEmpty // prevent error from empty String
+    @NotNull
+        @Schema(description = "Name of the table")
+        @NotEmpty // prevent empty String from breaking CQL statement, validate early
         String name,
     @Nullable @Schema(description = "Dropping table command option.", type = SchemaType.OBJECT)
         Options options)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
@@ -83,10 +83,8 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
 
   @Nested
   @Order(2)
-  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   class DropTableFails {
     @Test
-    @Order(1)
     public void dropInvalidTableIfExistsFalse() {
       assertNamespaceCommand(keyspaceName)
           .templated()
@@ -99,7 +97,6 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
 
     // [data-api#1811]: 500 for empty Table name
     @Test
-    @Order(2)
     public void dropInvalidTableWithEmptyName() {
       assertNamespaceCommand(keyspaceName)
           .templated()

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiResponseValidator.java
@@ -138,7 +138,7 @@ public class DataApiResponseValidator {
     return hasSingleApiError(errorCode, containsString(messageSnippet));
   }
 
-  // aaron 19-oct-2024 added wheile redoing a lot of errors, we still need to cleanup the error code
+  // aaron 19-oct-2024 added while redoing a lot of errors, we still need to cleanup the error code
   // world
   public DataApiResponseValidator hasSingleApiError(String errorCode, String messageSnippet) {
     return body("$", responseIsError)


### PR DESCRIPTION
**What this PR does**:

Fixes error handling of `DropTable` with `name=""`.

**Which issue(s) this PR fixes**:
Fixes #1811

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
