### PR TITLE
Fix #1971: clean up testing aspects of DocumentShredder

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/collections/DocumentShredder.java
@@ -15,15 +15,10 @@ import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonProcessingMetricsReporter;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
-import io.stargate.sgv2.jsonapi.service.cqldriver.executor.SchemaObjectName;
-import io.stargate.sgv2.jsonapi.service.cqldriver.executor.VectorConfig;
 import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
 import io.stargate.sgv2.jsonapi.service.schema.collections.CollectionIdType;
-import io.stargate.sgv2.jsonapi.service.schema.collections.CollectionLexicalConfig;
-import io.stargate.sgv2.jsonapi.service.schema.collections.CollectionRerankDef;
 import io.stargate.sgv2.jsonapi.service.schema.collections.CollectionSchemaObject;
 import io.stargate.sgv2.jsonapi.service.schema.collections.DocumentPath;
-import io.stargate.sgv2.jsonapi.service.schema.collections.IdConfig;
 import io.stargate.sgv2.jsonapi.service.schema.naming.NamingRules;
 import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -46,17 +41,6 @@ import org.bson.types.ObjectId;
  */
 @ApplicationScoped
 public class DocumentShredder {
-  // Collection Schema to use for testing: most settings missing, but $lexical
-  private static final CollectionSchemaObject TEST_COLLECTION_SCHEMA_WITH_LEXICAL =
-      new CollectionSchemaObject(
-          SchemaObjectName.MISSING,
-          null,
-          IdConfig.defaultIdConfig(),
-          VectorConfig.NOT_ENABLED_CONFIG,
-          null,
-          CollectionLexicalConfig.configForEnabledStandard(),
-          CollectionRerankDef.DISABLED);
-
   private static final NoArgGenerator UUID_V4_GENERATOR = Generators.randomBasedGenerator();
   private static final NoArgGenerator UUID_V6_GENERATOR = Generators.timeBasedReorderedGenerator();
   private static final NoArgGenerator UUID_V7_GENERATOR = Generators.timeBasedEpochGenerator();
@@ -75,27 +59,6 @@ public class DocumentShredder {
     this.objectMapper = objectMapper;
     this.documentLimits = documentLimits;
     this.jsonProcessingMetricsReporter = jsonProcessingMetricsReporter;
-  }
-
-  /**
-   * Test-only shred-method that does not require a {@link CommandContext} and passes in a
-   * hard-coded command name and indexing projector. This is only used for testing: ideally should
-   * be refactored away: named specifically to avoid confusion with the actual production code. MUST
-   * NOT be called by non-test code.
-   *
-   * @param doc Document to shred.
-   * @return Shredded document
-   */
-  public WritableShreddedDocument testShred(JsonNode doc, UUID txId) {
-    // "testCommand" is a placeholder for the command name in the context of testing.
-    // Cannot refer to a constant as this is not a test class, hence hard-coded here.
-    return shred(
-        doc,
-        txId,
-        IndexingProjector.identityProjector(),
-        "testCommand",
-        TEST_COLLECTION_SCHEMA_WITH_LEXICAL,
-        null);
   }
 
   /** Shred method that takes a {@link CommandContext} and shreds the provided JSON document. */

--- a/src/test/java/io/stargate/sgv2/jsonapi/TestConstants.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/TestConstants.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 /**
  * Re-usable values for tests.
  *
- * <p>THis must be an instance so that quarkus can setup the environment, we need this because of
+ * <p>This must be an instance so that quarkus can set up the environment, we need this because of
  * the use of their config library
  */
 public class TestConstants {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/InsertOneTableIntegrationTest.java
@@ -16,10 +16,12 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusIntegrationTest
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
@@ -1550,18 +1552,18 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
 
       String inputJSON =
               """
-                          { "id": "vectorValidBase64",
-                            "vector": {"$binary": "%s"}
-                          }
-                          """
+                      { "id": "vectorValidBase64",
+                        "vector": {"$binary": "%s"}
+                      }
+                      """
               .formatted(Base64Util.encodeAsMimeBase64(floatsAsBytes));
       // Base64-encoded float array used in input but will be read back as Array:
       String expJSON =
           """
-                          { "id": "vectorValidBase64",
-                            "vector": [1.0, -0.5, 2.5]
-                          }
-                          """;
+                      { "id": "vectorValidBase64",
+                        "vector": [1.0, -0.5, 2.5]
+                      }
+                      """;
       assertTableCommand(keyspaceName, TABLE_WITH_VECTOR_COLUMN)
           .templated()
           .insertOne(inputJSON)
@@ -1609,11 +1611,11 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
     void insertValidVectorKey() {
       String docJSON =
           """
-                          {
-                            "vectorId": [0.75, -0.25, 0.5],
-                            "textValue": "stuff"
-                          }
-                          """;
+                      {
+                        "vectorId": [0.75, -0.25, 0.5],
+                        "textValue": "stuff"
+                      }
+                      """;
       assertTableCommand(keyspaceName, TABLE_WITH_VECTOR_KEY)
           .templated()
           .insertOne(docJSON)
@@ -1635,11 +1637,11 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
           .templated()
           .insertOne(
               """
-              {
-                "id": "vectorInvalid",
-                "vector": 1
-              }
-              """)
+                              {
+                                "id": "vectorInvalid",
+                                "vector": 1
+                              }
+                              """)
           .hasSingleApiError(
               DocumentException.Code.INVALID_COLUMN_VALUES,
               DocumentException.class,
@@ -1652,11 +1654,11 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
           .templated()
           .insertOne(
               """
-                      {
-                        "id":" vectorInvalid",
-                        "vector": ["abc", 123, false]
-                      }
-                      """)
+                              {
+                                "id":" vectorInvalid",
+                                "vector": ["abc", 123, false]
+                              }
+                              """)
           .hasSingleApiError(
               DocumentException.Code.INVALID_COLUMN_VALUES,
               DocumentException.class,
@@ -1671,17 +1673,23 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
           .templated()
           .insertOne(
                   """
-                      { "id": "vectorValidBase64",
-                        "vector": {"$binary": "%s"}
-                      }
-                      """
+                              { "id": "vectorValidBase64",
+                                "vector": {"$binary": "%s"}
+                              }
+                              """
                   .formatted(Base64Util.encodeAsMimeBase64(floatsAsBytes)))
           .hasSingleApiError(
               DocumentException.Code.INVALID_COLUMN_VALUES,
               DocumentException.class,
               "vector(vector) - Cause: expected vector of length 3, got one with 2 elements");
     }
+  }
 
