### PR TITLE
Fix post #1847: disallow empty Field names (segments)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/naming/FieldNamingRule.java
@@ -8,9 +8,10 @@ package io.stargate.sgv2.jsonapi.service.schema.naming;
  * <p>The rules for field names are:
  *
  * <ul>
+ *   <li>Field names must not be Empty (length > 0)
  *   <li>Field names must not start with a dollar sign ($).
- *   <li>Field names are hierarchical (forming a Path), but validation is done on name-by-name
- *       basis.
+ *   <li>Field names are hierarchical (forming a Path), but validation is done on segment-by-segment
+ *       (individual JSON property name) basis.
  * </ul>
  */
 public class FieldNamingRule extends NamingRule {
@@ -26,7 +27,7 @@ public class FieldNamingRule extends NamingRule {
    * @return true if the name is valid, false otherwise
    */
   public boolean apply(String name) {
-    // Dollar not allowed to start any field name (not just root)
-    return !name.startsWith("$");
+    // Dollar not allowed to start any field name (not just root); empty names are also invalid
+    return !name.isEmpty() && !name.startsWith("$");
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -459,7 +459,7 @@ public class DocumentShredder {
           ;
         } else {
           throw ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION.toApiException(
-              "field name '%s' starts with '$'", key);
+              "field name '%s' %s", key, key.isEmpty() ? "is empty" : "starts with '$'");
         }
       }
       int totalPathLength = parentPathLength + key.length();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderDocLimitsTest.java
@@ -416,16 +416,9 @@ public class DocumentShredderDocLimitsTest {
       assertThat(documentShredder.shred(doc)).isNotNull();
     }
 
-    @Test
-    public void allowEmptyFieldName() {
-      final ObjectNode doc = objectMapper.createObjectNode();
-      doc.put("", 123456);
-      assertThat(documentShredder.shred(doc)).isNotNull();
-    }
-
     // formerly invalid names that now are allowed
     @ParameterizedTest
-    @ValueSource(strings = {"app.kubernetes.io/name", "index[1]", "a/b", "a\\b", "a$b"})
+    @ValueSource(strings = {"app.kubernetes.io/name", "index[1]", "a/b", "a\\b", "a$b", "   "})
     public void allowUnusualFieldNames(String validName) {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
@@ -441,6 +434,8 @@ public class DocumentShredderDocLimitsTest {
           "{\"app\": { \"amount.total\": 30 }}",
           "{\"x\": { \"r&b\": true, \"a\\b\": 12 }}",
           "{\"app.kubernetes.io/name\": { \"type\": \"app\", \"abc$def\": 37 }}",
+          // Blank names ok (just not empty)
+          "{\"root\": { \" \": 12 }}",
         })
     public void allowUnusualNestedFieldNames(String json) throws IOException {
       assertThat(documentShredder.shred(objectMapper.readTree(json))).isNotNull();
@@ -453,7 +448,7 @@ public class DocumentShredderDocLimitsTest {
           "$a.b",
           "$function",
         })
-    public void catchInvalidFieldName(String invalidName) {
+    public void catchInvalidFieldNameDollar(String invalidName) {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       doc.put(invalidName, 123456);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
@@ -385,6 +385,30 @@ public class DocumentShredderTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
           .hasMessage("Document field name invalid: field name '$usd' starts with '$'");
     }
+
+    @Test
+    public void docBadFieldNameEmptyRoot() {
+      Throwable t =
+          catchThrowable(() -> documentShredder.shred(objectMapper.readTree("{ \"\" : 1972 }")));
+
+      assertThat(t)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
+          .hasMessage("Document field name invalid: field name '' is empty");
+    }
+
+    @Test
+    public void docBadFieldNameEmptyNested() {
+      Throwable t =
+          catchThrowable(
+              () ->
+                  documentShredder.shred(objectMapper.readTree("{ \"price\": { \"\" : false } }")));
+
+      assertThat(t)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
+          .hasMessage("Document field name invalid: field name '' is empty");
+    }
   }
 
   @Nested


### PR DESCRIPTION
**What this PR does**:

Adds validation to #1847 based on discussions: empty Field path segments no longer allowed.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
