### PR TITLE
Fix #1939: support sort on $lexical for "findOneAndXxx", "deleteOne", "updateOne"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/DeleteOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/DeleteOneCommandResolver.java
@@ -10,7 +10,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
-import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.exception.SortException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.TableSchemaObject;
 import io.stargate.sgv2.jsonapi.service.operation.*;
@@ -136,18 +135,13 @@ public class DeleteOneCommandResolver implements CommandResolver<DeleteOneComman
     // BM25 search / sort?
     SortExpression bm25Expr = SortClauseUtil.resolveBM25Search(sortClause);
     if (bm25Expr != null) {
-      throw ErrorCodeV1.INVALID_SORT_CLAUSE.toApiException(
-          "BM25 search is not yet supported for this command");
-      // Likely implementation of [data-api#1939] to support BM25 sort
-      /*
       return FindCollectionOperation.bm25Single(
-              commandContext,
-              dbLogicalExpression,
-              DocumentProjector.includeAllProjector(),
-              CollectionReadType.KEY,
-              objectMapper,
-              bm25Expr);
-       */
+          commandContext,
+          dbLogicalExpression,
+          DocumentProjector.includeAllProjector(),
+          CollectionReadType.KEY,
+          objectMapper,
+          bm25Expr);
     }
 
     List<FindCollectionOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindOneAndDeleteCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindOneAndDeleteCommandResolver.java
@@ -8,7 +8,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
-import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.service.operation.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.collections.CollectionReadType;
 import io.stargate.sgv2.jsonapi.service.operation.collections.DeleteCollectionOperation;
@@ -99,18 +98,13 @@ public class FindOneAndDeleteCommandResolver implements CommandResolver<FindOneA
     // BM25 search / sort?
     SortExpression bm25Expr = SortClauseUtil.resolveBM25Search(sortClause);
     if (bm25Expr != null) {
-      throw ErrorCodeV1.INVALID_SORT_CLAUSE.toApiException(
-          "BM25 search is not yet supported for this command");
-      // Likely implementation of [data-api#1939] to support BM25 sort
-      /*
       return FindCollectionOperation.bm25Single(
-              commandContext,
-              dbLogicalExpression,
-              DocumentProjector.includeAllProjector(),
-              CollectionReadType.DOCUMENT,
-              objectMapper,
-              bm25Expr);
-      */
+          commandContext,
+          dbLogicalExpression,
+          DocumentProjector.includeAllProjector(),
+          CollectionReadType.DOCUMENT,
+          objectMapper,
+          bm25Expr);
     }
 
     List<FindCollectionOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindOneAndReplaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindOneAndReplaceCommandResolver.java
@@ -131,18 +131,13 @@ public class FindOneAndReplaceCommandResolver implements CommandResolver<FindOne
     // BM25 search / sort?
     SortExpression bm25Expr = SortClauseUtil.resolveBM25Search(sortClause);
     if (bm25Expr != null) {
-      throw ErrorCodeV1.INVALID_SORT_CLAUSE.toApiException(
-          "BM25 search is not yet supported for this command");
-      // Likely implementation of [data-api#1939] to support BM25 sort
-      /*
       return FindCollectionOperation.bm25Single(
-              commandContext,
-              dbLogicalExpression,
-              DocumentProjector.includeAllProjector(),
-              CollectionReadType.DOCUMENT,
-              objectMapper,
-              bm25Expr);
-       */
+          commandContext,
+          dbLogicalExpression,
+          DocumentProjector.includeAllProjector(),
+          CollectionReadType.DOCUMENT,
+          objectMapper,
+          bm25Expr);
     }
 
     List<FindCollectionOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindOneAndUpdateCommandResolver.java
@@ -8,7 +8,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
-import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizerService;
 import io.stargate.sgv2.jsonapi.service.operation.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.collections.CollectionReadType;