+  @Nested
+  @Order(12)
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class InsertVectorizeColumns {
+    @Order(1)
     @Test
     void insertDifferentVectorizeDimensions() {
       // Two vector columns with same provider and model, but different dimension, is now allowed
@@ -1728,11 +1736,12 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
               "The Embedding Provider returned a HTTP client error: Provider: openai; HTTP Status: 401; Error Message: Incorrect API key provided: test_emb");
     }
 
+    @Order(2)
     @Test
     void insertDifferentVectorizeModels() {
       // Two vector columns with same provider, different models, different dimensions
       // is supported
-      String tableName = "insertOneMultipleVectorizeDiffModelsTable";
+      final String tableName = "insertOneMultipleVectorizeDiffModelsTable";
 
       assertNamespaceCommand(keyspaceName)
           .templated()
@@ -1775,10 +1784,11 @@ public class InsertOneTableIntegrationTest extends AbstractTableIntegrationTestB
               "The Embedding Provider returned a HTTP client error: Provider: openai; HTTP Status: 401; Error Message: Incorrect API key provided: test_emb");
     }
 
+    @Order(3)
     @Test
     void insertDifferentVectorizeProviders() {
       // Two columns with different providers, not allowed for now
-      String tableName = "insertOneMultipleVectorizeDiffProvidersTable";
+      final String tableName = "insertOneMultipleVectorizeDiffProvidersTable";
 
       assertNamespaceCommand(keyspaceName)
           .templated()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperationRetryTest.java
@@ -153,7 +153,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
             }
             """;
     JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-    SimpleStatement stmt3 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id1));
+    SimpleStatement stmt3 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1));
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger failedUpdateQueryAssert = new AtomicInteger();
@@ -164,7 +165,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
               return Uni.createFrom().item(results3);
             });
 
-    SimpleStatement stmt4 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id2));
+    SimpleStatement stmt4 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2));
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateQueryAssert = new AtomicInteger();
@@ -294,7 +296,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
             }
             """;
     JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-    SimpleStatement stmt3 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id1));
