### PR TITLE
Fix #1981: match the error code in RerankingProviderResponseValidation

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderResponseValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderResponseValidation.java
@@ -1,6 +1,5 @@
 package io.stargate.sgv2.jsonapi.service.reranking.configuration;
 
-import static io.stargate.sgv2.jsonapi.exception.ErrorCodeV1.EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE;
 import static io.stargate.sgv2.jsonapi.exception.ErrorCodeV1.RERANKING_PROVIDER_UNEXPECTED_RESPONSE;
 
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
@@ -64,7 +63,7 @@ public class RerankingProviderResponseValidation implements ClientResponseFilter
         logger.error(
             "Cannot convert the provider's error response to string: {}", e.getMessage(), e);
       }
-      throw EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE.toApiException(
+      throw RERANKING_PROVIDER_UNEXPECTED_RESPONSE.toApiException(
           "Expected response Content-Type ('application/json' or 'text/json') from the reranking provider but found '%s'; HTTP Status: %s; The response body is: '%s'.",
           contentType, responseContext.getStatus(), responseBody);
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix #1981: match the error code in RerankingProviderResponseValidation

**Which issue(s) this PR fixes**:
Fixes #1981 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
