### PR TITLE
Fix, insert empty list/set against table 

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/tables/RowShredder.java
@@ -145,7 +145,7 @@ public class RowShredder {
 
   /**
    * For non-string key maps, public API uses tuple format to represent map entries. This method
-   * will detect if the given array looks like tuple map entries, then then shred to object format
+   * will detect if the given array looks like tuple map entries, then shred to object format
    * JsonLiteral.
    *
    * <p>Tuple map entries are represented as an array of arrays where each inner array has two
@@ -162,6 +162,12 @@ public class RowShredder {
    *     then shred to object format JsonLiteral.
    */
   private static Optional<JsonLiteral<?>> tupleToObject(ArrayNode arrayNode) {
+
+    // this is to avoid the case where an empty array is considered as list/set
+    // so to insert an empty map, user should use {} instead of []
+    if (arrayNode.isEmpty()) {
+      return Optional.empty();
+    }
 
     // Tuple map entries are represented as an array of arrays where each inner array has two
     // elements.

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -927,6 +927,28 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
     }
 
     @Test
+    void insertEmptyLists() {
+      String docJSON =
+          """
+                          { "id": "emptyLists",
+                            "stringList": [],
+                            "intList": [],
+                            "doubleList": []
+                          }
+                          """;
+      assertTableCommand(keyspaceName, TABLE_WITH_LIST_COLUMNS)
+          .templated()
+          .insertOne(docJSON)
+          .wasSuccessful()
+          .hasInsertedIds(List.of("emptyLists"));
+
+      assertTableCommand(keyspaceName, TABLE_WITH_LIST_COLUMNS)
+          .postFindOne("{ \"filter\": { \"id\": \"emptyLists\" } }")
+          .wasSuccessful()
+          .hasJSONField("data.document", "{\"id\": \"emptySets\"}");
+    }
+
+    @Test
     void failOnNonArrayListValue() {
       assertTableCommand(keyspaceName, TABLE_WITH_LIST_COLUMNS)
           .templated()
@@ -1059,6 +1081,29 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
                                 "intSet": [-999, 3, 42]
                               }
                               """);
+    }
+
+    @Test
+    void insertEmptySets() {
+      String docJSON =
+          """
+                   {
+                        "id": "emptySets",
+                        "doubleSet": [],
+                        "intSet": [],
+                        "stringSet": []
+                   }
+              """;
+      assertTableCommand(keyspaceName, TABLE_WITH_SET_COLUMNS)
+          .templated()
+          .insertOne(docJSON)
+          .wasSuccessful()
+          .hasInsertedIds(List.of("emptySets"));
+
+      assertTableCommand(keyspaceName, TABLE_WITH_SET_COLUMNS)
+          .postFindOne("{ \"filter\": { \"id\": \"emptySets\" } }")
+          .wasSuccessful()
+          .hasJSONField("data.document", "{\"id\": \"emptySets\"}");
     }
 
     @Test
@@ -1270,6 +1315,61 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
                             ]
                         }
                         """);
