### PR TITLE
Minor addition to #1965: mark extra properties as ignorable to robustify handling

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AwsBedrockEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AwsBedrockEmbeddingProvider.java
@@ -162,7 +162,7 @@ public class AwsBedrockEmbeddingProvider extends EmbeddingProvider {
   private record EmbeddingRequest(
       String inputText, @JsonInclude(value = JsonInclude.Include.NON_DEFAULT) int dimensions) {}
 
-  @JsonIgnoreProperties({"embeddingsByType"})
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(float[] embedding, int inputTextTokenCount) {}
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AzureOpenAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/AzureOpenAIEmbeddingProvider.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
@@ -105,9 +106,12 @@ public class AzureOpenAIEmbeddingProvider extends EmbeddingProvider {
       String model,
       @JsonInclude(value = JsonInclude.Include.NON_DEFAULT) int dimensions) {}
 
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(String object, Data[] data, String model, Usage usage) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Data(String object, int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Usage(int prompt_tokens, int total_tokens) {}
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/CohereEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/CohereEmbeddingProvider.java
@@ -103,7 +103,8 @@ public class CohereEmbeddingProvider extends EmbeddingProvider {
 
   private record EmbeddingRequest(String[] texts, String model, String input_type) {}
 
-  @JsonIgnoreProperties({"id", "texts", "meta", "response_type"})
+  // @JsonIgnoreProperties({"id", "texts", "meta", "response_type"})
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private static class EmbeddingResponse {
 
     protected EmbeddingResponse() {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceDedicatedEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/HuggingFaceDedicatedEmbeddingProvider.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
@@ -92,9 +93,12 @@ public class HuggingFaceDedicatedEmbeddingProvider extends EmbeddingProvider {
   // https://huggingface.github.io/text-embeddings-inference/#/Text%20Embeddings%20Inference/openai_embed
   private record EmbeddingRequest(String[] input) {}
 
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(String object, Data[] data, String model, Usage usage) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Data(String object, int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Usage(int prompt_tokens, int total_tokens) {}
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/JinaAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/JinaAIEmbeddingProvider.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
@@ -101,9 +102,12 @@ public class JinaAIEmbeddingProvider extends EmbeddingProvider {
       @JsonInclude(value = JsonInclude.Include.NON_NULL) String task,
       @JsonInclude(value = JsonInclude.Include.NON_NULL) Boolean late_chunking) {}
 
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(String object, Data[] data, String model, Usage usage) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Data(String object, int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Usage(int prompt_tokens, int total_tokens) {}
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MistralEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MistralEmbeddingProvider.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
@@ -96,10 +97,13 @@ public class MistralEmbeddingProvider extends EmbeddingProvider {
 
   private record EmbeddingRequest(List<String> input, String model, String encoding_format) {}
 
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(
       String id, String object, Data[] data, String model, Usage usage) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Data(String object, int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Usage(
         int prompt_tokens, int total_tokens, int completion_tokens, int request_count) {}
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
@@ -91,7 +91,7 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
 
   private record EmbeddingRequest(String[] input, String model, String input_type) {}
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(Data[] data, String model, Usage usage) {
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record Data(int index, float[] embedding) {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/OpenAIEmbeddingProvider.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
@@ -106,9 +107,12 @@ public class OpenAIEmbeddingProvider extends EmbeddingProvider {
       String model,
       @JsonInclude(value = JsonInclude.Include.NON_DEFAULT) int dimensions) {}
 
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private record EmbeddingResponse(String object, Data[] data, String model, Usage usage) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Data(String object, int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Usage(int prompt_tokens, int total_tokens) {}
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/UpstageAIEmbeddingProvider.java
@@ -110,11 +110,12 @@ public class UpstageAIEmbeddingProvider extends EmbeddingProvider {
   // NOTE: "input" is a single String, not array of Constants!
   record EmbeddingRequest(String input, String model) {}
 
-  @JsonIgnoreProperties({"object"})
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   record EmbeddingResponse(Data[] data, String model, Usage usage) {
-    @JsonIgnoreProperties({"object"})
+    @JsonIgnoreProperties(ignoreUnknown = true)
     record Data(int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     record Usage(int prompt_tokens, int total_tokens) {}
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VertexAIEmbeddingProvider.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
@@ -89,6 +90,7 @@ public class VertexAIEmbeddingProvider extends EmbeddingProvider {
     public record Content(String content) {}
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   private static class EmbeddingResponse {
     public EmbeddingResponse() {}
 
@@ -112,6 +114,7 @@ public class VertexAIEmbeddingProvider extends EmbeddingProvider {
       this.metadata = metadata;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     protected static class Prediction {
       public Prediction() {}
 
@@ -125,6 +128,7 @@ public class VertexAIEmbeddingProvider extends EmbeddingProvider {
         this.embeddings = embeddings;
       }
 
+      @JsonIgnoreProperties(ignoreUnknown = true)
       protected static class Embeddings {
         public Embeddings() {}
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
@@ -99,11 +99,12 @@ public class VoyageAIEmbeddingProvider extends EmbeddingProvider {
       String model,
       @JsonInclude(JsonInclude.Include.NON_NULL) Boolean truncation) {}
 
-  @JsonIgnoreProperties({"object"})
+  @JsonIgnoreProperties(ignoreUnknown = true) // ignore possible extra fields without error
   record EmbeddingResponse(Data[] data, String model, Usage usage) {
-    @JsonIgnoreProperties({"object"})
+    @JsonIgnoreProperties(ignoreUnknown = true)
     record Data(int index, float[] embedding) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     record Usage(int total_tokens) {}
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds to #1965, marking record types to ignore possible unknown JSON properties

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
