### PR TITLE
Switch over from "dse-next" to DSE 6.9 for IDE-run ITs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,15 +22,18 @@
     <quarkus.container-image.name>jsonapi</quarkus.container-image.name>
     <quarkus.container-image.tag>v${project.version}</quarkus.container-image.tag>
     <quarkus.container-image.additional-tags>v1</quarkus.container-image.additional-tags>
-    <cassandra.version>4.0.11-591d171ac9c9</cassandra.version>
+    <cassandra.version>6.9.7</cassandra.version>
     <!-- Integration test props -->
     <!-- When updating please change defaults in the DseTestResource class -->
-    <stargate.int-test.cassandra.image>stargateio/dse-next</stargate.int-test.cassandra.image>
-    <!-- from Stargate persistence, latest as of 2024-01-24: -->
+    <!-- 14-Mar-2025, tatu: default to DSE (was "dse-next") -->
+    <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
     <stargate.int-test.cassandra.image-tag>${cassandra.version}</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-dse-next</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>
-    <stargate.int-test.cluster.name>dse-next-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+    <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+    <!-- 14-Mar-2025, tatu: what should this be? Only have "dse-next" and "dse-6.8"
+          persistence backends?
+      -->
     <stargate.int-test.cluster.persistence>persistence-dse-next</stargate.int-test.cluster.persistence>
     <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
     <stargate.int-test.cluster.hcd>false</stargate.int-test.cluster.hcd>

--- a/pom.xml
+++ b/pom.xml
@@ -28,17 +28,12 @@
     <!-- 14-Mar-2025, tatu: default to DSE (was "dse-next") -->
     <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
     <stargate.int-test.cassandra.image-tag>${cassandra.version}</stargate.int-test.cassandra.image-tag>
-    <stargate.int-test.coordinator.image>stargateio/coordinator-dse-next</stargate.int-test.coordinator.image>
-    <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
-    <!-- 14-Mar-2025, tatu: what should this be? Only have "dse-next" and "dse-6.8"
-          persistence backends?
-      -->
-    <stargate.int-test.cluster.persistence>persistence-dse-next</stargate.int-test.cluster.persistence>
     <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
     <stargate.int-test.cluster.hcd>false</stargate.int-test.cluster.hcd>
     <stargate.int-test.cassandra.auth-enabled>true</stargate.int-test.cassandra.auth-enabled>
-    <stargate.int-test.use-coordinator>true</stargate.int-test.use-coordinator>
+    <!-- 14-Mar-2025, tatu: no more use of Stargate Coordinator -->
+    <stargate.int-test.use-coordinator>false</stargate.int-test.use-coordinator>
     <!-- Cassandra driver -->
     <driver.version>4.17.0</driver.version>
     <!-- Compiler -->

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -321,7 +321,7 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
         useCoordinator()
             ? Integer.getInteger(IntegrationTestUtils.STARGATE_CQL_PORT_PROP)
             : Integer.getInteger(IntegrationTestUtils.CASSANDRA_CQL_PORT_PROP);
