### PR TITLE
Fix #1847: allow most characters in Document Field names

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -33,10 +33,12 @@ public interface DocumentConstants {
     /** Field name used in projection clause to get similarity score in response. */
     String VECTOR_FUNCTION_SIMILARITY_FIELD = "$similarity";
 
-    // Current definition of valid JSON API names: note that this only validates
-    // characters, not length limits (nor empty nor "too long" allowed but validated
-    // separately)
-    Pattern VALID_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_\\-]*");
+    // Current definition of valid JSON API Field names: note that this only validates
+    // characters, not length limits.
+    // NOTE: no longer used, see {@link
+    // io.stargate.sgv2.jsonapi.service.schema.naming.FieldNamingRule}
+    // for replacement
+    @Deprecated Pattern VALID_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_\\-]*");
 
     /** Field name pattern in sort and filter clause. */
     Pattern VALID_PATH_PATTERN = Pattern.compile("[a-zA-Z0-9_.\\-]*");

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
@@ -1,0 +1,20 @@
+package io.stargate.sgv2.jsonapi.service.schema.naming;
+
+public class FieldNamingRule extends NamingRule {
+  public FieldNamingRule() {
+    super("Field");
+  }
+
+  /**
+   * Validates the given Field name. The only limit is that the name must NOT start with a dollar
+   * sign ($). Note that field names are hierarchical, but validation is done on per-segment basis.
+   *
+   * @param depth Level of the field in the hierarchy (1 for root, 2 for first child, etc.)
+   * @param name the name to validate
+   * @return true if the name is valid, false otherwise
+   */
+  public boolean apply(int depth, String name) {
+    // Dollar not allowed for any fields (not just root)
+    return !name.startsWith("$");
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
@@ -22,11 +22,10 @@ public class FieldNamingRule extends NamingRule {
    * Validates the given Field name. The only limit is that the name must NOT start with a dollar
    * sign ($). Note that field names are hierarchical, but validation is done on name-by-name basis.
    *
-   * @param depth Level of the field in the hierarchy (1 for root, 2 for first child, etc.)
    * @param name the name to validate
    * @return true if the name is valid, false otherwise
    */
-  public boolean apply(int depth, String name) {
+  public boolean apply(String name) {
     // Dollar not allowed to start any field name (not just root)
     return !name.startsWith("$");
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
@@ -1,5 +1,18 @@
 package io.stargate.sgv2.jsonapi.service.schema.naming;
 
+/**
+ * {@link NamingRule} for validating field names: names that come from properties of JSON document
+ * used to create a Document in a Collection. These names form a hierarchy of fields, where each
+ * field can have sub-fields.
+ *
+ * <p>The rules for field names are:
+ *
+ * <ul>
+ *   <li>Field names must not start with a dollar sign ($).
+ *   <li>Field names are hierarchical (forming a Path), but validation is done on name-by-name
+ *       basis.
+ * </ul>
+ */
 public class FieldNamingRule extends NamingRule {
   public FieldNamingRule() {
     super("Field");
@@ -7,14 +20,14 @@ public class FieldNamingRule extends NamingRule {
 
   /**
    * Validates the given Field name. The only limit is that the name must NOT start with a dollar
-   * sign ($). Note that field names are hierarchical, but validation is done on per-segment basis.
+   * sign ($). Note that field names are hierarchical, but validation is done on name-by-name basis.
    *
    * @param depth Level of the field in the hierarchy (1 for root, 2 for first child, etc.)
    * @param name the name to validate
    * @return true if the name is valid, false otherwise
    */
   public boolean apply(int depth, String name) {
-    // Dollar not allowed for any fields (not just root)
+    // Dollar not allowed to start any field name (not just root)
     return !name.startsWith("$");
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/NamingRules.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/NamingRules.java
@@ -2,13 +2,15 @@ package io.stargate.sgv2.jsonapi.service.schema.naming;
 
 /**
  * This class serves as a centralized repository for naming rules that validate the names of
- * different components, such as keyspaces, collections, tables, and indexes.
+ * different components, such as keyspaces, collections, tables, indexes and (document) fields
  */
-public final class NamingRules {
+public abstract class NamingRules {
   private NamingRules() {}
 
   public static final SchemaObjectNamingRule KEYSPACE = new KeyspaceNamingRule();
   public static final SchemaObjectNamingRule COLLECTION = new CollectionNamingRule();
   public static final SchemaObjectNamingRule TABLE = new TableNamingRule();
   public static final SchemaObjectNamingRule INDEX = new IndexNamingRule();
+
+  public static final FieldNamingRule FIELD = new FieldNamingRule();
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -442,7 +442,7 @@ public class DocumentShredder {
         }
 
         validateObjectKey(key, entry.getValue(), depth, parentPathLength);
-        // Path through field consists of segments separated by comma:
+        // Path through field consists of segments separated by periods:
         final int propPathLength = parentPathLength + 1 + key.length();
         validateValue(key, entry.getValue(), depth, propPathLength);
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -451,7 +451,7 @@ public class DocumentShredder {
     private void validateObjectKey(String key, JsonNode value, int depth, int parentPathLength) {
       // NOTE: empty keys are allowed on v1.0.21 and later
 
-      if (!NamingRules.FIELD.apply(depth, key)) {
+      if (!NamingRules.FIELD.apply(key)) {
         // Special names are accepted in some cases:
         if ((depth == 1)
             && (key.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -190,7 +190,7 @@ public class DocumentShredder {
 
   /**
    * Method called to ensure that Document has Document Id (generating id if necessary), and that it
-   * is the very first property in the document (reordering as needed). Note that a new document is
+   * is the very first field in the document (reordering as needed). Note that a new document is
    * created and returned; input document is never modified.
    *
    * @param collectionSettings Collection settings to use for document id generation
@@ -373,7 +373,7 @@ public class DocumentShredder {
   /**
    * Validator applied to the full document, before removing non-indexable properties. Used to
    * ensure that the full document does not violate overall structural limits such as total length
-   * or maximum nesting depth, or invalid property names. Most checks are done at a later point with
+   * or maximum nesting depth, or invalid field names. Most checks are done at a later point with
    * {@link IndexableValueValidator}.
    */
   static class FullDocValidator {
@@ -442,7 +442,7 @@ public class DocumentShredder {
         }
 
         validateObjectKey(key, entry.getValue(), depth, parentPathLength);
-        // Path through property consists of segments separated by comma:
+        // Path through field consists of segments separated by comma:
         final int propPathLength = parentPathLength + 1 + key.length();
         validateValue(key, entry.getValue(), depth, propPathLength);
       }
@@ -517,12 +517,12 @@ public class DocumentShredder {
         if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
           if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
             throw ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-                "number of elements Vector embedding (property '%s') has (%d) exceeds maximum allowed (%d)",
+                "number of elements Vector embedding (field '%s') has (%d) exceeds maximum allowed (%d)",
                 referringPropertyName, arrayValue.size(), limits.maxVectorEmbeddingLength());
           }
         } else {
           throw ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-              "number of elements an indexable Array (property '%s') has (%d) exceeds maximum allowed (%d)",
+              "number of elements an indexable Array (field '%s') has (%d) exceeds maximum allowed (%d)",
               referringPropertyName, arrayValue.size(), limits.maxArrayLength());
         }
       }
@@ -536,7 +536,7 @@ public class DocumentShredder {
       final int propCount = objectValue.size();
       if (propCount > limits.maxObjectProperties()) {
         throw ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "number of properties an indexable Object (property '%s') has (%d) exceeds maximum allowed (%s)",
+            "number of properties an indexable Object (field '%s') has (%d) exceeds maximum allowed (%s)",
             referringPropertyName, objectValue.size(), limits.maxObjectProperties());
       }
       totalProperties.addAndGet(propCount);
@@ -556,7 +556,7 @@ public class DocumentShredder {
           JsonUtil.lengthInBytesIfAbove(value, limits.maxStringLengthInBytes());
       if (encodedLength.isPresent()) {
         throw ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "indexed String value (property '%s') length (%d bytes) exceeds maximum allowed (%d bytes)",
+            "indexed String value (field '%s') length (%d bytes) exceeds maximum allowed (%d bytes)",
             referringPropertyName, encodedLength.getAsInt(), limits.maxStringLengthInBytes());
       }
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -261,7 +261,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractKeyspaceInte
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
-              containsString("number of elements an indexable Array (property 'bigArray')"))
+              containsString("number of elements an indexable Array (field 'bigArray')"))
           .body("errors[0].message", containsString("exceeds maximum allowed"));
     }
 
@@ -332,7 +332,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractKeyspaceInte
             .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
             .body(
                 "errors[0].message",
-                containsString("number of properties an indexable Object (property 'bigObject')"))
+                containsString("number of properties an indexable Object (field 'bigObject')"))
             .body("errors[0].message", containsString("exceeds maximum allowed"));
       }
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -923,7 +923,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               is(
-                  "Document size limitation violated: number of elements an indexable Array (property 'arr') has ("
+                  "Document size limitation violated: number of elements an indexable Array (field 'arr') has ("
                       + ARRAY_LEN
                       + ") exceeds maximum allowed ("
                       + MAX_ARRAY_LENGTH
@@ -976,7 +976,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: property path length (1003) exceeds maximum allowed (1000)"));
+                  "Document size limitation violated: field path length (1003) exceeds maximum allowed (1000)"));
     }
 
     @Test
@@ -1079,7 +1079,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: indexed String value (property 'bigString') length (8056 bytes) exceeds maximum allowed"));
+                  "Document size limitation violated: indexed String value (field 'bigString') length (8056 bytes) exceeds maximum allowed"));
     }
 
     private String createBigString(int minLen) {
@@ -1185,7 +1185,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               endsWith(
-                  "indexable Object (property 'subdoc') has (1001) exceeds maximum allowed (1000)"));
+                  "indexable Object (field 'subdoc') has (1001) exceeds maximum allowed (1000)"));
     }
 
     @Test
@@ -2120,7 +2120,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
     boolean bigEnough = false;
 
-    // Since we add one property before loop, reduce max by 1.
+    // Since we add one field before loop, reduce max by 1.
     // Target is around 1 meg; can have at most 2000 properties, and for
     // big doc we don't want to exceed 1000 bytes per property.
     // So let's make properties arrays of 4 Constants to get there.

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1863,7 +1863,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
                         "insertMany": {
                           "documents": [
                             { "_id": "doc1", "username": "userA"  },
-                            { "_id": "doc2", "username's": "userB" },
+                            { "_id": "doc2", "$username": "userB" },
                             { "_id": "doc3", "username": "userC"
                             }
                           ],
@@ -1886,8 +1886,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("errors[0].errorCode", is("SHRED_DOC_KEY_NAME_VIOLATION"))
           .body(
               "errors[0].message",
-              startsWith(
-                  "Document field name invalid: field name ('username's') contains invalid character(s)"))
+              startsWith("Document field name invalid: field name '$username' starts with '$'"))
           .body("insertedIds", is(nullValue()))
           .body("status.documentResponses", hasSize(3))
           .body("status.documentResponses[0]", is(Map.of("_id", "doc1", "status", "OK")))
@@ -1964,7 +1963,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
                             "insertMany": {
                               "documents": [
                                 { "_id": "doc1", "username": "userA"  },
-                                { "_id": "doc2", "username's": "userB" },
+                                { "_id": "doc2", "$username": "userB" },
                                 { "_id": "doc3", "username": "userC"
                                 }
                               ],
@@ -1987,8 +1986,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("errors[0].errorCode", is("SHRED_DOC_KEY_NAME_VIOLATION"))
           .body(
               "errors[0].message",
-              startsWith(
-                  "Document field name invalid: field name ('username's') contains invalid character(s)"))
+              startsWith("Document field name invalid: field name '$username' starts with '$'"))
           .body("insertedIds", is(nullValue()))
           .body("status.documentResponses", hasSize(3))
           .body("status.documentResponses[0]", is(Map.of("_id", "doc1", "status", "OK")))

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderDocLimitsTest.java
@@ -157,7 +157,7 @@ public class DocumentShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of properties an indexable Object (property 'subdoc') has ("
+              " number of properties an indexable Object (field 'subdoc') has ("
                   + tooManyProps
                   + ") exceeds maximum allowed ("
                   + maxObProps
@@ -235,7 +235,7 @@ public class DocumentShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of elements an indexable Array (property 'arr') has ("
+              " number of elements an indexable Array (field 'arr') has ("
                   + arraySizeAboveMax
                   + ") exceeds maximum allowed ("
                   + docLimits.maxArrayLength()
@@ -325,7 +325,7 @@ public class DocumentShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value (property 'arr') length ("
+              " String value (field 'arr') length ("
                   + tooLongLength
                   + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()
@@ -357,7 +357,7 @@ public class DocumentShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCodeV1.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value (property 'text') length ("
+              " String value (field 'text') length ("
                   + (tooLongCharLength * 3)
                   + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
@@ -360,6 +360,31 @@ public class DocumentShredderTest {
           .hasMessage("Bad value for '_id' property: empty String not allowed")
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_BAD_DOCID_EMPTY_STRING);
     }
+
+    @Test
+    public void docBadFieldNameRootLeadingDollar() {
+      Throwable t =
+          catchThrowable(() -> documentShredder.shred(objectMapper.readTree("{ \"$id\" : 42 }")));
+
+      assertThat(t)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
+          .hasMessage("Document field name invalid: field name '$id' starts with '$'");
+    }
+
+    @Test
+    public void docBadFieldNameNestedLeadingDollar() {
+      Throwable t =
+          catchThrowable(
+              () ->
+                  documentShredder.shred(
+                      objectMapper.readTree("{ \"price\": { \"$usd\" : 42.0 } }")));
+
+      assertThat(t)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
+          .hasMessage("Document field name invalid: field name '$usd' starts with '$'");
+    }
   }
 
   @Nested


### PR DESCRIPTION
**What this PR does**:

Changes validation rules (wrt #1664) to allow most characters in Document Field names -- allows insertion by changing Shredder validation (but no other parts like Filtering, Sorting or Update operations)

Also fixes terminology: instead of "properties", Documents contain "fields".

**Which issue(s) this PR fixes**:
Fixes #1847

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