@@ -126,18 +125,13 @@ public class FindOneAndUpdateCommandResolver implements CommandResolver<FindOneA
     // BM25 search / sort?
     SortExpression bm25Expr = SortClauseUtil.resolveBM25Search(sortClause);
     if (bm25Expr != null) {
-      throw ErrorCodeV1.INVALID_SORT_CLAUSE.toApiException(
-          "BM25 search is not yet supported for this command");
-      // Likely implementation of [data-api#1939] to support BM25 sort
-      /*
       return FindCollectionOperation.bm25Single(
-              commandContext,
-              dbLogicalExpression,
-              DocumentProjector.includeAllProjector(),
-              CollectionReadType.DOCUMENT,
-              objectMapper,
-              bm25Expr);
-       */
+          commandContext,
+          dbLogicalExpression,
+          DocumentProjector.includeAllProjector(),
+          CollectionReadType.DOCUMENT,
+          objectMapper,
+          bm25Expr);
     }
     List<FindCollectionOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
     // If orderBy present

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/UpdateOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/UpdateOneCommandResolver.java
@@ -10,7 +10,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.UpdateOneCommand;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
-import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.exception.SortException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.TableSchemaObject;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizerService;
@@ -171,18 +170,13 @@ public class UpdateOneCommandResolver implements CommandResolver<UpdateOneComman
     // BM25 search / sort?
     SortExpression bm25Expr = SortClauseUtil.resolveBM25Search(sortClause);
     if (bm25Expr != null) {
-      throw ErrorCodeV1.INVALID_SORT_CLAUSE.toApiException(
-          "BM25 search is not yet supported for this command");
-      // Likely implementation of [data-api#1939] to support BM25 sort
-      /*
       return FindCollectionOperation.bm25Single(
-              commandContext,
-              dbLogicalExpression,
-              DocumentProjector.includeAllProjector(),
-              CollectionReadType.DOCUMENT,
-              objectMapper,
-              bm25Expr);
-       */
+          commandContext,
+          dbLogicalExpression,
+          DocumentProjector.includeAllProjector(),
+          CollectionReadType.DOCUMENT,
+          objectMapper,
+          bm25Expr);
     }
 
     List<FindCollectionOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -123,7 +123,7 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
                   """
                 .formatted(collectionToCreate))
         .when()
-        .post(KeyspaceResource.BASE_PATH, keyspaceName)
+        .post(KeyspaceResource.BASE_PATH, keyspace)
         .then()
         .statusCode(200)
         .body("$", responseIsDDLSuccess());

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
@@ -21,9 +21,13 @@ import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
- * Tests for the Lexical sort feature in the JSON API, for:
+ * Tests for the Lexical sort feature in the JSON API, with the following commands:
  *
- * <p>- "find" and "findOne" commands
+ * <ul>
+ *   <li>"find" and "findOne"
+ *   <li>"findOneAndUpdate", "findOneAndReplace", "findOneAndDelete"
+ *   <li>"updateOne" and "deleteOne"
+ * </ul>
  */
 @QuarkusIntegrationTest
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
@@ -255,7 +255,39 @@ public class FindCollectionWithLexicalSortIntegrationTest
   @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
   @Nested
   @Order(11)
-  class HappyCasesUpdateOne {}
+  class HappyCasesUpdateOne {
+    @Test
+    void updateOne() {
+      final String expectedAfterChange = lexicalDoc(1, "monkey banana", "value1-updated-2");
+      givenHeadersPostJsonThenOkNoErrors(
+              keyspaceName,
+              COLLECTION_WITH_LEXICAL,
+              """
+           {
+             "updateOne": {
+               "sort": { "$lexical": "banana" },
+               "update" : {"$set" : {"value": "value1-updated-2"}}
+             }
+           }
+           """)
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1));
+      // Plus query to check that the document was updated
+      givenHeadersPostJsonThenOkNoErrors(
+              keyspaceName,
+              COLLECTION_WITH_LEXICAL,
+              """
+          {
+            "findOne": {
+              "filter" : {"_id" : "lexical-1"},
+              "projection": {"*": 1 }
+            }
+          }
+          """)
+          .body("$", responseIsFindSuccess())
+          .body("data.document", jsonEquals(expectedAfterChange));
+    }
+  }
 
   @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
@@ -212,6 +212,66 @@ public class FindCollectionWithLexicalSortIntegrationTest
     }
   }
 
+  @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
+  @Nested
+  @Order(10)
+  class HappyCasesFindOneAndUpdate {
+    @Test
+    void findOneAndUpdate() {
+      final String expectedAfterChange = lexicalDoc(1, "monkey banana", "value1-updated");
+      givenHeadersPostJsonThenOkNoErrors(
+              keyspaceName,
+              COLLECTION_WITH_LEXICAL,
+              """
+           {
+             "findOneAndUpdate": {
+               "sort": { "$lexical": "banana" },
+               "update" : {"$set" : {"value": "value1-updated"}},
+               "projection": {"$lexical": 1 },
+               "options": {"returnDocument": "after"}
+             }
+           }
+           """)
+          .body("data.document", jsonEquals(expectedAfterChange))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1));
+      // Plus query to check that the document was updated
+      givenHeadersPostJsonThenOkNoErrors(
+              keyspaceName,
+              COLLECTION_WITH_LEXICAL,
+              """
+          {
+            "findOne": {
+              "filter" : {"_id" : "lexical-1"},
+              "projection": {"*": 1 }
+            }
+          }
+          """)
+          .body("$", responseIsFindSuccess())
+          .body("data.document", jsonEquals(expectedAfterChange));
+    }
+  }
+
+  @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
+  @Nested
+  @Order(11)
+  class HappyCasesUpdateOne {}
+
+  @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
+  @Nested
+  @Order(12)
+  class HappyCasesFindOneAndReplace {}
+
+  @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
+  @Nested
+  @Order(13)
+  class HappyCasesFindOneAndDelete {}
+
+  @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
+  @Nested
+  @Order(14)
+  class HappyCasesDeleteOne {}
+
   static String lexicalDoc(int id, String keywords, String value) {
     return
         """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionWithLexicalSortIntegrationTest.java
@@ -17,6 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+/**
+ * Tests for the Lexical sort feature in the JSON API, for:
+ *
+ * <p>- "find" and "findOne" commands
+ */
 @QuarkusIntegrationTest
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
@@ -28,11 +33,11 @@ public class FindCollectionWithLexicalSortIntegrationTest
   static final String COLLECTION_WITHOUT_LEXICAL =
       "coll_no_lexical_sort_" + RandomStringUtils.randomNumeric(16);
 
-  static final String DOC1_JSON = lexicalDoc(1, "monkey banana");
-  static final String DOC2_JSON = lexicalDoc(2, "monkey");
-  static final String DOC3_JSON = lexicalDoc(3, "biking fun");
-  static final String DOC4_JSON = lexicalDoc(4, "banana");
-  static final String DOC5_JSON = lexicalDoc(5, "fun");
+  static final String DOC1_JSON = lexicalDoc(1, "monkey banana", "value1");
+  static final String DOC2_JSON = lexicalDoc(2, "monkey", "value2");
+  static final String DOC3_JSON = lexicalDoc(3, "biking fun", "value3");
+  static final String DOC4_JSON = lexicalDoc(4, "banana bread with butter", "value4");
+  static final String DOC5_JSON = lexicalDoc(5, "fun", "value5");
 
   @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
   @Nested
@@ -98,8 +103,8 @@ public class FindCollectionWithLexicalSortIntegrationTest
                           """)
           .body("$", responseIsFindSuccess())
           .body("data.documents", hasSize(2))
-          .body("data.documents[0]._id", is("lexical-4"))
-          .body("data.documents[1]._id", is("lexical-1"));
+          .body("data.documents[0]._id", is("lexical-1"))
+          .body("data.documents[1]._id", is("lexical-4"));
     }
   }
 
@@ -147,7 +152,7 @@ public class FindCollectionWithLexicalSortIntegrationTest
   @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
   @Nested
   @Order(3)
-  class FailingCases {
+  class FailingCasesFindMany {
     @Test
     void failIfLexicalDisabledForCollection() {
       givenHeadersPostJsonThenOk(
@@ -207,14 +212,15 @@ public class FindCollectionWithLexicalSortIntegrationTest
     }
   }
 
-  static String lexicalDoc(int id, String keywords) {
+  static String lexicalDoc(int id, String keywords, String value) {
     return
         """
             {
               "_id": "lexical-%d",
-              "$lexical": "%s"
+              "$lexical": "%s",
+              "value": "%s"
             }
         """
-        .formatted(id, keywords);
+        .formatted(id, keywords, value);
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds support for sorting on `$lexical` for remaining 5 specialized "find-and-xxx" commands (see #1939).

**Which issue(s) this PR fixes**:
Fixes #1939

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
