### PR TITLE
Update to latest (?) HCD version

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -5,5 +5,5 @@ DATAAPITAG=v1
 DATAAPIIMAGE=stargateio/jsonapi
 DSETAG=6.9.7
 DSEIMAGE="cr.dtsx.io/datastax/dse-server"
-HCDTAG=1.1.0
+HCDTAG=1.2.0
 HCDIMAGE="cr.dtsx.io/datastax/hcd"

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
       <properties>
         <!-- Note, Cassandra HCD image is not in public repository anymore, Data API need to pull from certain ECR repo -->
         <stargate.int-test.cassandra.image>559669398656.dkr.ecr.us-west-2.amazonaws.com/engops-shared/hcd/prod/hcd</stargate.int-test.cassandra.image>
-        <stargate.int-test.cassandra.image-tag>1.1.0</stargate.int-test.cassandra.image-tag>
+        <stargate.int-test.cassandra.image-tag>1.2.0</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.cluster.name>hcd-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
         <stargate.int-test.use-coordinator>false</stargate.int-test.use-coordinator>
         <stargate.int-test.cluster.hcd>true</stargate.int-test.cluster.hcd>


### PR DESCRIPTION
**What this PR does**:

Updates version of HCD we default to (from 1.1 to 1.2), to get access to BM25 sort

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
