### PR TITLE
Fix #1902: prevent filtering on "$lexical"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilder.java
@@ -544,6 +544,10 @@ public abstract class FilterClauseBuilder<T extends SchemaObject> {
         throw ErrorCodeV1.INVALID_FILTER_EXPRESSION.toApiException(
             "filter clause path cannot be empty String");
       }
+      if (path.equals(DocumentConstants.Fields.LEXICAL_CONTENT_FIELD)) {
+        throw ErrorCodeV1.INVALID_FILTER_EXPRESSION.toApiException(
+            "Cannot filter on lexical content field '%s': only 'sort' clause supported", path);
+      }
       throw ErrorCodeV1.INVALID_FILTER_EXPRESSION.toApiException(
           "filter clause path ('%s') cannot start with `$`", path);
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -831,6 +831,24 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
               containsString(
                   "Bad JSON Extension value: '$objectId' value has to be 24-digit hexadecimal ObjectId, instead got (\"bogus\")"));
     }
+
+    // [data-api#1902] - $lexical not allowed in filter
+    @Test
+    public void failForFilteringOnLexical() {
+      for (String filter :
+          new String[] {
+            "{\"$lexical\": \"quick brown fox\"}", "{\"$lexical\": {\"eq\": \"quick brown fox\"}}"
+          }) {
+        givenHeadersPostJsonThenOk("{ \"findOne\": { \"filter\" : %s}}".formatted(filter))
+            .body("$", responseIsError())
+            .body("errors", hasSize(1))
+            .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+            .body(
+                "errors[0].message",
+                containsString(
+                    "Cannot filter on lexical content field '$lexical': only 'sort' clause supported"));
+      }
+    }
   }
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -267,7 +266,7 @@ public class DocumentShredderTest {
     }
 
     @Test
-    public void shredOverlappingPaths() throws JsonProcessingException {
+    public void shredOverlappingPaths() throws Exception {
       final String inputJson =
           """
               {


### PR DESCRIPTION
**What this PR does**:

Adds checks to prevent filtering on "$lexical" virtual field: for now, can only `sort`, and in future handle with `"$match"`.

**Which issue(s) this PR fixes**:
Fixes #1902

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
