### PR TITLE
Fix MC-1577: dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,8 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <!-- 27-Mar-2025, tatu: Latest available Quarkus version today
-      -->
-    <quarkus.platform.version>3.21.0</quarkus.platform.version>
+    <!-- 27-Mar-2025, tatu: Updated to later but not Latest available Quarkus -->
+    <quarkus.platform.version>3.15.4</quarkus.platform.version>
     <!-- miscellaneous -->
     <wiremock.version>3.4.2</wiremock.version>
     <mockito.version>5.12.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <!-- Testing -->
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
-    <surefire-plugin.version>3.3.0</surefire-plugin.version>
+    <surefire-plugin.version>3.5.2</surefire-plugin.version>
     <skipITs>false</skipITs>
   </properties>
   <dependencyManagement>
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.26.12</version>
+        <version>2.26.31</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,13 @@
     <stargate.version>2.1.0-BETA-23</stargate.version>
     <!-- 16-Aug-2024, tatu: Quarkus depends on 2.17 already, but keep explicit -->
     <!-- 23-Oct-2024, tatu: For latest FP optimizations let's get 2.18 -->
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.18.3</jackson.version>
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.13.3</quarkus.platform.version>
+    <!-- 27-Mar-2025, tatu: Latest available Quarkus version today
+      -->
+    <quarkus.platform.version>3.21.0</quarkus.platform.version>
     <!-- miscellaneous -->
     <wiremock.version>3.4.2</wiremock.version>
     <mockito.version>5.12.0</mockito.version>


### PR DESCRIPTION
**What this PR does**:

Updates Quarkus dependency to address downstream security scan alerts.

* `CVE-2025-1247`: resolved by upgrade to Quarkus 3.15.4
* `CVE-2024-7254` (https://www.cve.org/CVERecord?id=CVE-2024-7254): indirectly by quarkus update, `protobuf-java` to 3.25.5
* `CVE-2025-24970` (https://www.cve.org/CVERecord?id=CVE-2025-24970) indirectly by quarkus update, `netty-handler` to `4.1.118`

## Details

Quarkus dependency up to 3.15.4 which resolves "CVE-2025-1247" (see f.ex https://quarkus.io/blog/cve-fixes-feb-2025/ ) -- 3.15.x being LTS version, and one with which Data API compiles without other changes.

LibXML dependency should be addressed by Docker image rebuild, base of `registry.access.redhat.com/ubi8/openjdk-21:1.21` with , tag `latest`:

https://catalog.redhat.com/software/containers/ubi8/openjdk-21-runtime/653fd184292263c0a2f14d69?q=openjdk%2021%20ubi&image=67d2cd09889512303be896ae

should have the upgrade.

**Which issue(s) this PR fixes**:
N/A (different tracker, MC-1577)

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
