### PR TITLE
(WIP) Support insert of "$lexical"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -20,11 +20,17 @@ public interface DocumentConstants {
     /** Physical table column name that stores the vector field. */
     String VECTOR_SEARCH_INDEX_COLUMN_NAME = "query_vector_value";
 
+    /** Physical table column name that stores the lexical content. */
+    String LEXICAL_INDEX_COLUMN_NAME = "query_lexical_value";
+
     /** Document field name to which vector data is stored. */
     String VECTOR_EMBEDDING_FIELD = "$vector";
 
     /** Document field name that will have text value for which vectorize method in called */
     String VECTOR_EMBEDDING_TEXT_FIELD = "$vectorize";
+
+    /** Document field name that will have lexical (BM-25) content for analyzed text for search */
+    String LEXICAL_CONTENT_FIELD = "$lexical";
 
     /** Document field name that will have text value for which vectorize method in called */
     String BINARY_VECTOR_TEXT_FIELD = "$binary";

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionTableMatcher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionTableMatcher.java
@@ -6,6 +6,8 @@ import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.internal.core.type.PrimitiveType;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
+import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +80,7 @@ public class CollectionTableMatcher implements Predicate<TableMetadata> {
                     new PrimitiveType(ProtocolConstants.DataType.VARCHAR)))
             .or(
                 new CqlColumnMatcher.BasicType(
-                    CqlIdentifier.fromInternal("query_lexical_value"),
+                    CqlIdentifier.fromInternal(DocumentConstants.Fields.LEXICAL_INDEX_COLUMN_NAME),
                     new PrimitiveType(ProtocolConstants.DataType.VARCHAR)));
 
     // TODO: do not duplicate all of the code above below here, just add one extra predicate if we
@@ -135,7 +137,7 @@ public class CollectionTableMatcher implements Predicate<TableMetadata> {
                     new PrimitiveType(ProtocolConstants.DataType.VARCHAR)))
             .or(
                 new CqlColumnMatcher.BasicType(
-                    CqlIdentifier.fromInternal("query_lexical_value"),
+                    CqlIdentifier.fromInternal(DocumentConstants.Fields.LEXICAL_INDEX_COLUMN_NAME),
                     new PrimitiveType(ProtocolConstants.DataType.VARCHAR)))
             .or(
                 new CqlColumnMatcher.Vector(


### PR DESCRIPTION
**What this PR does**:
Adds support for inserting (and finding) of "$lexical", for BM-25 search (via "sort")

**Which issue(s) this PR fixes**:
Fixes #1901

**Checklist**
- [] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
