### PR TITLE
fix double quote problem when we parse indexTarget

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/sort/TableCqlSortClauseResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/sort/TableCqlSortClauseResolver.java
@@ -307,9 +307,9 @@ public class TableCqlSortClauseResolver<CmdT extends Command & Filterable & Sort
               }));
     }
 
-    // HACK - waiting for index support on the APiTableDef
-    var optionalIndexMetadata = findIndexMetadata(commandContext.schemaObject(), vectorSortColumn);
-    if (optionalIndexMetadata.isEmpty()) {
+    // see if Table has vector index on the target sort vector column
+    var optionalVectorIndex = apiTableDef.indexes().firstIndexFor(vectorSortIdentifier);
+    if (optionalVectorIndex.isEmpty()) {
       throw SortException.Code.CANNOT_VECTOR_SORT_NON_INDEXED_VECTOR_COLUMNS.get(
           errVars(
               commandContext.schemaObject(),

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/ListIndexesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/ListIndexesIntegrationTest.java
@@ -3,12 +3,19 @@ package io.stargate.sgv2.jsonapi.api.v1.tables;
 import static io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders.assertNamespaceCommand;
 import static io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders.assertTableCommand;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import io.stargate.sgv2.jsonapi.util.CqlIdentifierUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
@@ -105,10 +112,11 @@ public class ListIndexesIntegrationTest extends AbstractTableIntegrationTestBase
         .postCreateTable(tableData.formatted(TABLE))
         .wasSuccessful();
 
+    // index1, name_idx
     assertTableCommand(keyspaceName, TABLE).postCreateIndex(createIndex).wasSuccessful();
-
+    // index2, city_idx
     assertTableCommand(keyspaceName, TABLE).postCreateIndex(createWithoutOptions).wasSuccessful();
-
+    // index3, content_idx
     assertTableCommand(keyspaceName, TABLE)
         .postCreateVectorIndex(createVectorIndex)
         .wasSuccessful();
@@ -147,6 +155,213 @@ public class ListIndexesIntegrationTest extends AbstractTableIntegrationTestBase
                   jsonEquals(createIndex),
                   jsonEquals(createWithoutOptionsExpected),
                   jsonEquals(createVectorIndex)));
+    }
+  }
+
+  // ==================================================================================================================
+  // This subClass is to test some index corner cases.
+  // 1. Currently, Data API does not support create index on set/list/map column, so we need to
+  // create these indexes in CQL, and then test ListIndexes command
+  // 2. Data API resolves index target from IndexMetaData, detail in {@link CQLSAIINDEX}, test
+  // columns with doubleQuote
+  // ==================================================================================================================
+  @Nested
+  @Order(2)
+  public class CreatedIndexOnPreExistedCqlTable {
+    private static final String PRE_EXISTED_CQL_TABLE = "perExistedCqlTable";
+
+    @Test
+    @Order(1)
+    public final void createPerExistedCqlTable() {
+      // Build the CREATE TABLE statement
+      CreateTable createTable =
+          SchemaBuilder.createTable(
+                  CqlIdentifierUtil.cqlIdentifierFromUserInput(keyspaceName),
+                  CqlIdentifierUtil.cqlIdentifierFromUserInput(PRE_EXISTED_CQL_TABLE))
+              .withPartitionKey("id", DataTypes.TEXT) // Primary key
+              .withColumn(
+                  CqlIdentifierUtil.cqlIdentifierFromUserInput("TextQuoted"),
+                  DataTypes.TEXT) // doubleQuoted column
+              .withColumn("\"setColumn\"", DataTypes.setOf(DataTypes.TEXT, false)) // set column
+              .withColumn("\"listColumn\"", DataTypes.listOf(DataTypes.TEXT, false)) // list column
+              .withColumn(
+                  "\"mapColumn\"",
+                  DataTypes.mapOf(DataTypes.TEXT, DataTypes.INT, false)) // map column
+              .withColumn(
+                  "\"frozenMapColumn\"",
+                  DataTypes.mapOf(DataTypes.TEXT, DataTypes.INT, true)); // frozen map column
+
+      assertThat(executeCqlStatement(createTable.build())).isTrue();
+
+      // Create an index on the doubleQuoted column "TextQuoted"
+      String createTextIndexCql =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS \"idx_textQuoted\" ON \"%s\".\"%s\" (\"TextQuoted\") USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(createTextIndexCql))).isTrue();
+
+      // Create an index on the entire set
+      String createSetIndexCql =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS idx_set ON \"%s\".\"%s\" (\"setColumn\") USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(createSetIndexCql))).isTrue();
+
+      // Create an index on the entire list
+      String createListIndexCql =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS idx_list ON \"%s\".\"%s\" (\"listColumn\") USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(createListIndexCql))).isTrue();
+
+      // Create an index on the keys of the map
+      String createMapKeyIndexCql =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS idx_map_keys ON \"%s\".\"%s\" (KEYS(\"mapColumn\")) USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(createMapKeyIndexCql))).isTrue();
+
+      // Create an index on the values of the map
+      String createMapValueIndexCql =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS idx_map_values ON \"%s\".\"%s\" (VALUES(\"mapColumn\")) USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(createMapValueIndexCql))).isTrue();
+
+      // Create an index on the entries of the map
+      String createMapEntryIndexCql =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS idx_map_entries ON \"%s\".\"%s\" (ENTRIES(\"mapColumn\")) USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(createMapEntryIndexCql))).isTrue();
+
+      // Create a full index on the frozen map
+      String fullIndex =
+          String.format(
+              "CREATE CUSTOM INDEX IF NOT EXISTS idx_full_frozen_map ON \"%s\".\"%s\" (FULL(\"frozenMapColumn\")) USING 'StorageAttachedIndex'",
+              keyspaceName, PRE_EXISTED_CQL_TABLE);
+      assertThat(executeCqlStatement(SimpleStatement.newInstance(fullIndex))).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    public void listIndexesWithDefinition() {
+      // TODO, currently ApiIndexType treats index on map/set/list as unsupported, so the index on
+      // these columns have UNKNOWN column in the definition
+      var expected_idx_set =
+          """
+                {
+                      "name": "idx_set",
+                       "definition": {
+                           "column": {
+                               "setColumn": "$values"
+                           },
+                           "options": {
+                           }
+                       },
+                      "indexType": "regular"
+               }
+              """;
+      var expected_idx_map_values =
+          """
+                {
+                        "name": "idx_map_values",
+                        "definition": {
+                            "column": {
+                                "mapColumn": "$values"
+                            },
+                            "options": {
+                            }
+                        },
+                        "indexType": "regular"
+               }
+              """;
+      var expected_idx_map_keys =
+              """
+                {
+                        "name": "idx_map_keys",
+                        "definition": {
+                            "column": {
+                                "mapColumn": "$keys"
+                            },
+                            "options": {
+                            }
+                        },
+                        "indexType": "regular"
+               }
+              """
+              .formatted(keyspaceName, PRE_EXISTED_CQL_TABLE);
+      var expected_idx_map_entries =
+          """
+                      {
+                            "name": "idx_map_entries",
+                            "definition": {
+                                "column": "mapColumn",
+                                "options": {
+                                   \s
+                                }
+                            },
+                            "indexType": "regular"
+                        }
+              """;
+      var expected_full_index_frozen_map =
+              """
+                  {
+                        "name": "idx_full_frozen_map",
+                        "definition": {
+                            "column": "UNKNOWN",
+                            "apiSupport": {
+                                "createIndex": false,
+                                "filter": false,
+                                "cqlDefinition": "CREATE CUSTOM INDEX idx_full_frozen_map ON \\"%s\\".\\"%s\\" (full(\\"frozenMapColumn\\"))\\nUSING 'StorageAttachedIndex'"
+                            }
+                        },
+                        "indexType": "UNKNOWN"
+                    }
+              """
+              .formatted(keyspaceName, PRE_EXISTED_CQL_TABLE);
+      var expected_idx_list =
+              """
+                 {
+                             "name": "idx_list",
+                             "definition": {
+                                 "column": {
+                                     "listColumn": "$values"
+                                 },
+                                 "options": {
+                                 }
+                             },
+                             "indexType": "regular"
+                         }
+              """
+              .formatted(keyspaceName, PRE_EXISTED_CQL_TABLE);
+      var expected_idx_quoted =
+          """
+                     {
+                         "name": "idx_textQuoted",
+                         "definition": {
+                             "column": "TextQuoted",
+                             "options": {
+                             }
+                         },
+                         "indexType": "regular"
+                     }
+                     """;
+      assertTableCommand(keyspaceName, PRE_EXISTED_CQL_TABLE)
+          .templated()
+          .listIndexes(true)
+          .wasSuccessful()
+          .body("status.indexes", hasSize(7))
+          .body(
+              "status.indexes",
+              containsInAnyOrder( // Validate that the indexes are in any order
+                  jsonEquals(expected_idx_set),
+                  jsonEquals(expected_idx_map_keys),
+                  jsonEquals(expected_idx_map_values),
+                  jsonEquals(expected_idx_map_entries),
+                  jsonEquals(expected_full_index_frozen_map),
+                  jsonEquals(expected_idx_list),
+                  jsonEquals(expected_idx_quoted)));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UnsupportedTypeTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UnsupportedTypeTableIntegrationTest.java
@@ -580,14 +580,11 @@ public class UnsupportedTypeTableIntegrationTest extends AbstractTableIntegratio
                      {
                          "name": "idx_textQuoted",
                          "definition": {
-                             "column": "UNKNOWN",
-                             "apiSupport": {
-                               "createIndex": false,
-                               "filter": false,
-                               "cqlDefinition": "CREATE CUSTOM INDEX \\"idx_textQuoted\\" ON \\"%s\\".%s (\\"TextQuoted\\")\\nUSING 'StorageAttachedIndex'"
+                              "column": "TextQuoted",
+                               "options": {}
                            }
                          },
-                         "indexType": "UNKNOWN"
+                         "indexType": "regular"
                      }
                      """
               .formatted(keyspaceName, TABLE_WITH_UNSUPPORTED_INDEX);


### PR DESCRIPTION
This is a redo for [#1723](https://github.com/stargate/data-api/pull/1772)

What this PR does:
When columnName is doubleQuoted in index target, previous regex can not parse it correctly, which will end up create an unknown ApiIndex.
This will not only cause confusion in listIndexCommand, but also for any command using that index, will complain index not found, because it is parsing as  an unknown unsupported index.

Which issue(s) this PR fixes:
Fixes [#1770]

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