+    SimpleStatement stmt3 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1));
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger updateFailedQueryAssert = new AtomicInteger();
@@ -305,7 +308,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
               return Uni.createFrom().item(results3);
             });
 
-    SimpleStatement stmt4 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id2));
+    SimpleStatement stmt4 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2));
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateRetryFailedQueryAssert = new AtomicInteger();
@@ -443,7 +447,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
             }
             """;
     JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-    SimpleStatement stmt3 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id1));
+    SimpleStatement stmt3 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1));
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger updateFailedQueryAssert = new AtomicInteger();
@@ -454,7 +459,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
               return Uni.createFrom().item(results3);
             });
 
-    SimpleStatement stmt4 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id2));
+    SimpleStatement stmt4 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2));
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateRetryFailedQueryAssert = new AtomicInteger();
@@ -610,7 +616,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
             });
 
     JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-    SimpleStatement stmt3 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id1));
+    SimpleStatement stmt3 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1));
     List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
     final AtomicInteger failedUpdateFirstQueryAssert = new AtomicInteger();
@@ -621,7 +628,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
               return Uni.createFrom().item(results3);
             });
 
-    SimpleStatement stmt4 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id2));
+    SimpleStatement stmt4 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2));
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger failedUpdateRetryFirstQueryAssert = new AtomicInteger();
@@ -633,7 +641,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
             });
 
     jsonNode = objectMapper.readTree(doc2Updated);
-    SimpleStatement stmt5 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id3));
+    SimpleStatement stmt5 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id3));
     List<Row> rows5 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
     AsyncResultSet results5 = new MockAsyncResultSet(COLUMNS_APPLIED, rows5, null);
     final AtomicInteger updateSecondQueryAssert = new AtomicInteger();
@@ -806,7 +815,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
             });
 
     JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-    SimpleStatement stmt4 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id1));
+    SimpleStatement stmt4 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1));
     List<Row> rows4 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results4 = new MockAsyncResultSet(COLUMNS_APPLIED, rows4, null);
     final AtomicInteger updateQueryDoc1Assert = new AtomicInteger();
@@ -817,7 +827,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
               return Uni.createFrom().item(results4);
             });
 
-    SimpleStatement stmt5 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id2));
+    SimpleStatement stmt5 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2));
     List<Row> rows5 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results5 = new MockAsyncResultSet(COLUMNS_APPLIED, rows5, null);
     final AtomicInteger updateRetryQueryDoc1Assert = new AtomicInteger();
@@ -830,7 +841,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
 
     jsonNode = objectMapper.readTree(doc2Updated);
 
-    SimpleStatement stmt6 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id3));
+    SimpleStatement stmt6 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id3));
     List<Row> rows6 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results6 = new MockAsyncResultSet(COLUMNS_APPLIED, rows6, null);
     final AtomicInteger updateQueryDoc2Assert = new AtomicInteger();
@@ -841,7 +853,8 @@ public class ReadAndUpdateCollectionOperationRetryTest extends OperationTestBase
               return Uni.createFrom().item(results6);
             });
 
-    SimpleStatement stmt7 = nonVectorUpdateStatement(documentShredder.testShred(jsonNode, tx_id4));
+    SimpleStatement stmt7 =
+        nonVectorUpdateStatement(documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id4));
     List<Row> rows7 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.FALSE));
     AsyncResultSet results7 = new MockAsyncResultSet(COLUMNS_APPLIED, rows7, null);
     final AtomicInteger updateRetryQueryDoc2Assert = new AtomicInteger();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/ReadAndUpdateCollectionOperationTest.java
@@ -190,7 +190,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
             """;
 
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id);
       SimpleStatement stmt2 = vectorUpdateStatement(shredDocument);
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
@@ -553,7 +554,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
               }
               """;
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id1);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
 
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
@@ -799,7 +801,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
                 }
                 """;
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id);
 
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
@@ -899,7 +902,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
 
       // update
       JsonNode jsonNode = objectMapper.readTree(doc1_select_update);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, null);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, null);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
