### PR TITLE
Fix #1817: handle null/missing vector value with find/findOne

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/optvector/SubtypeOnlyFloatVectorToArrayCodec.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/optvector/SubtypeOnlyFloatVectorToArrayCodec.java
@@ -75,7 +75,8 @@ public class SubtypeOnlyFloatVectorToArrayCodec implements TypeCodec<float[]> {
 
   @Override
   public ByteBuffer encode(float[] array, ProtocolVersion protocolVersion) {
-    if (array == null) {
+    // May pass either null or empty array for missing/null/empty vector
+    if (array == null || array.length == 0) {
       return null;
     }
     int length = array.length;
@@ -90,9 +91,9 @@ public class SubtypeOnlyFloatVectorToArrayCodec implements TypeCodec<float[]> {
 
   @Override
   public float[] decode(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+    // When we have missing or `null` valued vector we get here so:
     if (bytes == null || bytes.remaining() == 0) {
-      throw new IllegalArgumentException(
-          "Input ByteBuffer must not be null and must have non-zero remaining bytes");
+      return null;
     }
     // TODO: Do we want to treat this as an error?  We could also just ignore any extraneous bytes
     // if they appear.

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -1209,6 +1209,29 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
           .hasJSONField("data.document", expJSON);
     }
 
+    // [databind#1817]
+    @Test
+    void insertNullVectorValueUsingList() {
+      // To read vector back as null can either omit or add null; issue reported with
+      // former so use that (handling should be same either way)
+      String docJSON =
+              """
+                          {
+                            "id": "vectorNULL"
+                          }
+                          """;
+      assertTableCommand(keyspaceName, TABLE_WITH_VECTOR_COLUMN)
+              .templated()
+              .insertOne(docJSON)
+              .wasSuccessful()
+              .hasInsertedIds(List.of("vectorNULL"));
+
+      assertTableCommand(keyspaceName, TABLE_WITH_VECTOR_COLUMN)
+              .postFindOne("{ \"filter\": { \"id\": \"vectorNULL\" } }")
+              .wasSuccessful()
+              .hasJSONField("data.document", docJSON);
+    }
+
     @Test
     void insertValidVectorKey() {
       String docJSON =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -1215,21 +1215,21 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
       // To read vector back as null can either omit or add null; issue reported with
       // former so use that (handling should be same either way)
       String docJSON =
-              """
+          """
                           {
                             "id": "vectorNULL"
                           }
                           """;
       assertTableCommand(keyspaceName, TABLE_WITH_VECTOR_COLUMN)
-              .templated()
-              .insertOne(docJSON)
-              .wasSuccessful()
-              .hasInsertedIds(List.of("vectorNULL"));
+          .templated()
+          .insertOne(docJSON)
+          .wasSuccessful()
+          .hasInsertedIds(List.of("vectorNULL"));
 
       assertTableCommand(keyspaceName, TABLE_WITH_VECTOR_COLUMN)
-              .postFindOne("{ \"filter\": { \"id\": \"vectorNULL\" } }")
-              .wasSuccessful()
-              .hasJSONField("data.document", docJSON);
+          .postFindOne("{ \"filter\": { \"id\": \"vectorNULL\" } }")
+          .wasSuccessful()
+          .hasJSONField("data.document", docJSON);
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Fixes #1817 wherein missing/null `vector` column value (API Tables) handling throws and returns HTTP 500 fail for `find`/`findOne`

**Which issue(s) this PR fixes**:
Fixes #1817

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
