### PR TITLE
Handle HTTP 429 throttling error in RerankingResponseErrorMessageMapper

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
@@ -99,6 +99,7 @@ public enum ErrorCodeV1 {
   RERANKING_PROVIDER_UNEXPECTED_RESPONSE("The Reranking Provider returned an unexpected response"),
   RERANKING_PROVIDER_CLIENT_ERROR("The Reranking Provider returned a HTTP client error"),
   RERANKING_PROVIDER_SERVER_ERROR("The Reranking Provider returned a HTTP server error"),
+  RERANKING_PROVIDER_RATE_LIMITED("The Reranking Provider rate limited the request"),
   RERANKING_PROVIDER_TIMEOUT("The Reranking Provider timed out"),
   RERANKING_PROVIDER_AUTHENTICATION_KEYS_NOT_PROVIDED(
       "The reranking provider authentication key is not provided"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/error/RerankingResponseErrorMessageMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/error/RerankingResponseErrorMessageMapper.java
@@ -26,7 +26,11 @@ public class RerankingResponseErrorMessageMapper {
     }
 
     // Status code == 429
-    // TODO reranking EmbeddingGateway rate limiting
+    if (response.getStatus() == Response.Status.TOO_MANY_REQUESTS.getStatusCode()) {
+      return ErrorCodeV1.RERANKING_PROVIDER_RATE_LIMITED.toApiException(
+          "Provider: %s; HTTP Status: %s; Error Message: %s",
+          providerName, response.getStatus(), message);
+    }
 
     // Status code in 4XX other than 429
     if (response.getStatusInfo().getFamily() == CLIENT_ERROR) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This is just a quick solution for issue #1955, we want to solve this problem quickly.
A more comprehensive refactor is in another PR https://github.com/stargate/data-api/pull/1938


**Which issue(s) this PR fixes**:
Fixes #1955 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
