### PR TITLE
Fix #1913 (and add a test) -- ensure "projection" is always JSON Object

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -76,7 +76,8 @@ public class DocumentProjector {
   public static DocumentProjector createFromDefinition(
       JsonNode projectionDefinition, boolean includeSimilarity) {
     // First special case: "simple" default projection
-    if (projectionDefinition == null || projectionDefinition.isEmpty()) {
+    if (projectionDefinition == null
+            || (projectionDefinition.isObject() && projectionDefinition.isEmpty())) {
       if (includeSimilarity) {
         return defaultProjectorWithSimilarity();
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -77,7 +77,7 @@ public class DocumentProjector {
       JsonNode projectionDefinition, boolean includeSimilarity) {
     // First special case: "simple" default projection
     if (projectionDefinition == null
-            || (projectionDefinition.isObject() && projectionDefinition.isEmpty())) {
+        || (projectionDefinition.isObject() && projectionDefinition.isEmpty())) {
       if (includeSimilarity) {
         return defaultProjectorWithSimilarity();
       }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -23,13 +23,32 @@ public class DocumentProjectorTest {
   @Nested
   class ProjectorDefValidation {
     @Test
-    public void verifyProjectionJsonObject() throws Exception {
-      JsonNode def = objectMapper.readTree(" [ 1, 2, 3 ]");
-      Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
+    public void verifyProjectionJsonObjectNotArray() {
+      Throwable t =
+          catchThrowable(
+              () -> DocumentProjector.createFromDefinition(objectMapper.readTree(" [ 1, 2, 3 ]")));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM)
           .hasMessage("Unsupported projection parameter: definition must be OBJECT, was ARRAY");
+    }
+
+    // Also verify that JSON String not allowed: common mistake to try
+    //
+    // {"projection": "*"}
+    //
+    // instead of valid
+    //
+    // {"projection": {"*": 1}}
+    @Test
+    public void verifyProjectionJsonObjectNotString() {
+      Throwable t =
+          catchThrowable(
+              () -> DocumentProjector.createFromDefinition(objectMapper.readTree(" \"*\"")));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.UNSUPPORTED_PROJECTION_PARAM)
+          .hasMessage("Unsupported projection parameter: definition must be OBJECT, was STRING");
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Fixes check that enforces that `projection` is always JSON Object, adds a test.

**Which issue(s) this PR fixes**:
Fixes #1913

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
