### PR TITLE
Add `ApiFeature.LEXICAL`, retrofit `createCollection`, tests as base for #1903

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
     <stargate.int-test.cluster.hcd>false</stargate.int-test.cluster.hcd>
     <stargate.int-test.cassandra.auth-enabled>true</stargate.int-test.cassandra.auth-enabled>
+    <stargate.int-test.lexical-disabled/>
     <!-- 14-Mar-2025, tatu: no more use of Stargate Coordinator -->
     <stargate.int-test.use-coordinator>false</stargate.int-test.use-coordinator>
     <!-- Cassandra driver -->
@@ -396,6 +397,7 @@
                 <testing.containers.cluster-dse>${stargate.int-test.cluster.dse}</testing.containers.cluster-dse>
                 <testing.containers.cluster-hcd>${stargate.int-test.cluster.hcd}</testing.containers.cluster-hcd>
                 <testing.package.type>${quarkus.package.type}</testing.package.type>
+                <testing.db.lexical-disabled>${stargate.int-test.lexical-disabled}</testing.db.lexical-disabled>
                 <maven.home>${maven.home}</maven.home>
                 <testing.containers.use-coordinator>${stargate.int-test.use-coordinator}</testing.containers.use-coordinator>
               </systemPropertyVariables>
@@ -423,6 +425,8 @@
         <stargate.int-test.use-coordinator>false</stargate.int-test.use-coordinator>
         <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
         <stargate.int-test.cluster.hcd>false</stargate.int-test.cluster.hcd>
+        <!-- No lexical-sort on DSE: -->
+        <stargate.int-test.lexical-disabled>true</stargate.int-test.lexical-disabled>
       </properties>
     </profile>
     <profile>
@@ -442,6 +446,8 @@
         <stargate.int-test.use-coordinator>false</stargate.int-test.use-coordinator>
         <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
         <stargate.int-test.cluster.hcd>true</stargate.int-test.cluster.hcd>
+        <!-- HCD does have lexical-sort: -->
+        <stargate.int-test.lexical-disabled>false</stargate.int-test.lexical-disabled>
       </properties>
     </profile>
   </profiles>

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -227,9 +227,8 @@ public class CollectionResource {
                       .failure(ErrorCodeV1.TABLE_FEATURE_NOT_ENABLED.toApiException());
                 }
 
-                // TODO: This needs to change, currenty it is only checking if there is vecotrize
-                // for
-                // the $vector column in a collection
+                // TODO: This needs to change, currently it is only checking if there is vectorize
+                // for the $vector column in a collection
 
                 VectorColumnDefinition vectorColDef = null;
                 if (schemaObject.type() == SchemaObject.SchemaObjectType.COLLECTION) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
