### PR TITLE
Fix #1923: use staging env for ECR access (for HCD image)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,9 @@
       </activation>
       <properties>
         <!-- Note, Cassandra HCD image is not in public repository anymore, Data API need to pull from certain ECR repo -->
-        <stargate.int-test.cassandra.image>559669398656.dkr.ecr.us-west-2.amazonaws.com/engops-shared/hcd/prod/hcd</stargate.int-test.cassandra.image>
+        <!-- 14-Mar-2025, tatu [data-api#1923]: Need to use pre-release image for HCD; hence diff URL -->
+        <!-- 559669398656.dkr.ecr.us-west-2.amazonaws.com/engops-shared/hcd/prod/hcd -->
+        <stargate.int-test.cassandra.image>559669398656.dkr.ecr.us-west-2.amazonaws.com/engops-shared/hcd/staging/hcd</stargate.int-test.cassandra.image>
         <stargate.int-test.cassandra.image-tag>1.1.0</stargate.int-test.cassandra.image-tag>
         <stargate.int-test.cluster.name>hcd-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
         <stargate.int-test.use-coordinator>false</stargate.int-test.use-coordinator>


### PR DESCRIPTION
**What this PR does**:

Changes endpoint used to access HCD image for ITs (and CI) to give access to pre-release versions.

**Which issue(s) this PR fixes**:
Fixes #1923

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