@@ -1045,7 +1049,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
               """;
 
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id1);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
 
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
@@ -1211,7 +1216,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
                 }
                 """;
       JsonNode jsonNode = objectMapper.readTree(doc2Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id2);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
 
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
@@ -1327,7 +1333,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
                 """;
 
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, null);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, null);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
@@ -1521,7 +1528,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
 
       // update
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id1);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id1);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);
@@ -1534,7 +1542,7 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
               });
 
       jsonNode = objectMapper.readTree(doc2Updated);
-      shredDocument = documentShredder.testShred(jsonNode, tx_id2);
+      shredDocument = documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id2);
       SimpleStatement stmt3 = nonVectorUpdateStatement(shredDocument);
       List<Row> rows3 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results3 = new MockAsyncResultSet(COLUMNS_APPLIED, rows3, null);
@@ -1632,7 +1640,8 @@ public class ReadAndUpdateCollectionOperationTest extends OperationTestBase {
                   }
                   """;
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, null);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, null);
       SimpleStatement stmt2 = nonVectorUpdateStatement(shredDocument);
       List<Row> rows2 = Arrays.asList(resultRow(COLUMNS_APPLIED, 0, Boolean.TRUE));
       AsyncResultSet results2 = new MockAsyncResultSet(COLUMNS_APPLIED, rows2, null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/SerialConsistencyOverrideOperationTest.java
@@ -293,7 +293,8 @@ public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
           ReadAndUpdateCollectionOperation.buildUpdateQuery(
               KEYSPACE_NAME, COLLECTION_NAME, false, false);
       JsonNode jsonNode = objectMapper.readTree(doc1Updated);
-      WritableShreddedDocument shredDocument = documentShredder.testShred(jsonNode, tx_id);
+      WritableShreddedDocument shredDocument =
+          documentShredder.shred(COMMAND_CONTEXT, jsonNode, tx_id);
       SimpleStatement updateStmt =
           ReadAndUpdateCollectionOperation.bindUpdateValues(updateCql, shredDocument, false, false);
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
@@ -490,9 +490,11 @@ public class CommandResolverWithVectorizerTest {
               InsertCollectionOperation.class,
               op -> {
                 WritableShreddedDocument first =
-                    documentShredder.testShred(command.documents().get(0), null);
+                    documentShredder.shred(
+                        testConstants.collectionContext(), command.documents().get(0), null);
                 WritableShreddedDocument second =
-                    documentShredder.testShred(command.documents().get(1), null);
+                    documentShredder.shred(
+                        testConstants.collectionContext(), command.documents().get(1), null);
                 assertThat(first.queryVectorValues().length).isEqualTo(3);
                 assertThat(first.queryVectorValues()).containsExactly(0.25f, 0.25f, 0.25f);
                 assertThat(second.queryVectorValues().length).isEqualTo(3);
@@ -578,7 +580,8 @@ public class CommandResolverWithVectorizerTest {
               InsertCollectionOperation.class,
               op -> {
                 WritableShreddedDocument expected =
-                    documentShredder.testShred(command.document(), null);
+                    documentShredder.shred(
+                        testConstants.collectionContext(), command.document(), null);
                 assertThat(expected.queryVectorValues().length).isEqualTo(3);
                 assertThat(expected.queryVectorValues()).containsExactly(0.25f, 0.25f, 0.25f);
                 assertThat(op.commandContext()).isEqualTo(commandContext);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolverWithVectorizerTest.java
@@ -78,8 +78,8 @@ public class CommandResolverWithVectorizerTest {
   @Inject InsertOneCommandResolver insertOneCommandResolver;
 
   @Inject DataVectorizerService dataVectorizerService;
-  private TestConstants testConstants = new TestConstants();
-  private TestEmbeddingProvider testEmbeddingProvider = new TestEmbeddingProvider();
+  private final TestConstants testConstants = new TestConstants();
+  private final TestEmbeddingProvider testEmbeddingProvider = new TestEmbeddingProvider();
 
   @Nested
   class Resolve {
@@ -491,10 +491,10 @@ public class CommandResolverWithVectorizerTest {
               op -> {
                 WritableShreddedDocument first =
                     documentShredder.shred(
-                        testConstants.collectionContext(), command.documents().get(0), null);
+                        VECTOR_COMMAND_CONTEXT, command.documents().get(0), null);
                 WritableShreddedDocument second =
                     documentShredder.shred(
-                        testConstants.collectionContext(), command.documents().get(1), null);
+                        VECTOR_COMMAND_CONTEXT, command.documents().get(1), null);
                 assertThat(first.queryVectorValues().length).isEqualTo(3);
                 assertThat(first.queryVectorValues()).containsExactly(0.25f, 0.25f, 0.25f);
                 assertThat(second.queryVectorValues().length).isEqualTo(3);
@@ -580,8 +580,7 @@ public class CommandResolverWithVectorizerTest {
               InsertCollectionOperation.class,
               op -> {
                 WritableShreddedDocument expected =
-                    documentShredder.shred(
-                        testConstants.collectionContext(), command.document(), null);
+                    documentShredder.shred(VECTOR_COMMAND_CONTEXT, command.document(), null);
                 assertThat(expected.queryVectorValues().length).isEqualTo(3);
                 assertThat(expected.queryVectorValues()).containsExactly(0.25f, 0.25f, 0.25f);
                 assertThat(op.commandContext()).isEqualTo(commandContext);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderDocLimitsTest.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.jsonapi.TestConstants;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
@@ -41,6 +43,8 @@ public class DocumentShredderDocLimitsTest {
 
   @InjectMock protected RequestContext dataApiRequestInfo;
 
+  private final TestConstants testConstants = new TestConstants();
+
   // Tests for Document size/depth violations
   @Nested
   class ValidationDocSizeViolations {
@@ -49,11 +53,11 @@ public class DocumentShredderDocLimitsTest {
       // Given we fail at 4 meg
       // let's try 600k (8 x 5 x 7.5k)
       final ObjectNode bigDoc = createBigDoc(8, 5);
-      assertThat(documentShredder.testShred(bigDoc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), bigDoc, null)).isNotNull();
 
       // let's also try 1m (12 x 12 x 7.5k)
       final ObjectNode bigDoc1m = createBigDoc(12, 12);
-      assertThat(documentShredder.testShred(bigDoc1m, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), bigDoc1m, null)).isNotNull();
     }
 
     @Test
@@ -62,7 +66,7 @@ public class DocumentShredderDocLimitsTest {
       // (12x45) x 7.5k String values, divided in 12 sub documents of 45 properties
       final ObjectNode bigDoc = createBigDoc(12, 45);
 
-      Exception e = catchException(() -> documentShredder.testShred(bigDoc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), bigDoc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -94,7 +98,7 @@ public class DocumentShredderDocLimitsTest {
         ob = ob.putObject("sub");
       }
 
-      assertThat(documentShredder.testShred(deepDoc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), deepDoc, null)).isNotNull();
     }
 
     @Test
@@ -110,7 +114,7 @@ public class DocumentShredderDocLimitsTest {
         obNode = array.addObject();
       }
 
-      Exception e = catchException(() -> documentShredder.testShred(deepDoc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), deepDoc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -128,7 +132,7 @@ public class DocumentShredderDocLimitsTest {
     public void allowDocWithManyObjectProps() {
       // Max allowed is 1,000
       final ObjectNode doc = docWithNProps("subdoc", docLimits.maxObjectProperties());
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     @Test
@@ -150,7 +154,7 @@ public class DocumentShredderDocLimitsTest {
       final int tooManyProps = maxObProps + 1;
       final ObjectNode doc = docWithNProps("subdoc", tooManyProps);
 
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -179,7 +183,7 @@ public class DocumentShredderDocLimitsTest {
       // Max allowed 2000, create one with bit more
       final ObjectNode doc = docWithNestedProps(50, 41);
 
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -208,7 +212,7 @@ public class DocumentShredderDocLimitsTest {
     public void allowDocWithManyArrayElements() {
       // Max allowed 1000, test:
       final ObjectNode doc = docWithNArrayElems("arr", docLimits.maxArrayLength());
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     // Test to verify that max-array-size limit only imposed on indexable properties
@@ -228,7 +232,7 @@ public class DocumentShredderDocLimitsTest {
     public void catchTooManyArrayElements() {
       final int arraySizeAboveMax = docLimits.maxArrayLength() + 1;
       final ObjectNode doc = docWithNArrayElems("arr", arraySizeAboveMax);
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -247,7 +251,7 @@ public class DocumentShredderDocLimitsTest {
       // Let's add 120 elements (max allowed normally: 100)
       final ObjectNode doc =
           docWithNArrayElems(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD, 120);
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
   }
 
@@ -259,7 +263,7 @@ public class DocumentShredderDocLimitsTest {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       doc.put("prop_123456789_123456789_123456789_123456789", true);
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     @Test
@@ -271,7 +275,7 @@ public class DocumentShredderDocLimitsTest {
       ObjectNode ob3 = ob2.putObject("hijkl".repeat(60));
       // and then one short one, for 992 char total path
       ob3.put("xyz".repeat(30), 123);
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     @Test
@@ -284,7 +288,7 @@ public class DocumentShredderDocLimitsTest {
       final String lastSegment = "a1234".repeat(20);
       ob3.put(lastSegment, 123);
 
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -305,7 +309,7 @@ public class DocumentShredderDocLimitsTest {
       doc.put("_id", 123);
       // Use ASCII to keep chars == bytes, use length of just slight below max allowed
       doc.put("text", RandomStringUtils.randomAscii(docLimits.maxStringLengthInBytes() - 100));
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     @Test
@@ -318,7 +322,7 @@ public class DocumentShredderDocLimitsTest {
       String str = RandomStringUtils.randomAscii(tooLongLength);
       arr.add(str);
 
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -350,7 +354,7 @@ public class DocumentShredderDocLimitsTest {
       assertThat(tooLongString.getBytes(StandardCharsets.UTF_8))
           .hasSizeGreaterThan(docLimits.maxStringLengthInBytes());
 
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isNotNull()
           .isInstanceOf(JsonApiException.class)
@@ -413,7 +417,7 @@ public class DocumentShredderDocLimitsTest {
       doc.put(validName, 123456);
 
       // Enough to verify that shredder does not throw exception
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     // formerly invalid names that now are allowed
@@ -425,7 +429,7 @@ public class DocumentShredderDocLimitsTest {
       doc.put(validName, 123456);
 
       // Enough to verify that shredder does not throw exception
-      assertThat(documentShredder.testShred(doc, null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), doc, null)).isNotNull();
     }
 
     @ParameterizedTest
@@ -438,7 +442,8 @@ public class DocumentShredderDocLimitsTest {
           "{\"root\": { \" \": 12 }}",
         })
     public void allowUnusualNestedFieldNames(String json) throws IOException {
-      assertThat(documentShredder.testShred(objectMapper.readTree(json), null)).isNotNull();
+      assertThat(documentShredder.shred(commandContext(), objectMapper.readTree(json), null))
+          .isNotNull();
     }
 
     @ParameterizedTest
@@ -454,7 +459,7 @@ public class DocumentShredderDocLimitsTest {
       doc.put(invalidName, 123456);
 
       // First check at root level
-      Exception e = catchException(() -> documentShredder.testShred(doc, null));
+      Exception e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
@@ -466,7 +471,7 @@ public class DocumentShredderDocLimitsTest {
       ObjectNode leaf = doc2.putObject("root");
       leaf.put(invalidName, 13);
 
-      e = catchException(() -> documentShredder.testShred(doc, null));
+      e = catchException(() -> documentShredder.shred(commandContext(), doc, null));
       assertThat(e)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
@@ -483,5 +488,9 @@ public class DocumentShredderDocLimitsTest {
       arr.add(i);
     }
     return doc;
+  }
+
+  private CommandContext<CollectionSchemaObject> commandContext() {
+    return testConstants.collectionContext();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderWithExtendedTypesTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/DocumentShredderWithExtendedTypesTest.java
@@ -10,6 +10,8 @@ import com.fasterxml.uuid.impl.UUIDUtil;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.jsonapi.TestConstants;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.service.projection.IndexingProjector;
@@ -18,11 +20,8 @@ import io.stargate.sgv2.jsonapi.service.schema.collections.CollectionSchemaObjec
 import io.stargate.sgv2.jsonapi.service.shredding.collections.*;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
 import jakarta.inject.Inject;
-import java.io.IOException;
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +42,8 @@ public class DocumentShredderWithExtendedTypesTest {
   @Inject DocumentShredder documentShredder;
   @InjectMock protected RequestContext bogusRequestInfo;
 
+  private final TestConstants testConstants = new TestConstants();
+
   @Nested
   class OkCasesExplicitId {
     @Test
@@ -58,7 +59,7 @@ public class DocumentShredderWithExtendedTypesTest {
                       """
               .formatted(idUUID, valueUUID);
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      WritableShreddedDocument doc = documentShredder.testShred(inputDoc, null);
+      WritableShreddedDocument doc = documentShredder.shred(commandContext(), inputDoc, null);
 
       assertThat(doc.id())
           .isEqualTo(
@@ -110,7 +111,7 @@ public class DocumentShredderWithExtendedTypesTest {
                           """
               .formatted(idObjectId, valueObjectId);
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      WritableShreddedDocument doc = documentShredder.testShred(inputDoc, null);
+      WritableShreddedDocument doc = documentShredder.shred(commandContext(), inputDoc, null);
 
       assertThat(doc.id())
           .isEqualTo(
@@ -159,7 +160,7 @@ public class DocumentShredderWithExtendedTypesTest {
                       }
                       """;
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      WritableShreddedDocument doc = documentShredder.testShred(inputDoc, null);
+      WritableShreddedDocument doc = documentShredder.shred(commandContext(), inputDoc, null);
 
       assertThat(doc.id()).isInstanceOf(DocumentId.StringId.class);
       // should be auto-generated UUID:
@@ -344,7 +345,7 @@ public class DocumentShredderWithExtendedTypesTest {
                   }
                   """;
       final JsonNode inputDoc = objectMapper.readTree(inputJson);
-      WritableShreddedDocument doc = documentShredder.testShred(inputDoc, null);
+      WritableShreddedDocument doc = documentShredder.shred(commandContext(), inputDoc, null);
 
       List<JsonPath> expPaths =
           Arrays.asList(JsonPath.from("_id"), JsonPath.from("age"), JsonPath.from("$vector"));
@@ -368,7 +369,9 @@ public class DocumentShredderWithExtendedTypesTest {
                               }
                               """;
       Throwable t =
-          catchThrowable(() -> documentShredder.testShred(objectMapper.readTree(inputJson), null));
+          catchThrowable(
+              () ->
+                  documentShredder.shred(commandContext(), objectMapper.readTree(inputJson), null));
 
       assertThat(t)
           .isNotNull()
@@ -387,7 +390,9 @@ public class DocumentShredderWithExtendedTypesTest {
                           }
                           """;
       Throwable t =
-          catchThrowable(() -> documentShredder.testShred(objectMapper.readTree(inputJson), null));
+          catchThrowable(
+              () ->
+                  documentShredder.shred(commandContext(), objectMapper.readTree(inputJson), null));
 
       assertThat(t)
           .isNotNull()
@@ -399,8 +404,10 @@ public class DocumentShredderWithExtendedTypesTest {
       t =
           catchThrowable(
               () ->
-                  documentShredder.testShred(
-                      objectMapper.readTree("{ \"_id\" : {\"$uuid\": { } } }"), null));
+                  documentShredder.shred(
+                      commandContext(),
+                      objectMapper.readTree("{ \"_id\" : {\"$uuid\": { } } }"),
+                      null));
 
       assertThat(t)
           .isNotNull()
@@ -416,7 +423,9 @@ public class DocumentShredderWithExtendedTypesTest {
                                   { "_id" : {"$unknown": "value"} }
                                   """;
       Throwable t =
-          catchThrowable(() -> documentShredder.testShred(objectMapper.readTree(inputJson), null));
+          catchThrowable(
+              () ->
+                  documentShredder.shred(commandContext(), objectMapper.readTree(inputJson), null));
 
       assertThat(t)
           .isNotNull()
@@ -434,8 +443,10 @@ public class DocumentShredderWithExtendedTypesTest {
       Throwable t =
           catchThrowable(
               () ->
-                  documentShredder.testShred(
-                      objectMapper.readTree("{ \"value\": { \"$objectId\": \"abc\" } }"), null));
+                  documentShredder.shred(
+                      commandContext(),
+                      objectMapper.readTree("{ \"value\": { \"$objectId\": \"abc\" } }"),
+                      null));
 
       assertThat(t)
           .isNotNull()
@@ -450,8 +461,10 @@ public class DocumentShredderWithExtendedTypesTest {
       Throwable t =
           catchThrowable(
               () ->
-                  documentShredder.testShred(
-                      objectMapper.readTree("{ \"value\": { \"$uuid\": \"foobar\" } }"), null));
+                  documentShredder.shred(
+                      commandContext(),
+                      objectMapper.readTree("{ \"value\": { \"$uuid\": \"foobar\" } }"),
+                      null));
 
       assertThat(t)
           .isNotNull()
@@ -466,27 +479,16 @@ public class DocumentShredderWithExtendedTypesTest {
       Throwable t =
           catchThrowable(
               () ->
-                  documentShredder.testShred(
-                      objectMapper.readTree("{ \"value\": { \"$unknownType\": 123 } }"), null));
+                  documentShredder.shred(
+                      commandContext(),
+                      objectMapper.readTree("{ \"value\": { \"$unknownType\": 123 } }"),
+                      null));
 
       assertThat(t)
           .isNotNull()
           .hasFieldOrPropertyWithValue("errorCode", ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION)
           .hasMessageStartingWith(ErrorCodeV1.SHRED_DOC_KEY_NAME_VIOLATION.getMessage());
     }
-  }
-
-  protected JsonNode fromJson(String json) {
-    try {
-      return objectMapper.readTree(json);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  protected Date defaultTestDate() {
-    OffsetDateTime dt = OffsetDateTime.parse("2023-01-01T00:00:00Z");
-    return new Date(dt.toInstant().toEpochMilli());
   }
 
   protected UUID defaultTestUUID() {
@@ -503,5 +505,9 @@ public class DocumentShredderWithExtendedTypesTest {
 
   protected ObjectId defaultTestObjectId2() {
     return new ObjectId("1234567890abcdef87654321");
+  }
+
+  private CommandContext<CollectionSchemaObject> commandContext() {
+    return testConstants.collectionContext();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
@@ -188,7 +188,7 @@ public abstract class StargateTestResource
     final String JVM_EXTRA_OPTS =
         "-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.load_ring_state=false -Dcassandra.initial_token=1 -Dcassandra.sai.max_string_term_size_kb=8"
             // 18-Mar-2025, tatu: to work around [https://github.com/riptano/cndb/issues/13330],
-            // need to temporarily add this:
+            // need to temporarily add this for HCD:
             + " -Dcassandra.cluster_version_provider.min_stable_duration_ms=-1";
     container
         .withEnv("HEAP_NEWSIZE", "512M")


### PR DESCRIPTION
**What this PR does**:

Cleans up testing cruft from `DocumentShredder`

**Which issue(s) this PR fixes**:
Fixes #1971

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
