### PR TITLE
Update HCD version from 1.0.0 to 1.1.0 (latest) for docker-compose

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -5,6 +5,5 @@ DATAAPITAG=v1
 DATAAPIIMAGE=stargateio/jsonapi
 DSETAG=6.9.7
 DSEIMAGE="cr.dtsx.io/datastax/dse-server"
-HCDTAG=1.0.0
+HCDTAG=1.1.0
 HCDIMAGE="cr.dtsx.io/datastax/hcd"
-


### PR DESCRIPTION
**What this PR does**:

Updates HCD version defaulted to by docker-compose set up

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