-    String dc = null;
+    String dc;
     if (StargateTestResource.isDse() || StargateTestResource.isHcd()) {
       dc = "dc1";
     } else {

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -21,24 +21,7 @@ public class DseTestResource extends StargateTestResource {
       System.setProperty("testing.containers.cluster-dse", "true");
     }
 
-    // 14-Mar-2025, tatu: We no longer run Stargate Coordinator for ITs, left this here
-    //   for reference for now.
-    /*
-    if (null == System.getProperty("testing.containers.stargate-image")) {
-      // 07-Dec-2023, tatu: For some reason floating tag "v2.1" does not seem to work so
-      //    use specific version. Needs to be kept up to date:
-      System.setProperty(
-          "testing.containers.stargate-image", "stargateio/coordinator-dse-next:v2.1.0-BETA-23");
-    }
-
-    if (null == System.getProperty("testing.containers.cluster-persistence")) {
-      System.setProperty("testing.containers.cluster-persistence", "persistence-dse-next");
-    }
-
-    if (null == System.getProperty("testing.containers.cluster-dse")) {
-      System.setProperty("testing.containers.cluster-dse", "false");
-    }
-     */
+    // 14-Mar-2025, tatu: We no longer run Stargate Coordinator for ITs set up removed
 
     if (null == System.getProperty("cassandra.sai.max_string_term_size_kb")) {
       System.setProperty(

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -6,20 +6,29 @@ import java.util.Map;
 
 public class DseTestResource extends StargateTestResource {
   // set default props if not set, so we launch DSE
-  // this is only needed for test from the IDE
+  // this is only needed for tests run from the IDE
   public DseTestResource() {
     super();
 
     if (null == System.getProperty("testing.containers.cassandra-image")) {
+      // 14-Mar-2025, tatu: Change from custom "dse-next" to the official DSE image
+      //  even for IDE tests
       System.setProperty(
-          "testing.containers.cassandra-image", "stargateio/dse-next:4.0.11-591d171ac9c9");
+          "testing.containers.cassandra-image",
+          // "stargateio/dse-next:4.0.11-591d171ac9c9"
+          "datastax/dse-server:6.9.7");
+      // MUST set this to get DS_LICENSE env var set
+      System.setProperty("testing.containers.cluster-dse", "true");
     }
 
+    // 14-Mar-2025, tatu: We no longer run Stargate Coordinator for ITs, left this here
+    //   for reference for now.
+    /*
     if (null == System.getProperty("testing.containers.stargate-image")) {
       // 07-Dec-2023, tatu: For some reason floating tag "v2.1" does not seem to work so
       //    use specific version. Needs to be kept up to date:
       System.setProperty(
-          "testing.containers.stargate-image", "stargateio/coordinator-dse-next:v2.1.0-BETA-14");
+          "testing.containers.stargate-image", "stargateio/coordinator-dse-next:v2.1.0-BETA-23");
     }
 
     if (null == System.getProperty("testing.containers.cluster-persistence")) {
@@ -29,6 +38,7 @@ public class DseTestResource extends StargateTestResource {
     if (null == System.getProperty("testing.containers.cluster-dse")) {
       System.setProperty("testing.containers.cluster-dse", "false");
     }
+     */
 
     if (null == System.getProperty("cassandra.sai.max_string_term_size_kb")) {
       System.setProperty(

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
@@ -270,16 +270,12 @@ public abstract class StargateTestResource
   }
 
   public static boolean isDse() {
-    String dse =
-        System.getProperty(
-            "testing.containers.cluster-dse", StargateTestResource.Defaults.CLUSTER_DSE);
+    String dse = System.getProperty("testing.containers.cluster-dse", null);
     return "true".equals(dse);
   }
 
   public static boolean isHcd() {
-    String dse =
-        System.getProperty(
-            "testing.containers.cluster-hcd", StargateTestResource.Defaults.CLUSTER_HCD);
+    String dse = System.getProperty("testing.containers.cluster-hcd", null);
     return "true".equals(dse);
   }
 
@@ -316,8 +312,7 @@ public abstract class StargateTestResource
       HttpResponse<String> response =
           HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
       ObjectMapper objectMapper = new ObjectMapper();
-      AuthResponse authResponse =
-          (AuthResponse) objectMapper.readValue((String) response.body(), AuthResponse.class);
+      AuthResponse authResponse = objectMapper.readValue(response.body(), AuthResponse.class);
       return authResponse.authToken;
     } catch (Exception var9) {
       throw new RuntimeException("Failed to get Cassandra token for integration tests.", var9);
@@ -334,29 +329,5 @@ public abstract class StargateTestResource
 
   public abstract Long getMaxDocumentSortCount();
 
-  interface Defaults {
-    String CASSANDRA_IMAGE = "cassandra";
-    String CASSANDRA_IMAGE_TAG = "4.0.10";
-    String STARGATE_IMAGE = "stargateio/coordinator-4_0";
-    String STARGATE_IMAGE_TAG = "v2.1";
-    String CLUSTER_NAME = "int-test-cluster";
-    String PERSISTENCE_MODULE = "persistence-cassandra-4.0";
-    String CLUSTER_DSE = null;
-
-    String CLUSTER_HCD = null;
-
-    String CQL_HOST = "stargate";
-    long CASSANDRA_STARTUP_TIMEOUT = 2L;
-    long COORDINATOR_STARTUP_TIMEOUT = 3L;
-  }
-
-  static record AuthResponse(String authToken) {
-    AuthResponse(String authToken) {
-      this.authToken = authToken;
-    }
-
-    public String authToken() {
-      return this.authToken;
-    }
-  }
+  record AuthResponse(String authToken) {}
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
@@ -165,7 +165,7 @@ public abstract class StargateTestResource
 
   private GenericContainer<?> baseCassandraContainer(boolean reuse) {
     String image = this.getCassandraImage();
-    GenericContainer<?> container = null;
+    GenericContainer<?> container;
     if (this.isDse()) {
       container =
           new GenericContainer<>(image)


### PR DESCRIPTION
**What this PR does**:

Changes default Cassandra to run for ITs from IDEs to DSE 6.9(.7) from older custom-built "dse-next". Pre-req for more changes to running ITs.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
