### PR TITLE
fix NPE when the vectorize model is not supported

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
@@ -150,6 +150,7 @@ public enum ErrorCodeV1 {
   VECTOR_SEARCH_TOO_BIG_VALUE("Vector embedding property '$vector' length too big"),
   VECTOR_SIZE_MISMATCH("Length of vector parameter different from declared '$vector' dimension"),
 
+  VECTORIZE_MODEL_DEPRECATED("Vectorize model is deprecated"),
   VECTORIZE_FEATURE_NOT_AVAILABLE("Vectorize feature is not available in the environment"),
   VECTORIZE_SERVICE_NOT_REGISTERED("Vectorize service name provided is not registered : "),
   VECTORIZE_SERVICE_TYPE_UNAVAILABLE("Vectorize service unavailable : "),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/SchemaException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/SchemaException.java
@@ -53,8 +53,7 @@ public class SchemaException extends RequestException {
     // older below - seperated because they need to be confirmed
     INVALID_CONFIGURATION,
     INVALID_KEYSPACE,
-    INVALID_VECTORIZE_CONFIGURATION,
-    VECTORIZE_MODEL_DEPRECATED;
+    INVALID_VECTORIZE_CONFIGURATION;
 
     private final ErrorTemplate<SchemaException> template;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/SchemaException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/SchemaException.java
@@ -53,7 +53,8 @@ public class SchemaException extends RequestException {
     // older below - seperated because they need to be confirmed
     INVALID_CONFIGURATION,
     INVALID_KEYSPACE,
-    INVALID_VECTORIZE_CONFIGURATION;
+    INVALID_VECTORIZE_CONFIGURATION,
+    VECTORIZE_MODEL_DEPRECATED;
 
     private final ErrorTemplate<SchemaException> template;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProviderConfigStore.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProviderConfigStore.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.configuration;
 
+import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import java.util.Map;
 import java.util.Optional;
 
@@ -35,6 +36,11 @@ public interface EmbeddingProviderConfigStore {
     }
 
     public String getBaseUrl(String modelName) {
+      if (modelUrlOverrides != null && modelUrlOverrides.get(modelName) == null) {
+        throw ErrorCodeV1.VECTORIZE_MODEL_DEPRECATED.toApiException(
+            "Mode %s is deprecated, supported models for provider %s are %s",
+            modelName, serviceName, modelUrlOverrides.keySet());
+      }
       return modelUrlOverrides != null ? modelUrlOverrides.get(modelName).orElse(baseUrl) : baseUrl;
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProviderConfigStore.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProviderConfigStore.java
@@ -38,7 +38,7 @@ public interface EmbeddingProviderConfigStore {
     public String getBaseUrl(String modelName) {
       if (modelUrlOverrides != null && modelUrlOverrides.get(modelName) == null) {
         throw ErrorCodeV1.VECTORIZE_MODEL_DEPRECATED.toApiException(
-            "Mode %s is deprecated, supported models for provider %s are %s",
+            "Model %s is deprecated, supported models for provider '%s' are %s",
             modelName, serviceName, modelUrlOverrides.keySet());
       }
       return modelUrlOverrides != null ? modelUrlOverrides.get(modelName).orElse(baseUrl) : baseUrl;


### PR DESCRIPTION
This is the fix for bug regarding `service-url-override` for nvidia.

If a DB has a collection with old Nvidia model setting in it, that will cause any CollectionCommand failure against this collection.
NPE in this line : 
`return modelUrlOverrides != null ? modelUrlOverrides.get(modelName).orElse(baseUrl) : baseUrl;`
```

"message": "Server failed: root cause: (java.lang.NullPointerException) Cannot invoke \"java.util.Optional.orElse(Object)\" because the return value of \"java.util.Map.get(Object)\" is null",
            "errorCode": "SERVER_UNHANDLED_ERROR",
```

This will cause Astra Portal break down, since they send countCommand for every collection.



**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
