### PR TITLE
Update Exception in DocumentPath `decode` Method

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ProjectionException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ProjectionException.java
@@ -15,8 +15,6 @@ public class ProjectionException extends RequestException {
 
   public enum Code implements ErrorCode<ProjectionException> {
     UNSUPPORTED_COLUMN_TYPES,
-    UNSUPPORTED_AMPERSAND_ESCAPE_USAGE,
-    UNSUPPORTED_PROJECTION_PATH,
     UNKNOWN_TABLE_COLUMNS;
 
     private final ErrorTemplate<ProjectionException> template;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -65,7 +65,13 @@ class ProjectionLayer {
     // Root is always branch (not terminal):
     ProjectionLayer root = new ProjectionLayer("", false);
     for (String fullPath : dotPaths) {
-      DocumentPath path = DocumentPath.from(fullPath);
+      DocumentPath path;
+      try {
+        path = DocumentPath.from(fullPath);
+      } catch (IllegalArgumentException e) {
+        throw ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM.toApiException(
+            "projection path ('%s') is not a valid path. " + e.getMessage(), fullPath);
+      }
       buildPath(failOnOverlap, fullPath, root, path);
     }
     // Slices similar to path but processed differently (and while "exclusions"
@@ -115,7 +121,13 @@ class ProjectionLayer {
 
   static void buildSlicer(boolean failOnOverlap, SliceDef slice, ProjectionLayer layer) {
     final String fullPath = slice.path;
-    DocumentPath path = DocumentPath.from(fullPath);
+    DocumentPath path;
+    try {
+      path = DocumentPath.from(fullPath);
+    } catch (IllegalArgumentException e) {
+      throw ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM.toApiException(
+          "projection path ('%s') is not a valid path. " + e.getMessage(), fullPath);
+    }
     final int last = path.getSegmentsSize() - 1;
     for (int i = 0; i < last; ++i) {
       layer = layer.findOrCreateBranch(failOnOverlap, fullPath, path.getSegment(i));
@@ -184,7 +196,13 @@ class ProjectionLayer {
    * @return {@code true} if path is included; {@code false} if not.
    */
   public boolean isPathIncluded(String path) {
-    DocumentPath p = DocumentPath.from(path);
+    DocumentPath p;
+    try {
+      p = DocumentPath.from(path);
+    } catch (IllegalArgumentException e) {
+      throw ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM.toApiException(
+          "projection path ('%s') is not a valid path. " + e.getMessage(), path);
+    }
     return isPathIncluded(p, 0);
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
@@ -222,7 +222,14 @@ public class PathMatchLocator implements Comparable<PathMatchLocator> {
   }
 
   private static DocumentPath splitAndVerify(String dotPath) throws JsonApiException {
-    return DocumentPath.from(dotPath);
+    DocumentPath path;
+    try {
+      path = DocumentPath.from(dotPath);
+    } catch (IllegalArgumentException e) {
+      throw ErrorCodeV1.UNSUPPORTED_UPDATE_OPERATION_PATH.toApiException(
+          "update path ('%s') is not a valid path. " + e.getMessage(), dotPath);
+    }
+    return path;
   }
 
   private int findIndexFromSegment(String segment) {

--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -625,16 +625,15 @@ request-errors:
       Resend the command using only supported column types.
 
   - scope: PROJECTION
-    code: UNSUPPORTED_AMPERSAND_ESCAPE_USAGE
-    title: The usage of ampersand escape is not supported
+    code: UNKNOWN_TABLE_COLUMNS
+    title: Columns in the projection are not defined in the table schema
     body: |-
-      The usage of ampersand escape is not supported.
+      Only columns defined in the table schema can be included in the projection.
       
-      Ampersand & can only be used as an escape character and must be followed by a & or . character.
+      The table ${keyspace}.${table} defines the columns: ${allColumns}.
+      The projection included the following unknown columns: ${unknownColumns}.
       
-      The command used the unsupported ampersand escape path: '${unsupportedAmpersandEscape}'.
-      
-      Resend the command using supported ampersand escape.
+      ${SNIPPET.RESEND_USING_ONLY_DEFINED_COLUMNS}
 
   # ================================================================================================================
   # Family: REQUEST         Scope: SCHEMA

--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -636,30 +636,6 @@ request-errors:
       
       Resend the command using supported ampersand escape.
 
-  - scope: PROJECTION
-    code: UNSUPPORTED_PROJECTION_PATH
-    title: The path in the projection is not supported
-    body: |-
-      The path in the projection is not supported.
-      
-      The segments from the path in the projection cannot be empty.
-      
-      The command used the unsupported projection path: '${unsupportedProjectionPath}'.
-      
-      Resend the command using supported projection path.
-
-
-  - scope: PROJECTION
-    code: UNKNOWN_TABLE_COLUMNS
-    title: Columns in the projection are not defined in the table schema
-    body: |-
-      Only columns defined in the table schema can be included in the projection.
-      
-      The table ${keyspace}.${table} defines the columns: ${allColumns}.
-      The projection included the following unknown columns: ${unknownColumns}.
-      
-      ${SNIPPET.RESEND_USING_ONLY_DEFINED_COLUMNS}
-
   # ================================================================================================================
   # Family: REQUEST         Scope: SCHEMA
   # ================================================================================================================

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -9,7 +9,6 @@ import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
-import io.stargate.sgv2.jsonapi.exception.ProjectionException;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.*;
 
@@ -2136,11 +2135,10 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("$", responseIsError())
           .body(
               "errors[0].message",
-              containsString("The command used the unsupported ampersand escape path: 'price&'."))
-          .body(
-              "errors[0].errorCode",
-              is(ProjectionException.Code.UNSUPPORTED_AMPERSAND_ESCAPE_USAGE.name()))
-          .body("errors[0].exceptionClass", is("ProjectionException"));
+              containsString(
+                  "Unsupported projection parameter: projection path ('price&') is not a valid path."))
+          .body("errors[0].errorCode", is("UNSUPPORTED_PROJECTION_PARAM"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -2159,11 +2157,9 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body(
               "errors[0].message",
               containsString(
-                  "The command used the unsupported ampersand escape path: 'price&abc'."))
-          .body(
-              "errors[0].errorCode",
-              is(ProjectionException.Code.UNSUPPORTED_AMPERSAND_ESCAPE_USAGE.name()))
-          .body("errors[0].exceptionClass", is("ProjectionException"));
+                  "Unsupported projection parameter: projection path ('price&abc') is not a valid path."))
+          .body("errors[0].errorCode", is("UNSUPPORTED_PROJECTION_PARAM"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -2181,11 +2177,10 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("$", responseIsError())
           .body(
               "errors[0].message",
-              containsString("The segments from the path in the projection cannot be empty."))
-          .body(
-              "errors[0].errorCode",
-              is(ProjectionException.Code.UNSUPPORTED_PROJECTION_PATH.name()))
-          .body("errors[0].exceptionClass", is("ProjectionException"));
+              containsString(
+                  "Unsupported projection parameter: projection path ('foo..bar') is not a valid path."))
+          .body("errors[0].errorCode", is("UNSUPPORTED_PROJECTION_PARAM"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentPathTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentPathTest.java
@@ -3,8 +3,6 @@ package io.stargate.sgv2.jsonapi.service.projection;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.stargate.sgv2.jsonapi.exception.APIException;
-import io.stargate.sgv2.jsonapi.exception.ProjectionException;
 import io.stargate.sgv2.jsonapi.service.schema.collections.DocumentPath;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,11 +52,10 @@ public class DocumentPathTest {
 
   @ParameterizedTest
   @MethodSource("invalidDecodePathToSegmentsTestCases")
-  public <T extends APIException> void encodeSegmentPathTest(
-      String path, String code, Class<T> errorClass, String message, String description) {
+  public <T extends Exception> void encodeSegmentPathTest(
+      String path, Class<T> errorClass, String message, String description) {
     T error = assertThrows(errorClass, () -> DocumentPath.from(path), description);
     assertThat(error).as(description).isInstanceOf(errorClass);
-    assertThat(error.code).isEqualTo(code);
     assertThat(error.getMessage()).contains(message);
   }
 
@@ -66,33 +63,28 @@ public class DocumentPathTest {
     return Stream.of(
         Arguments.of(
             ".path",
-            ProjectionException.Code.UNSUPPORTED_PROJECTION_PATH.name(),
-            ProjectionException.class,
-            "The segments from the path in the projection cannot be empty.",
+            IllegalArgumentException.class,
+            "The path cannot contain an empty segment.",
             "The path starts with `.` which will result in an empty segment, which is not allowed."),
         Arguments.of(
             "foo..bar",
-            ProjectionException.Code.UNSUPPORTED_PROJECTION_PATH.name(),
-            ProjectionException.class,
-            "The segments from the path in the projection cannot be empty.",
+            IllegalArgumentException.class,
+            "The path cannot contain an empty segment.",
             "The path contains two consecutive `.` which will result in an empty segment, which is not allowed."),
         Arguments.of(
             "path.",
-            ProjectionException.Code.UNSUPPORTED_PROJECTION_PATH.name(),
-            ProjectionException.class,
-            "The segments from the path in the projection cannot be empty.",
+            IllegalArgumentException.class,
+            "Path cannot end with a dot. Each segment must be a non-empty segment.",
             "The path ends with `.` which will result in an empty segment, which is not allowed."),
         Arguments.of(
             "path&",
-            ProjectionException.Code.UNSUPPORTED_AMPERSAND_ESCAPE_USAGE.name(),
-            ProjectionException.class,
-            "The usage of ampersand escape is not supported.",
+            IllegalArgumentException.class,
+            "The ampersand character '&' at position 4 must be followed by either '&' or '.'",
             "& is not followed by a valid escape character."),
         Arguments.of(
             "price&usd",
-            ProjectionException.Code.UNSUPPORTED_AMPERSAND_ESCAPE_USAGE.name(),
-            ProjectionException.class,
-            "The usage of ampersand escape is not supported.",
+            IllegalArgumentException.class,
+            "The ampersand character '&' at position 5 must be followed by either '&' or '.'",
             "& is not followed by a valid escape character."));
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -9,7 +9,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import io.stargate.sgv2.jsonapi.exception.ProjectionException;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Nested;
@@ -266,13 +265,11 @@ public class DocumentProjectorTest {
               () ->
                   DocumentProjector.createFromDefinition(objectMapper.readTree(projectionString)));
       assertThat(t)
-          .isInstanceOf(ProjectionException.class)
-          .hasFieldOrPropertyWithValue(
-              "code", ProjectionException.Code.UNSUPPORTED_AMPERSAND_ESCAPE_USAGE.name())
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM)
           .hasMessageContaining(
-              "Ampersand & can only be used as an escape character and must be followed by a & or . character.")
-          .hasMessageContaining(
-              "The command used the unsupported ampersand escape path: 'pricing.price&.usd&'.");
+              ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+                  + ": projection path ('pricing.price&.usd&') is not a valid path.");
     }
 
     @Test
@@ -289,13 +286,11 @@ public class DocumentProjectorTest {
               () ->
                   DocumentProjector.createFromDefinition(objectMapper.readTree(projectionString)));
       assertThat(t)
-          .isInstanceOf(ProjectionException.class)
-          .hasFieldOrPropertyWithValue(
-              "code", ProjectionException.Code.UNSUPPORTED_AMPERSAND_ESCAPE_USAGE.name())
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM)
           .hasMessageContaining(
-              "Ampersand & can only be used as an escape character and must be followed by a & or . character.")
-          .hasMessageContaining(
-              "The command used the unsupported ampersand escape path: 'pricing.price&usd'.");
+              ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+                  + ": projection path ('pricing.price&usd') is not a valid path.");
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
@@ -10,7 +10,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import io.stargate.sgv2.jsonapi.exception.ProjectionException;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
 import jakarta.inject.Inject;
 import java.io.IOException;
@@ -147,11 +146,11 @@ public class PathMatchLocatorTest {
           catchException(() -> PathMatchLocator.forPath("a..x").findIfExists(objectFromJson("{}")));
       assertThat(e)
           .isNotNull()
-          .isInstanceOf(ProjectionException.class)
-          .hasFieldOrPropertyWithValue(
-              "code", ProjectionException.Code.UNSUPPORTED_PROJECTION_PATH.name())
-          .hasMessageContaining("The segments from the path in the projection cannot be empty.")
-          .hasMessageContaining("The command used the unsupported projection path: 'a..x'");
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.UNSUPPORTED_UPDATE_OPERATION_PATH)
+          .hasMessageContaining(
+              ErrorCodeV1.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
+                  + ": update path ('a..x') is not a valid path.");
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
As I mentioned in PR #1890, the `ProjectionException` in the DocumentPath `decode` Method causes some problem:
1. It will become `SERVER_UNHANDLED_ERROR`
2. `ProjectionException` cannot be reused in other context

This PR replaces `ProjectionException` to `IllegalArgumentException` and the caller catches and re-throws the appropriate error. 


**Which issue(s) this PR fixes**:
Fixes NA

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