+    }
+
+    @Test
+    void insertEmptyMaps() {
+      String docJSON =
+          """
+                        { "id": "emptyMaps",
+                          "textMap": {},
+                          "asciiMap": {},
+                          "inetMap": {},
+                          "dateMap": {},
+                          "timeMap": {},
+                          "timestampMap": {},
+                          "uuidMap": {},
+                          "durationMap": {},
+                          "intMap": {},
+                          "tinyintMap": {},
+                          "varintMap": {},
+                          "floatMap": {},
+                          "bigintMap": {},
+                          "smallintMap": {},
+                          "decimalMap": {},
+                          "doubleMap": {},
+                          "booleanMap": {},
+                          "blobMap": {}
+                        }
+                      """;
+      assertTableCommand(keyspaceName, TABLE_WITH_MAP_COLUMNS)
+          .templated()
+          .insertOne(docJSON)
+          .wasSuccessful()
+          .hasInsertedIds(List.of("emptyMaps"));
+
+      assertTableCommand(keyspaceName, TABLE_WITH_MAP_COLUMNS)
+          .postFindOne("{ \"filter\": { \"id\": \"emptyMaps\" } }")
+          .wasSuccessful()
+          .hasJSONField("data.document", "{\"id\": \"emptyMaps\"}");
+
+      // Note, for inserting empty map, must use {}, can not use []
+      String invalidEmptyMap =
+          """
+                        { "id": "invalidEmptyMap",
+                          "intMap": []
+                        }
+                      """;
+      assertTableCommand(keyspaceName, TABLE_WITH_MAP_COLUMNS)
+          .templated()
+          .insertOne(invalidEmptyMap)
+          .hasSingleApiError(
+              DocumentException.Code.INVALID_COLUMN_VALUES,
+              DocumentException.class,
+              "Only values that are supported by",
+              "Error trying to convert to targetCQLType `Map(INT => INT",
+              "from value.class `java.util.ArrayList`, value []",
+              "no codec matching value type");
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -945,7 +945,7 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
       assertTableCommand(keyspaceName, TABLE_WITH_LIST_COLUMNS)
           .postFindOne("{ \"filter\": { \"id\": \"emptyLists\" } }")
           .wasSuccessful()
-          .hasJSONField("data.document", "{\"id\": \"emptySets\"}");
+          .hasJSONField("data.document", "{\"id\": \"emptyLists\"}");
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/filters/table/codecs/JSONCodecRegistryTest.java
@@ -333,6 +333,7 @@ public class JSONCodecRegistryTest {
     // Arguments: (CQL-type, from-caller-json, bound-by-driver-for-cql)
     return Stream.of(
         // // Lists:
+        Arguments.of(DataTypes.listOf(DataTypes.TEXT), List.of(), List.of()),
         Arguments.of(
             DataTypes.listOf(DataTypes.TEXT),
             Arrays.asList(stringLiteral("a"), stringLiteral("b")),
@@ -350,6 +351,7 @@ public class JSONCodecRegistryTest {
             Arrays.asList(0.25, -7.5)),
 
         // // Sets:
+        Arguments.of(DataTypes.setOf(DataTypes.TEXT), List.of(), Set.of()),
         Arguments.of(
             DataTypes.setOf(DataTypes.TEXT),
             Arrays.asList(stringLiteral("a"), stringLiteral("b")),
@@ -370,6 +372,7 @@ public class JSONCodecRegistryTest {
     // Arguments: (CQL-type, from-caller-json, bound-by-driver-for-cql)
     return Stream.of(
         // // Lists:
+        Arguments.of(DataTypes.listOf(DataTypes.TEXT), List.of(), List.of()),
         Arguments.of(
             DataTypes.listOf(DataTypes.TEXT, true),
             Arrays.asList(stringLiteral("a"), stringLiteral("b")),
@@ -387,6 +390,7 @@ public class JSONCodecRegistryTest {
             Arrays.asList(0.25, -7.5)),
 
         // // Sets:
+        Arguments.of(DataTypes.setOf(DataTypes.TEXT), List.of(), Set.of()),
         Arguments.of(
             DataTypes.setOf(DataTypes.TEXT, true),
             Arrays.asList(stringLiteral("a"), stringLiteral("b")),
@@ -406,6 +410,7 @@ public class JSONCodecRegistryTest {
   private static Stream<Arguments> validCodecToCQLTestCasesMaps() {
     // Arguments: (CQL-type, from-caller-json, bound-by-driver-for-cql)
     return Stream.of(
+        Arguments.of(DataTypes.mapOf(DataTypes.TEXT, DataTypes.TEXT), Map.of(), Map.of()),
         Arguments.of(
             DataTypes.mapOf(DataTypes.TEXT, DataTypes.TEXT),
             Map.of("str1", stringLiteral("a"), "str2", stringLiteral("b")),


### PR DESCRIPTION
**What this PR does**:
When inserting empty lists in tables, provided as [] in the JSON payload to insertions, cause the insertion command to fail.
This is because [] was been recognized as map tuple format incorrectly.

As a quick fix, need a validation for empty arrayNode for rowShredder. 
Since we don't have table context for rowShredder, we basically need to infer from the json payload. Probably need a bigger refactor.


**Which issue(s) this PR fixes**:
Fixes #1906

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
