### PR TITLE
Fix #1812: create new `ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX`, map non-parsing errors to that

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/table/definition/TableDefinitionDesc.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/table/definition/TableDefinitionDesc.java
@@ -2,7 +2,6 @@ package io.stargate.sgv2.jsonapi.api.model.command.table.definition;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.stargate.sgv2.jsonapi.config.constants.TableDescConstants;
 import jakarta.validation.Valid;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -14,8 +13,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  *
  * <p>Has the columns and the primary key definition, not the name of the table.
  */
-@JsonPropertyOrder({"name", "definition"})
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TableDefinitionDesc(
     @Valid
         @Schema(description = "API table columns definitions", type = SchemaType.OBJECT)

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
@@ -47,7 +47,7 @@ public enum ErrorCodeV1 {
   /** note: Only used by EmbeddingGateway */
   INVALID_REQUEST("Request not supported by the data store"),
 
-  INVALID_REQUEST_BAD_SYNTAX("Request invalid, JSON syntax incorrect"),
+  INVALID_REQUEST_STRUCTURE_MISMATCH("Request invalid, mismatching JSON structure"),
 
   INVALID_REQUEST_NOT_JSON("Request invalid, cannot parse as JSON"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
@@ -47,6 +47,8 @@ public enum ErrorCodeV1 {
   /** note: Only used by EmbeddingGateway */
   INVALID_REQUEST("Request not supported by the data store"),
 
+  INVALID_REQUEST_BAD_SYNTAX("Request invalid, JSON syntax incorrect"),
+
   INVALID_REQUEST_NOT_JSON("Request invalid, cannot parse as JSON"),
 
   INVALID_REQUEST_UNKNOWN_FIELD("Request invalid, unrecognized JSON field"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -265,7 +265,7 @@ public final class ThrowableToErrorMapper {
     // aaron 28-oct-2024, HACK just need something to handle our deserialization errors
     // should not be using V1 errors but would be too much to fix this now
     // NOTE: must be after the UnrecognizedPropertyException check
-    // 09-Jan-2025, tatu: [data-api#1812] Hardly ideal but slightly better
+    // 09-Jan-2025, tatu: [data-api#1812] Not ideal but slightly better than before
     if (e instanceof JsonMappingException jme) {
       return ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX
           .toApiException(

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -265,9 +265,14 @@ public final class ThrowableToErrorMapper {
     // aaron 28-oct-2024, HACK just need something to handle our deserialization errors
     // should not be using V1 errors but would be too much to fix this now
     // NOTE: must be after the UnrecognizedPropertyException check
+    // 09-Jan-2025, tatu: [data-api#1812] Hardly ideal but slightly better
     if (e instanceof JsonMappingException jme) {
-      return ErrorCodeV1.INVALID_REQUEST_NOT_JSON
-          .toApiException(Response.Status.BAD_REQUEST, "%s", e.getMessage())
+      return ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX
+          .toApiException(
+              Response.Status.BAD_REQUEST,
+              "underlying problem: (%s) %s",
+              e.getClass().getName(),
+              e.getMessage())
           .getCommandResultError();
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -267,7 +267,7 @@ public final class ThrowableToErrorMapper {
     // NOTE: must be after the UnrecognizedPropertyException check
     // 09-Jan-2025, tatu: [data-api#1812] Not ideal but slightly better than before
     if (e instanceof JsonMappingException jme) {
-      return ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX
+      return ErrorCodeV1.INVALID_REQUEST_STRUCTURE_MISMATCH
           .toApiException(
               Response.Status.BAD_REQUEST,
               "underlying problem: (%s) %s",

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
@@ -6,8 +6,10 @@ import static io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders.assertT
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders;
+import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.exception.SchemaException;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 import org.junit.jupiter.api.*;
 
@@ -482,6 +484,31 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
               SchemaException.class,
               "The known index types are: [collection, regular, text-analysed, vector].",
               "The command used the unknown index type: unknown.");
+    }
+
+    // [data-api#1812]: invalid JSON structure
+    @Test
+    public void invalidJSONStructure() {
+      assertTableCommand(keyspaceName, testTableName)
+          // Invalid JSON structure: "name" should be String, not Object;
+          // reported as HTTP 400
+          .expectHttpStatus(Response.Status.BAD_REQUEST)
+          .postCreateIndex(
+              """
+                        {
+                            "name": {
+                              "name": 1
+                            },
+                            "definition": {
+                              "column": {
+                                "background": true
+                              },
+                            }
+                        }
+                        """)
+          .hasSingleApiError(
+              ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX,
+              "Request invalid, JSON syntax incorrect: underlying problem");
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
@@ -507,8 +507,8 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
                         }
                         """)
           .hasSingleApiError(
-              ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX,
-              "Request invalid, JSON syntax incorrect: underlying problem");
+              ErrorCodeV1.INVALID_REQUEST_STRUCTURE_MISMATCH,
+              "Request invalid, mismatching JSON structure: underlying problem");
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIntegrationTest.java
@@ -322,10 +322,10 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                           """,
                   "invalidPartitionSortOrderingValueTable",
                   true,
-                  ErrorCodeV1.INVALID_REQUEST_NOT_JSON.name(),
+                  ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX.name(),
                   " may have a partitionSort field that is a JSON Object, each field is the name of a column, with a value of 1 for ASC, or -1 for DESC")));
 
-      // invalidPartitionSortOrderingValueTable
+      // invalidPartitionSortOrderingValueTypeTable
       testCases.add(
           Arguments.of(
               new CreateTableTestData(
@@ -351,7 +351,7 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                           """,
                   "invalidPartitionSortOrderingValueTypeTable",
                   true,
-                  ErrorCodeV1.INVALID_REQUEST_NOT_JSON.name(),
+                  ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX.name(),
                   " may have a partitionSort field that is a JSON Object, each field is the name of a column, with a value of 1 for ASC, or -1 for DESC")));
 
       // invalidColumnTypeTable
@@ -383,7 +383,7 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                   true,
                   SchemaException.Code.UNKNOWN_PRIMITIVE_DATA_TYPE.name(),
                   "The command used the unsupported data type: invalid_type.")));
-      // Column type not provided
+      // Column type not provided: nullColumnTypeTable
       testCases.add(
           Arguments.of(
               new CreateTableTestData(
@@ -410,7 +410,7 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                           """,
                   "nullColumnTypeTable",
                   true,
-                  ErrorCodeV1.INVALID_REQUEST_NOT_JSON.name(),
+                  ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX.name(),
                   "The Long Form type definition must be a JSON Object with at least a `type` field that is a String (value is null)")));
 
       // Map type tests

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIntegrationTest.java
@@ -322,7 +322,7 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                           """,
                   "invalidPartitionSortOrderingValueTable",
                   true,
-                  ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX.name(),
+                  ErrorCodeV1.INVALID_REQUEST_STRUCTURE_MISMATCH.name(),
                   " may have a partitionSort field that is a JSON Object, each field is the name of a column, with a value of 1 for ASC, or -1 for DESC")));
 
       // invalidPartitionSortOrderingValueTypeTable
@@ -351,7 +351,7 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                           """,
                   "invalidPartitionSortOrderingValueTypeTable",
                   true,
-                  ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX.name(),
+                  ErrorCodeV1.INVALID_REQUEST_STRUCTURE_MISMATCH.name(),
                   " may have a partitionSort field that is a JSON Object, each field is the name of a column, with a value of 1 for ASC, or -1 for DESC")));
 
       // invalidColumnTypeTable
@@ -410,7 +410,7 @@ class CreateTableIntegrationTest extends AbstractTableIntegrationTestBase {
                           """,
                   "nullColumnTypeTable",
                   true,
-                  ErrorCodeV1.INVALID_REQUEST_BAD_SYNTAX.name(),
+                  ErrorCodeV1.INVALID_REQUEST_STRUCTURE_MISMATCH.name(),
                   "The Long Form type definition must be a JSON Object with at least a `type` field that is a String (value is null)")));
 
       // Map type tests

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
@@ -46,9 +46,7 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
 
   @Nested
   @Order(1)
-  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   class DropTableSuccess {
-    @Order(1)
     @Test
     public void dropTableWithoutIfExist() {
       assertNamespaceCommand(keyspaceName)
@@ -64,7 +62,6 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
     }
 
     @Test
-    @Order(2)
     public void dropTableWithIfExists() {
       for (int i = 0; i < 2; i++) {
         assertNamespaceCommand(keyspaceName)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
@@ -63,8 +63,8 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
           .body("status.tables[0]", equalTo(duplicateTableName));
     }
 
-    @Order(2)
     @Test
+    @Order(2)
     public void dropTableWithIfExists() {
       for (int i = 0; i < 2; i++) {
         assertNamespaceCommand(keyspaceName)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/DropTableIntegrationTest.java
@@ -46,7 +46,9 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
 
   @Nested
   @Order(1)
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   class DropTableSuccess {
+    @Order(1)
     @Test
     public void dropTableWithoutIfExist() {
       assertNamespaceCommand(keyspaceName)
@@ -61,6 +63,7 @@ class DropTableIntegrationTest extends AbstractTableIntegrationTestBase {
           .body("status.tables[0]", equalTo(duplicateTableName));
     }
 
+    @Order(2)
     @Test
     public void dropTableWithIfExists() {
       for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
**What this PR does**:

Improves error handling wrt #1812

**Which issue(s) this PR fixes**:
Fixes #1812

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
