### PR TITLE
fix index analyze options default for non-text and non-ascii index

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/tables/ApiRegularIndex.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/tables/ApiRegularIndex.java
@@ -159,9 +159,9 @@ public class ApiRegularIndex extends ApiSupportedIndex {
         RegularIndexDefinitionDesc indexDesc) {
       var optionsDesc = indexDesc.options();
 
-      resolveAnalyzerProperty(tableSchemaObject, apiColumnDef, optionsDesc, null);
-      // After the validation, populate the indexOptions map
-      var indexOptions = populateIndexOptions(optionsDesc);
+      // resolve the analyzer options
+      var indexOptions =
+          resolveAnalyzerProperty(tableSchemaObject, apiColumnDef, optionsDesc, null);
 
       // indexFunction is null for primitive dataTypes
       return new ApiRegularIndex(indexIdentifier, targetIdentifier, indexOptions, null);
@@ -219,9 +219,9 @@ public class ApiRegularIndex extends ApiSupportedIndex {
               ? ApiIndexFunction.fromApiMapComponent(apiMapComponent)
               : ApiIndexFunction.VALUES;
 
-      resolveAnalyzerProperty(tableSchemaObject, apiColumnDef, optionsDesc, indexFunction);
-      // After the validation, populate the indexOptions map
-      var indexOptions = populateIndexOptions(optionsDesc);
+      // resolve the analyzer options
+      var indexOptions =
+          resolveAnalyzerProperty(tableSchemaObject, apiColumnDef, optionsDesc, indexFunction);
 
       return new ApiRegularIndex(indexIdentifier, targetIdentifier, indexOptions, indexFunction);
     }
@@ -244,8 +244,9 @@ public class ApiRegularIndex extends ApiSupportedIndex {
      * </ul>
      *
      * The method will error out as UNSUPPORTED_TEXT_ANALYSIS_FOR_DATA_TYPES if rules are violated.
+     * The method will return the indexOptions map if the rules are followed.
      */
-    private void resolveAnalyzerProperty(
+    private Map<String, String> resolveAnalyzerProperty(
         TableSchemaObject tableSchemaObject,
         ApiColumnDef apiColumnDef,
         RegularIndexDefinitionDesc.RegularIndexDescOptions optionsDesc,
@@ -253,7 +254,7 @@ public class ApiRegularIndex extends ApiSupportedIndex {
 
       // Nothing to validate if user does not specify the options.
       if (optionsDesc == null) {
-        return;
+        return new HashMap<>();
       }
 
       ApiTypeName targetTypeName =
@@ -302,6 +303,10 @@ public class ApiRegularIndex extends ApiSupportedIndex {
                     map.put("unsupportedColumns", errFmt(apiColumnDef));
                   }));
         }
+        // If the target column is not text or ascii, and the user has not specified any options.
+        return new HashMap<>();
+      } else {
+        return populateIndexOptions(optionsDesc);
       }
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/tables/ApiRegularIndex.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/tables/ApiRegularIndex.java
@@ -254,6 +254,11 @@ public class ApiRegularIndex extends ApiSupportedIndex {
 
       // Nothing to validate if user does not specify the options.
       if (optionsDesc == null) {
+        // Text and ascii fields will default options, this is to align with the previous behavior.
+        if (apiColumnDef.type().typeName() == ApiTypeName.TEXT
+            || apiColumnDef.type().typeName() == ApiTypeName.ASCII) {
+          return populateIndexOptions(null);
+        }
         return new HashMap<>();
       }
 


### PR DESCRIPTION
There is a regression introduced in v1.0.21, when createIndex on a non-text or non-ascii column and specify no analyze options, there should be no defaults.

- 1.0.20 won’t have default options.
```
 "indexes": [
            {
                "name": "age_index",
                "definition": {
                    "column": "age",
                    "options": {}
                }
            }
        ]
```

- 1.0.21 has {‘ascii’: ‘false’, ‘case_sensitive’: ‘true’, ‘normalize’: ‘false’};
```
 "indexes": [
            {
                "name": "age_index",
                "definition": {
                    "column": "age",
                    "options": {
                        "ascii": false,
                        "caseSensitive": true,
                        "normalize": false
                    }
                },
                "indexType": "regular"
            }
        ]
```
**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