@@ -17,6 +17,13 @@ import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
  */
 public enum ApiFeature {
   /**
+   * Lexical search/sort feature flag: if enabled, the API will allow construction of
+   * "$lexical"-enabled Collections. If disabled, those operations will fail with {@link
+   * ErrorCodeV1#LEXICAL_NOT_ENABLED_FOR_COLLECTION}).
+   */
+  LEXICAL("lexical"),
+
+  /**
    * API Tables feature flag: if enabled, the API will expose table-specific Namespace resource
    * commands, and support commands on Tables. If disabled, those operations will fail with {@link
    * ErrorCodeV1#TABLE_FEATURE_NOT_ENABLED}.

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
@@ -49,13 +49,20 @@ public enum ApiFeature {
    */
   private final String featureNameAsHeader;
 
-  ApiFeature(String featureName) {
+  /**
+   * State of feature if not otherwise specified: if {@code true}, feature is enabled by default;
+   * otherwise disabled.
+   */
+  private final boolean enabledByDefault;
+
+  ApiFeature(String featureName, boolean enabledByDefault) {
     if (!featureName.equals(featureName.toLowerCase())) {
       throw new IllegalStateException(
           "Internal error: 'featureName' must be lower-case, was: \"" + featureName + "\"");
     }
     this.featureName = featureName;
     featureNameAsHeader = HTTP_HEADER_PREFIX + featureName;
+    this.enabledByDefault = enabledByDefault;
   }
 
   @JsonValue // for Jackson to serialize as lower-case
@@ -65,5 +72,9 @@ public enum ApiFeature {
 
   public String httpHeaderName() {
     return featureNameAsHeader;
+  }
+
+  public boolean enabledByDefault() {
+    return enabledByDefault;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
@@ -19,7 +19,7 @@ public enum ApiFeature {
   /**
    * Lexical search/sort feature flag: if enabled, the API will allow construction of
    * "$lexical"-enabled Collections. If disabled, those operations will fail with {@link
-   * ErrorCodeV1#LEXICAL_NOT_ENABLED_FOR_COLLECTION}).
+   * ErrorCodeV1#LEXICAL_NOT_AVAILABLE_FOR_DATABASE}).
    *
    * <p>Enabled by default.
    */

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
@@ -21,14 +21,14 @@ public enum ApiFeature {
    * "$lexical"-enabled Collections. If disabled, those operations will fail with {@link
    * ErrorCodeV1#LEXICAL_NOT_ENABLED_FOR_COLLECTION}).
    */
-  LEXICAL("lexical"),
+  LEXICAL("lexical", true),
 
   /**
    * API Tables feature flag: if enabled, the API will expose table-specific Namespace resource
    * commands, and support commands on Tables. If disabled, those operations will fail with {@link
    * ErrorCodeV1#TABLE_FEATURE_NOT_ENABLED}.
    */
-  TABLES("tables");
+  TABLES("tables", false);
 
   /**
    * Prefix for HTTP headers used to override feature flags for specific requests: prepended before

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeature.java
@@ -20,6 +20,8 @@ public enum ApiFeature {
    * Lexical search/sort feature flag: if enabled, the API will allow construction of
    * "$lexical"-enabled Collections. If disabled, those operations will fail with {@link
    * ErrorCodeV1#LEXICAL_NOT_ENABLED_FOR_COLLECTION}).
+   *
+   * <p>Enabled by default.
    */
   LEXICAL("lexical", true),
 
@@ -27,6 +29,8 @@ public enum ApiFeature {
    * API Tables feature flag: if enabled, the API will expose table-specific Namespace resource
    * commands, and support commands on Tables. If disabled, those operations will fail with {@link
    * ErrorCodeV1#TABLE_FEATURE_NOT_ENABLED}.
+   *
+   * <p>Disabled by default.
    */
   TABLES("tables", false);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
@@ -47,6 +47,9 @@ public class ApiFeatures {
         b = httpHeaders.getHeaderAsBoolean(flag.httpHeaderName());
       }
     }
-    return (b != null) && b.booleanValue();
+    if (b != null) {
+      return b.booleanValue();
+    }
+    return flag.enabledByDefault();
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
@@ -168,6 +168,7 @@ public enum ErrorCodeV1 {
   VECTORIZE_CREDENTIAL_INVALID("Invalid credential name for vectorize"),
   VECTORIZECONFIG_CHECK_FAIL("Internal server error: VectorizeDefinition check fail"),
 
+  LEXICAL_NOT_AVAILABLE_FOR_DATABASE("Lexical search is not available on this database"),
   LEXICAL_NOT_ENABLED_FOR_COLLECTION("Lexical search is not enabled for the collection"),
 
   UNAUTHENTICATED_REQUEST("UNAUTHENTICATED: Invalid token"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.config.DatabaseLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.TableCommentConstants;
+import io.stargate.sgv2.jsonapi.config.feature.ApiFeature;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
@@ -66,12 +67,16 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
   public Operation resolveKeyspaceCommand(
       CommandContext<KeyspaceSchemaObject> ctx, CreateCollectionCommand command) {
 
+    final boolean lexicalAvailable = ctx.apiFeatures().isFeatureEnabled(ApiFeature.LEXICAL);
+
     final var name = validateSchemaName(command.name(), NamingRules.COLLECTION);
     final CreateCollectionCommand.Options options = command.options();
 
     if (options == null) {
       final CollectionLexicalConfig lexicalConfig =
-          CollectionLexicalConfig.configForEnabledStandard();
+          lexicalAvailable
+              ? CollectionLexicalConfig.configForEnabledStandard()
+              : CollectionLexicalConfig.configForDisabled();
       final CollectionRerankingConfig rerankingConfig =
           CollectionRerankingConfig.configForNewCollections(rerankingProvidersConfig);
       return CreateCollectionOperation.withoutVectorSearch(
@@ -93,7 +98,8 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
     boolean hasVectorSearch = options.vector() != null;
     CreateCollectionCommand.Options.VectorSearchConfig vector = options.vector();
     final CollectionLexicalConfig lexicalConfig =
-        CollectionLexicalConfig.validateAndConstruct(objectMapper, options.lexical());
+        CollectionLexicalConfig.validateAndConstruct(
+            objectMapper, lexicalAvailable, options.lexical());
     final CollectionRerankingConfig rerankingConfig =
         CollectionRerankingConfig.validateAndConstruct(options.rerank(), rerankingProvidersConfig);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
@@ -67,14 +67,14 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
   public Operation resolveKeyspaceCommand(
       CommandContext<KeyspaceSchemaObject> ctx, CreateCollectionCommand command) {
 
-    final boolean lexicalAvailable = ctx.apiFeatures().isFeatureEnabled(ApiFeature.LEXICAL);
+    final boolean lexicalAvailableForDB = ctx.apiFeatures().isFeatureEnabled(ApiFeature.LEXICAL);
 
     final var name = validateSchemaName(command.name(), NamingRules.COLLECTION);
     final CreateCollectionCommand.Options options = command.options();
 
     if (options == null) {
       final CollectionLexicalConfig lexicalConfig =
-          lexicalAvailable
+          lexicalAvailableForDB
               ? CollectionLexicalConfig.configForEnabledStandard()
               : CollectionLexicalConfig.configForDisabled();
       final CollectionRerankingConfig rerankingConfig =
@@ -99,7 +99,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
     CreateCollectionCommand.Options.VectorSearchConfig vector = options.vector();
     final CollectionLexicalConfig lexicalConfig =
         CollectionLexicalConfig.validateAndConstruct(
-            objectMapper, lexicalAvailable, options.lexical());
+            objectMapper, lexicalAvailableForDB, options.lexical());
     final CollectionRerankingConfig rerankingConfig =
         CollectionRerankingConfig.validateAndConstruct(options.rerank(), rerankingProvidersConfig);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
@@ -71,7 +71,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
 
     if (options == null) {
       final CollectionLexicalConfig lexicalConfig =
-          CollectionLexicalConfig.configForNewCollections();
+          CollectionLexicalConfig.configForEnabledStandard();
       final CollectionRerankingConfig rerankingConfig =
           CollectionRerankingConfig.configForNewCollections(rerankingProvidersConfig);
       return CreateCollectionOperation.withoutVectorSearch(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionLexicalConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionLexicalConfig.java
@@ -37,11 +37,11 @@ public record CollectionLexicalConfig(
    */
   public static CollectionLexicalConfig validateAndConstruct(
       ObjectMapper mapper,
-      boolean lexicalAvailable,
+      boolean lexicalAvailableForDB,
       CreateCollectionCommand.Options.LexicalConfigDefinition lexicalConfig) {
     // If not defined, enable if available, otherwise disable
     if (lexicalConfig == null) {
-      return lexicalAvailable ? configForEnabledStandard() : configForDisabled();
+      return lexicalAvailableForDB ? configForEnabledStandard() : configForDisabled();
     }
     // Otherwise validate and construct
     Boolean enabled = lexicalConfig.enabled();
@@ -50,7 +50,7 @@ public record CollectionLexicalConfig(
           "'enabled' is required property for 'lexical' Object value");
     }
     // Can only enable if feature is available
-    if (enabled && !lexicalAvailable) {
+    if (enabled && !lexicalAvailableForDB) {
       throw ErrorCodeV1.LEXICAL_NOT_AVAILABLE_FOR_DATABASE.toApiException();
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionLexicalConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionLexicalConfig.java
@@ -39,7 +39,7 @@ public record CollectionLexicalConfig(
       ObjectMapper mapper, CreateCollectionCommand.Options.LexicalConfigDefinition lexicalConfig) {
     // If not defined, use default for new collections; valid option
     if (lexicalConfig == null) {
-      return configForNewCollections();
+      return configForEnabledStandard();
     }
     // Otherwise validate and construct
     Boolean enabled = lexicalConfig.enabled();
@@ -59,26 +59,18 @@ public record CollectionLexicalConfig(
   }
 
   /**
-   * Accessor for an instance to use for a default configuration for newly created collections:
-   * where no configuration defined: needs to be enabled, using "standard" analyzer configuration.
+   * Accessor for an instance to use for "default enabled" cases, using "standard" analyzer
+   * configuration: typically used for new collections where lexical search is available.
    */
-  public static CollectionLexicalConfig configForNewCollections() {
+  public static CollectionLexicalConfig configForEnabledStandard() {
     return new CollectionLexicalConfig(true, DEFAULT_NAMED_ANALYZER_NODE);
   }
 
   /**
-   * Accessor for an instance to use for existing pre-lexical collections: ones without lexical
-   * field and index: needs to be disabled
+   * Accessor for an instance to use for "lexical disabled" cases: either for existing collections
+   * without lexical config, or envi
    */
-  public static CollectionLexicalConfig configForLegacyCollections() {
-    return new CollectionLexicalConfig(false, null);
-  }
-
-  /**
-   * Accessor for an instance to use for missing collection: cases where definition does not exist:
-   * needs to be disabled.
-   */
-  public static CollectionLexicalConfig configForMissingCollection() {
+  public static CollectionLexicalConfig configForDisabled() {
     return new CollectionLexicalConfig(false, null);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSchemaObject.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSchemaObject.java
@@ -44,7 +44,7 @@ public final class CollectionSchemaObject extends TableBasedSchemaObject {
           IdConfig.defaultIdConfig(),
           VectorConfig.NOT_ENABLED_CONFIG,
           null,
-          CollectionLexicalConfig.configForMissingCollection(),
+          CollectionLexicalConfig.configForDisabled(),
           CollectionRerankingConfig.configForMissingCollection());
 
   private final IdConfig idConfig;
@@ -261,7 +261,7 @@ public final class CollectionSchemaObject extends TableBasedSchemaObject {
 
     if (comment == null || comment.isBlank()) {
       // If no "comment", must assume Legacy (no Lexical) config
-      CollectionLexicalConfig lexicalConfig = CollectionLexicalConfig.configForLegacyCollections();
+      CollectionLexicalConfig lexicalConfig = CollectionLexicalConfig.configForDisabled();
       // If no "comment", must assume Legacy (no Reranking) config
       CollectionRerankingConfig rerankingConfig =
           CollectionRerankingConfig.configForLegacyCollections();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSettingsV0Reader.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSettingsV0Reader.java
@@ -55,7 +55,7 @@ public class CollectionSettingsV0Reader implements CollectionSettingsReader {
         vectorConfig,
         indexingConfig,
         // Legacy config, must assume legacy lexical config (disabled)
-        CollectionLexicalConfig.configForLegacyCollections(),
+        CollectionLexicalConfig.configForDisabled(),
         // Legacy config, must assume legacy reranking config (disabled)
         CollectionRerankingConfig.configForLegacyCollections());
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSettingsV1Reader.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSettingsV1Reader.java
@@ -53,7 +53,7 @@ public class CollectionSettingsV1Reader implements CollectionSettingsReader {
     JsonNode lexicalNode =
         collectionOptionsNode.path(TableCommentConstants.COLLECTION_LEXICAL_CONFIG_KEY);
     if (lexicalNode == null) {
-      lexicalConfig = CollectionLexicalConfig.configForLegacyCollections();
+      lexicalConfig = CollectionLexicalConfig.configForDisabled();
     } else {
       boolean enabled = lexicalNode.path("enabled").asBoolean(false);
       JsonNode analyzerNode = lexicalNode.path("analyzer");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,7 @@ stargate:
 
   feature: # See io.stargate.sgv2.jsonapi.config.feature.FeaturesConfig
     flags:  # Ok to leave out features that have no default value (enabled or disabled)
+      lexical: true
       tables:
 
   # custom grpc settings

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,7 +27,7 @@ stargate:
 
   feature: # See io.stargate.sgv2.jsonapi.config.feature.FeaturesConfig
     flags:  # Ok to leave out features that have no default value (enabled or disabled)
-      lexical: true
+      lexical:
       tables:
 
   # custom grpc settings

--- a/src/test/java/io/stargate/sgv2/jsonapi/TestConstants.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/TestConstants.java
@@ -7,7 +7,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonProcessingMetricsReporter;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
-import io.stargate.sgv2.jsonapi.config.feature.ApiFeatures;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.*;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingProvider;
@@ -42,7 +41,7 @@ public final class TestConstants {
           VectorConfig.NOT_ENABLED_CONFIG,
           null,
           // Use configs that by default enable lexical:
-          CollectionLexicalConfig.configForNewCollections(),
+          CollectionLexicalConfig.configForEnabledStandard(),
           // Use default reranking config - hardcode the value to avoid reading config
           new CollectionRerankingConfig(
               true,
@@ -57,7 +56,7 @@ public final class TestConstants {
           IdConfig.defaultIdConfig(),
           VectorConfig.NOT_ENABLED_CONFIG,
           null,
-          CollectionLexicalConfig.configForLegacyCollections(),
+          CollectionLexicalConfig.configForDisabled(),
           CollectionRerankingConfig.configForLegacyCollections());
 
   public static final CollectionSchemaObject VECTOR_COLLECTION_SCHEMA_OBJECT =
@@ -74,7 +73,7 @@ public final class TestConstants {
                       EmbeddingSourceModel.OTHER,
                       null))),
           null,
-          CollectionLexicalConfig.configForLegacyCollections(),
+          CollectionLexicalConfig.configForDisabled(),
           CollectionRerankingConfig.configForLegacyCollections());
 
   public static final KeyspaceSchemaObject KEYSPACE_SCHEMA_OBJECT =
@@ -85,8 +84,6 @@ public final class TestConstants {
   public static final String TEST_COMMAND_NAME = "testCommand";
 
   // CommandContext for working on the schema objects above
-
-  public static final ApiFeatures DEFAULT_API_FEATURES_FOR_TESTS = ApiFeatures.empty();
 
   public static CommandContext<CollectionSchemaObject> collectionContext() {
     return collectionContext(TEST_COMMAND_NAME, COLLECTION_SCHEMA_OBJECT, null, null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSchemaObjectTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSchemaObjectTest.java
@@ -27,7 +27,7 @@ public class CollectionSchemaObjectTest {
             IdConfig.defaultIdConfig(),
             VectorConfig.NOT_ENABLED_CONFIG,
             indexingConfig,
-            CollectionLexicalConfig.configForLegacyCollections(),
+            CollectionLexicalConfig.configForDisabled(),
             CollectionRerankingConfig.configForLegacyCollections());
     IndexingProjector indexingProj = settings.indexingProjector();
     assertThat(indexingProj)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -334,6 +334,10 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
     return builder.build();
   }
 
+  protected boolean isLexicalAvailable() {
+    return !"true".equals(System.getProperty("testing.db.lexical-disabled"));
+  }
+
   /** Utility method for reducing boilerplate code for sending JSON commands */
   protected ValidatableResponse givenHeadersPostJsonThen(String json) {
     return givenHeadersAndJson(json).when().post(KeyspaceResource.BASE_PATH, keyspaceName).then();

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -334,7 +334,8 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
     return builder.build();
   }
 
-  protected boolean isLexicalAvailable() {
+  /** Helper method for determining if lexical search is available for the database backend */
+  protected boolean isLexicalAvailableForDB() {
     return !"true".equals(System.getProperty("testing.db.lexical-disabled"));
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
@@ -25,7 +25,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
   class CreateLexicalHappyPath {
     @Test
     void createLexicalSimpleEnabledMinimal() {
-      Assumptions.assumeTrue(isLexicalAvailable());
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
 
       final String collectionName = "coll_lexical_minimal" + RandomStringUtils.randomNumeric(16);
       String json = createRequestWithLexical(collectionName, "{\"enabled\": true}");
@@ -38,7 +38,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
 
     @Test
     void createLexicalSimpleEnabledStandard() {
-      Assumptions.assumeTrue(isLexicalAvailable());
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
 
       final String collectionName = "coll_lexical_simple" + RandomStringUtils.randomNumeric(16);
       String json =
@@ -59,7 +59,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
 
     @Test
     void createLexicalSimpleEnabledCustom() {
-      Assumptions.assumeTrue(isLexicalAvailable());
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
 
       final String collectionName = "coll_lexical_cust_" + RandomStringUtils.randomNumeric(16);
       String json =
@@ -126,7 +126,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
                                 }
                           """);
 
-      if (isLexicalAvailable()) {
+      if (isLexicalAvailableForDB()) {
         givenHeadersPostJsonThenOk(json)
             .body("$", responseIsError())
             .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
@@ -154,7 +154,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
                                         }
                                   """);
 
-      if (isLexicalAvailable()) {
+      if (isLexicalAvailableForDB()) {
         givenHeadersPostJsonThenOk(json)
             .body("$", responseIsError())
             .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
@@ -9,6 +9,7 @@ import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
@@ -24,6 +25,8 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
   class CreateLexicalHappyPath {
     @Test
     void createLexicalSimpleEnabledMinimal() {
+      Assumptions.assumeTrue(isLexicalAvailable());
+
       final String collectionName = "coll_lexical_minimal" + RandomStringUtils.randomNumeric(16);
       String json = createRequestWithLexical(collectionName, "{\"enabled\": true}");
 
@@ -35,6 +38,8 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
 
     @Test
     void createLexicalSimpleEnabledStandard() {
+      Assumptions.assumeTrue(isLexicalAvailable());
+
       final String collectionName = "coll_lexical_simple" + RandomStringUtils.randomNumeric(16);
       String json =
           createRequestWithLexical(
@@ -54,6 +59,8 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
 
     @Test
     void createLexicalSimpleEnabledCustom() {
+      Assumptions.assumeTrue(isLexicalAvailable());
+
       final String collectionName = "coll_lexical_cust_" + RandomStringUtils.randomNumeric(16);
       String json =
           createRequestWithLexical(
@@ -77,6 +84,8 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
 
     @Test
     void createLexicalSimpleDisabled() {
+      // Fine regardless of whether Lexical available for DB or not
+
       final String collectionName = "coll_lexical_disabled" + RandomStringUtils.randomNumeric(16);
       String json = createRequestWithLexical(collectionName, "{\"enabled\": false}");
 
@@ -117,13 +126,19 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
                                 }
                           """);
 
-      givenHeadersPostJsonThenOk(json)
-          .body("$", responseIsError())
-          .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
-          // Not ideal: but Cassandra has pretty sub-optimal message for unknown pre-defined
-          // analyzers
-          .body("errors[0].message", containsString("Invalid analyzer config"))
-          .body("errors[0].message", containsString("token 'unknown'"));
+      if (isLexicalAvailable()) {
+        givenHeadersPostJsonThenOk(json)
+            .body("$", responseIsError())
+            .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
+            // Not ideal: but Cassandra has pretty sub-optimal message for unknown pre-defined
+            // analyzers
+            .body("errors[0].message", containsString("Invalid analyzer config"))
+            .body("errors[0].message", containsString("token 'unknown'"));
+      } else {
+        givenHeadersPostJsonThenOk(json)
+            .body("$", responseIsError())
+            .body("errors[0].errorCode", is("LEXICAL_NOT_AVAILABLE_FOR_DATABASE"));
+      }
     }
 
     @Test
@@ -139,15 +154,21 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
                                         }
                                   """);
 
-      givenHeadersPostJsonThenOk(json)
-          .body("$", responseIsError())
-          .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
-          // Not ideal: but Cassandra has pretty sub-optimal message for unknown pre-defined
-          // analyzers
-          .body(
-              "errors[0].message",
-              containsString(
-                  "'analyzer' property of 'lexical' must be either String or JSON Object, is: ARRAY"));
+      if (isLexicalAvailable()) {
+        givenHeadersPostJsonThenOk(json)
+            .body("$", responseIsError())
+            .body("errors[0].errorCode", is("INVALID_CREATE_COLLECTION_OPTIONS"))
+            // Not ideal: but Cassandra has pretty sub-optimal message for unknown pre-defined
+            // analyzers
+            .body(
+                "errors[0].message",
+                containsString(
+                    "'analyzer' property of 'lexical' must be either String or JSON Object, is: ARRAY"));
+      } else {
+        givenHeadersPostJsonThenOk(json)
+            .body("$", responseIsError())
+            .body("errors[0].errorCode", is("LEXICAL_NOT_AVAILABLE_FOR_DATABASE"));
+      }
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithRerankingIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithRerankingIntegrationTest.java
@@ -48,10 +48,7 @@ public class CreateCollectionWithRerankingIntegrationTest
                       {
                                       "name": "%s",
                                       "options": {
-                                          "lexical": {
-                                              "enabled": true,
-                                              "analyzer": "standard"
-                                          },
+                                          "lexical": %s,
                                           "rerank": {
                                               "enabled": true,
                                               "service": {
@@ -62,7 +59,7 @@ public class CreateCollectionWithRerankingIntegrationTest
                                       }
                                   }
                       """
-                      .formatted(collectionName)));
+                      .formatted(collectionName, lexical())));
 
       deleteCollection(collectionName);
     }
@@ -107,10 +104,7 @@ public class CreateCollectionWithRerankingIntegrationTest
                               {
                                               "name": "%s",
                                               "options": {
-                                                  "lexical": {
-                                                      "enabled": true,
-                                                      "analyzer": "standard"
-                                                  },
+                                                  "lexical": %s,
                                                   "rerank": {
                                                       "enabled": true,
                                                       "service": {
@@ -121,7 +115,7 @@ public class CreateCollectionWithRerankingIntegrationTest
                                               }
                                           }
                               """
-                      .formatted(collectionName)));
+                      .formatted(collectionName, lexical())));
 
       deleteCollection(collectionName);
     }
@@ -155,17 +149,14 @@ public class CreateCollectionWithRerankingIntegrationTest
                               {
                                               "name": "%s",
                                               "options": {
-                                                  "lexical": {
-                                                      "enabled": true,
-                                                      "analyzer": "standard"
-                                                  },
+                                                  "lexical": %s,
                                                   "rerank": {
                                                       "enabled": false
                                                   }
                                               }
                                           }
                               """
-                      .formatted(collectionName)));
+                      .formatted(collectionName, lexical())));
 
       deleteCollection(collectionName);
     }
@@ -210,17 +201,14 @@ public class CreateCollectionWithRerankingIntegrationTest
                                 {
                                                 "name": "%s",
                                                 "options": {
-                                                    "lexical": {
-                                                        "enabled": true,
-                                                        "analyzer": "standard"
-                                                    },
+                                                    "lexical": %s,
                                                     "rerank": {
                                                         "enabled": false
                                                     }
                                                 }
                                             }
                                 """
-                      .formatted(collectionName)));
+                      .formatted(collectionName, lexical())));
 
       deleteCollection(collectionName);
     }
@@ -303,5 +291,22 @@ public class CreateCollectionWithRerankingIntegrationTest
                           }
                           """
         .formatted(collectionName, rerankingDef);
+  }
+
+  private String lexical() {
+    return isLexicalAvailable()
+        ?
+        """
+            {
+                "enabled": true,
+                "analyzer": "standard"
+            }
+            """
+        :
+        """
+            {
+                "enabled": false
+            }
+            """;
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithRerankingIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithRerankingIntegrationTest.java
@@ -294,7 +294,7 @@ public class CreateCollectionWithRerankingIntegrationTest
   }
 
   private String lexical() {
-    return isLexicalAvailable()
+    return isLexicalAvailableForDB()
         ?
         """
             {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
@@ -16,6 +16,7 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -106,6 +107,9 @@ class FindCollectionsIntegrationTest extends AbstractKeyspaceIntegrationTestBase
     @Test
     @Order(3)
     public void happyPathWithExplain() {
+      // To create Collection with Lexical, it must be available for the database
+      Assumptions.assumeTrue(isLexicalAvailable());
+
       String json =
           """
               {
@@ -358,6 +362,9 @@ class FindCollectionsIntegrationTest extends AbstractKeyspaceIntegrationTestBase
     @Test
     @Order(7)
     public void happyPathIndexingWithExplain() {
+      // To create Collection with Lexical, it must be available for the database
+      Assumptions.assumeTrue(isLexicalAvailable());
+
       String json =
           """
                   {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
@@ -108,7 +108,7 @@ class FindCollectionsIntegrationTest extends AbstractKeyspaceIntegrationTestBase
     @Order(3)
     public void happyPathWithExplain() {
       // To create Collection with Lexical, it must be available for the database
-      Assumptions.assumeTrue(isLexicalAvailable());
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
 
       String json =
           """
@@ -363,7 +363,7 @@ class FindCollectionsIntegrationTest extends AbstractKeyspaceIntegrationTestBase
     @Order(7)
     public void happyPathIndexingWithExplain() {
       // To create Collection with Lexical, it must be available for the database
-      Assumptions.assumeTrue(isLexicalAvailable());
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
 
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertInCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertInCollectionIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -1021,6 +1022,9 @@ public class InsertInCollectionIntegrationTest extends AbstractCollectionIntegra
     @Test
     @Order(1)
     public void insertDocWithLexicalOk() {
+      // Must have Lexical functionality available
+      Assumptions.assumeTrue(isLexicalAvailable());
+
       givenHeadersPostJsonThenOkNoErrors(
                   """
                   {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertInCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertInCollectionIntegrationTest.java
@@ -1023,7 +1023,7 @@ public class InsertInCollectionIntegrationTest extends AbstractCollectionIntegra
     @Order(1)
     public void insertDocWithLexicalOk() {
       // Must have Lexical functionality available
-      Assumptions.assumeTrue(isLexicalAvailable());
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
 
       givenHeadersPostJsonThenOkNoErrors(
                   """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
@@ -245,7 +245,7 @@ public class DataVectorizerTest {
                           EmbeddingSourceModel.OTHER,
                           new VectorizeDefinition("custom", "custom", null, null)))),
               null,
-              CollectionLexicalConfig.configForLegacyCollections(),
+              CollectionLexicalConfig.configForDisabled(),
               CollectionRerankingConfig.configForLegacyCollections());
       List<JsonNode> documents = new ArrayList<>();
       for (int i = 0; i < 2; i++) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/TestEmbeddingProvider.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/TestEmbeddingProvider.java
@@ -35,7 +35,7 @@ public class TestEmbeddingProvider extends EmbeddingProvider {
                           EmbeddingSourceModel.OTHER,
                           new VectorizeDefinition("custom", "custom", null, null)))),
               null,
-              CollectionLexicalConfig.configForLegacyCollections(),
+              CollectionLexicalConfig.configForDisabled(),
               CollectionRerankingConfig.configForLegacyCollections()),
           null,
           new TestEmbeddingProvider());

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperationTest.java
@@ -74,7 +74,7 @@ public class CreateCollectionOperationTest extends OperationTestBase {
         buildColumnDefs(OperationTestBase.TestColumn.ofBoolean("[applied]"));
 
     private final CollectionLexicalConfig LEXICAL_CONFIG =
-        CollectionLexicalConfig.configForNewCollections();
+        CollectionLexicalConfig.configForEnabledStandard();
 
     private CollectionRerankingConfig RERANKING_CONFIG;
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/FindCollectionOperationTest.java
@@ -97,7 +97,7 @@ public class FindCollectionOperationTest extends OperationTestBase {
                             EmbeddingSourceModel.OTHER,
                             null))),
                 null,
-                CollectionLexicalConfig.configForLegacyCollections(),
+                CollectionLexicalConfig.configForDisabled(),
                 CollectionRerankingConfig.configForLegacyCollections()),
             jsonProcessingMetricsReporter,
             null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/InsertCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/InsertCollectionOperationTest.java
@@ -116,7 +116,7 @@ public class InsertCollectionOperationTest extends OperationTestBase {
                             EmbeddingSourceModel.OTHER,
                             null))),
                 null,
-                CollectionLexicalConfig.configForLegacyCollections(),
+                CollectionLexicalConfig.configForDisabled(),
                 CollectionRerankingConfig.configForLegacyCollections()),
             jsonProcessingMetricsReporter,
             null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/OperationTestBase.java
@@ -55,7 +55,7 @@ public class OperationTestBase {
           IdConfig.defaultIdConfig(),
           VectorConfig.NOT_ENABLED_CONFIG,
           null,
-          CollectionLexicalConfig.configForLegacyCollections(),
+          CollectionLexicalConfig.configForDisabled(),
           CollectionRerankingConfig.configForLegacyCollections());
 
   protected final KeyspaceSchemaObject KEYSPACE_SCHEMA_OBJECT =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperationTest.java
@@ -133,7 +133,7 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
                             EmbeddingSourceModel.OTHER,
                             null))),
                 null,
-                CollectionLexicalConfig.configForLegacyCollections(),
+                CollectionLexicalConfig.configForDisabled(),
                 CollectionRerankingConfig.configForLegacyCollections()),
             jsonProcessingMetricsReporter,
             null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
@@ -99,7 +99,7 @@ public class CommandResolverWithVectorizerTest {
                             EmbeddingSourceModel.OTHER,
                             null))),
                 null,
-                CollectionLexicalConfig.configForLegacyCollections(),
+                CollectionLexicalConfig.configForDisabled(),
                 CollectionRerankingConfig.configForLegacyCollections()),
             null,
             null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -67,7 +67,7 @@ public class DseTestResource extends StargateTestResource {
 
   // By default, allow Lexical on HCD backend, but not on DSE
   public String getFeatureFlagLexical() {
-    return this.isHcd() ? "true" : "false";
+    return isHcd() ? "true" : "false";
   }
 
   // By default, we enable the feature flag for tables

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -65,6 +65,11 @@ public class DseTestResource extends StargateTestResource {
     return 100L;
   }
 
+  // By default, allow Lexical on HCD backend, but not on DSE
+  public String getFeatureFlagLexical() {
+    return this.isHcd() ? "true" : "false";
+  }
+
   // By default, we enable the feature flag for tables
   public String getFeatureFlagTables() {
     return "true";
@@ -76,6 +81,12 @@ public class DseTestResource extends StargateTestResource {
     ImmutableMap.Builder<String, String> propsBuilder = ImmutableMap.builder();
     propsBuilder.putAll(env);
     propsBuilder.put("stargate.jsonapi.custom.embedding.enabled", "true");
+
+    // 17-Mar-2025, tatu: [data-api#1903] Lexical search/sort feature flag
+    String lexicalFeatureSetting = getFeatureFlagLexical();
+    if (lexicalFeatureSetting != null) {
+      propsBuilder.put("stargate.feature.flags.lexical", lexicalFeatureSetting);
+    }
 
     // 04-Sep-2024, tatu: [data-api#1335] Enable Tables using new Feature Flag:
     String tableFeatureSetting = getFeatureFlagTables();


### PR DESCRIPTION
**What this PR does**:

Adds new "feature flag" for Lexical sort (is lexical available for DB): based on which:

* Default to add/dont-add $lexical if no definition given, based on availability
* Fail attempts to create if not available
* Add specific overrides/checks for ITs to align (DSE -> not available, HCD -> available)

**Which issue(s) this PR fixes**:
Pre-req for, but won't fix #1903

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
