### PR TITLE
fixes #1954 improved rerankOn

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingTask.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingTask.java
@@ -170,12 +170,12 @@ public class RerankingTask<SchemaT extends TableBasedSchemaObject>
     int totalReads = 0;
 
     for (var deferredAndSource : deferredReads) {
-      var commandResult =
-          Objects.requireNonNull(
-              deferredAndSource.deferredRead().commandResult(),
-              "Deferred read from source %s returned null commandResult"
-                  .formatted(deferredAndSource.rankSource()));
-
+      var commandResult = deferredAndSource.deferredRead().commandResult();
+      if (commandResult == null) {
+        throw new IllegalStateException(
+            "Deferred read from source %s returned null commandResult"
+                .formatted(deferredAndSource.rankSource()));
+      }
       var multiDocResponse = (ResponseData.MultiResponseData) commandResult.data();
       totalReads++;
       if (merger == null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocument.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.operation.reranking;
 
 import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields.DOC_ID;
 import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields.VECTOR_FUNCTION_SIMILARITY_FIELD;
+import static io.stargate.sgv2.jsonapi.util.JsonUtil.nodeTypeAsString;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.*;
@@ -66,7 +67,7 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
   }
 
   /**
-   * Factory to create ane instance based on a document.
+   * Factory to create an instance based on a document.
    *
    * @param rank Rank of this document, the order it appeared in the result set.
    * @param rankSource The source of the rank
@@ -95,8 +96,11 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
         vectorScores = DocumentScores.fromVectorRead(numberNode.floatValue(), rank);
       } else {
         throw new IllegalArgumentException(
-            "%s document field is not a number or is missing for doc _id %s"
-                .formatted(VECTOR_FUNCTION_SIMILARITY_FIELD, documentId.asText()));
+            "%s document field is not a number or is missing type=%s _id=%s"
+                .formatted(
+                    VECTOR_FUNCTION_SIMILARITY_FIELD,
+                    nodeTypeAsString(similarityField),
+                    documentId.asText()));
       }
     } else {
       if (similarityField != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocument.java
@@ -1,11 +1,25 @@
 package io.stargate.sgv2.jsonapi.service.operation.reranking;
 
+import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields.DOC_ID;
+import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields.VECTOR_FUNCTION_SIMILARITY_FIELD;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.*;
+import com.google.common.annotations.VisibleForTesting;
+import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Optional;
 
+/**
+ * A document for scoring, with a passage and scores. The passage is used for reranking, the scores
+ * are then used to sort the documents.
+ *
+ * <p>Create using {@link #create(int, Rank.RankSource, JsonNode, PathMatchLocator)} and then merge
+ * the scores using {@link #mergeScore(DocumentScores)}.
+ *
+ * <p>TODO: more tests for the create function, only covering the passage extraction
+ */
 public class ScoredDocument implements Comparable<ScoredDocument> {
 
   // see compareTo()
@@ -14,10 +28,12 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
 
   private final JsonNode id;
   private final ObjectNode document;
-  private final String passage;
+  private final Optional<String> passage;
   private DocumentScores scores;
 
-  ScoredDocument(JsonNode id, JsonNode document, String passage, DocumentScores scores) {
+  /** Package protected so we can test with explicit scores */
+  @VisibleForTesting
+  protected ScoredDocument(JsonNode id, JsonNode document, String passage, DocumentScores scores) {
     this(id, checkCast(document), passage, scores);
   }
 
@@ -25,11 +41,13 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
     if (document instanceof ObjectNode on) {
       return on;
     }
+    Objects.requireNonNull(document, "document cannot be null");
     throw new IllegalArgumentException(
-        "Expected an ObjectNode, got document.getNodeType()=%s".formatted(document.getNodeType()));
+        "Expected document to be ObjectNode, got document.getNodeType()=%s"
+            .formatted(document.getNodeType()));
   }
 
-  ScoredDocument(JsonNode id, ObjectNode document, String passage, DocumentScores scores) {
+  private ScoredDocument(JsonNode id, ObjectNode document, String passage, DocumentScores scores) {
 
     this.id = Objects.requireNonNull(id);
     if (!id.isValueNode()) {
@@ -38,16 +56,101 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
           "id must be a value node, got id.getNodeType()=%s".formatted(id.getNodeType()));
     }
 
-    this.passage = Objects.requireNonNull(passage, "passage cannot be null");
+    if (passage != null && passage.isBlank()) {
+      throw new IllegalArgumentException("passage cannot be blank");
+    }
+
+    this.passage = Optional.ofNullable(passage);
     this.document = Objects.requireNonNull(document, "document cannot be null");
     this.scores = Objects.requireNonNull(scores, "scores cannot be null");
+  }
+
+  /**
+   * Factory to create ane instance based on a document.
+   *
+   * @param rank Rank of this document, the order it appeared in the result set.
+   * @param rankSource The source of the rank
+   * @param document Document to extract the id and passage from.
+   * @param passageLocator Locator to find the passage in the document.
+   * @return A new instance of ScoredDocument.
+   */
+  static ScoredDocument create(
+      int rank, Rank.RankSource rankSource, JsonNode document, PathMatchLocator passageLocator) {
+
+    Objects.requireNonNull(document, "document cannot be null");
+    Objects.requireNonNull(passageLocator, "passageLocator cannot be null");
+
+    var documentId =
+        switch (document.get(DOC_ID)) {
+          case null -> throw new IllegalArgumentException("Document id cannot be missing");
+          case NullNode ignored ->
+              throw new IllegalArgumentException("Document id cannot be a NullNode");
+          case JsonNode jsonNode -> jsonNode;
+        };
+
+    DocumentScores vectorScores;
+    var similarityField = document.get(VECTOR_FUNCTION_SIMILARITY_FIELD);
+    if (rankSource == Rank.RankSource.VECTOR) {
+      if (similarityField instanceof NumericNode numberNode) {
+        vectorScores = DocumentScores.fromVectorRead(numberNode.floatValue(), rank);
+      } else {
+        throw new IllegalArgumentException(
+            "%s document field is not a number or is missing for doc _id %s"
+                .formatted(VECTOR_FUNCTION_SIMILARITY_FIELD, documentId.asText()));
+      }
+    } else {
+      if (similarityField != null) {
+        throw new IllegalArgumentException(
+            "rankSource is %s but the document with id '%s' has %s field=%s"
+                .formatted(
+                    rankSource, documentId, VECTOR_FUNCTION_SIMILARITY_FIELD, similarityField));
+      }
+      vectorScores = DocumentScores.EMPTY;
+    }
+
+    // if we dont have a vector score, then use the rank as the bm25 rank (it is one or the other)
+    // if we have a vector score, then the BM25 is Empty
+    var bm25Scores =
+        rankSource == Rank.RankSource.BM25
+            ? DocumentScores.fromBm25Read(rank)
+            : DocumentScores.EMPTY;
+
+    var passageNode = passageLocator.findValueIn(document);
+    var passage =
+        switch (passageNode) {
+          case MissingNode ignored -> {
+            // undefined in the document, default to null so it is dropped
+            yield null;
+          }
+          case NullNode ignored -> {
+            // explicit {$vectorize : null} treat same as undefined, empty passage to rerank on
+            yield null;
+          }
+          case ValueNode valueNode -> {
+            // could be text, number, boolean, but not array or object
+            yield valueNode.asText();
+          }
+          default ->
+              throw new IllegalArgumentException(
+                  "Passage field %s is present but not null or a valueNode _id=%s , passageField=%s"
+                      .formatted(passageLocator.path(), documentId, passageNode));
+        };
+
+    // we will have one or the other of the vector or bm25 scores, merging handles this.
+    // normalise passage to null, to make it easier to use optional.
+    // cannot rerank on a blank passage
+    return new ScoredDocument(
+        documentId,
+        document,
+        passage == null || passage.isBlank() ? null : passage,
+        vectorScores.merge(bm25Scores));
   }
 
   public JsonNode id() {
     return id;
   }
 
-  public String passage() {
+  public Optional<String> passage() {
     return passage;
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindAndRerankOperationBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindAndRerankOperationBuilder.java
@@ -201,7 +201,8 @@ class FindAndRerankOperationBuilder {
                 providerConfig.authentication(),
                 commandContext.commandName());
 
-    // todo: move to a builder pattern, mosty to make it eaier to manage the task position and retry
+    // todo: move to a builder pattern, mosty to make it easier to manage the task position and
+    // retry
     // policy
     int commandLimit = getOrDefault(command.options(), FindAndRerankCommand.Options::limit, 10);
     RerankingTask<CollectionSchemaObject> task =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocumentTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocumentTests.java
@@ -1,10 +1,14 @@
 package io.stargate.sgv2.jsonapi.service.operation.reranking;
 
+import static io.stargate.sgv2.jsonapi.config.constants.DocumentConstants.Fields.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -14,9 +18,23 @@ import org.junit.jupiter.api.Test;
  * reranking score and what happens when the same
  */
 public class ScoredDocumentTests {
+
+  private static final JsonNode ID_1 = JsonNodeFactory.instance.textNode("id1");
+  private static final JsonNode ID_2 = JsonNodeFactory.instance.textNode("id2");
+  private static final JsonNode ID_3 = JsonNodeFactory.instance.textNode("id3");
+
   private static final String PASSAGE = "test PASSAGE";
-  private static final JsonNode DOCUMENT =
-      JsonNodeFactory.instance.objectNode().put("$vectorize", PASSAGE);
+  private static final PathMatchLocator VECTORIZE_LOCATOR =
+      PathMatchLocator.forPath(VECTOR_EMBEDDING_TEXT_FIELD);
+  private static final JsonNode DOCUMENT = baseDocument();
+
+  private static ObjectNode baseDocument() {
+    return JsonNodeFactory.instance
+        .objectNode()
+        .put(VECTOR_EMBEDDING_TEXT_FIELD, PASSAGE)
+        .put(VECTOR_FUNCTION_SIMILARITY_FIELD, 0.75f)
+        .set(DOC_ID, ID_1);
+  }
 
   private static ScoredDocument scoredDocument(JsonNode id, DocumentScores scores) {
     return new ScoredDocument(id, DOCUMENT, PASSAGE, scores);
@@ -25,13 +43,9 @@ public class ScoredDocumentTests {
   @Test
   public void testComparisonDiffReranking() {
 
-    var scoredDocument1 =
-        scoredDocument(JsonNodeFactory.instance.textNode("id1"), DocumentScores.fromReranking(10f));
-    var scoredDocument2 =
-        scoredDocument(JsonNodeFactory.instance.textNode("id2"), DocumentScores.fromReranking(5f));
-    var scoredDocument3 =
-        scoredDocument(
-            JsonNodeFactory.instance.textNode("id3"), DocumentScores.fromReranking(-10f));
+    var scoredDocument1 = scoredDocument(ID_1, DocumentScores.fromReranking(10f));
+    var scoredDocument2 = scoredDocument(ID_2, DocumentScores.fromReranking(5f));
+    var scoredDocument3 = scoredDocument(ID_3, DocumentScores.fromReranking(-10f));
 
     ScoreTests.threewayScoreComparison(scoredDocument1, scoredDocument2, scoredDocument3);
   }
@@ -39,15 +53,9 @@ public class ScoredDocumentTests {
   @Test
   public void testComparisonSameRerankingTextId() {
 
-    var scoredDocument1 =
-        scoredDocument(
-            JsonNodeFactory.instance.textNode("id1"), DocumentScores.fromReranking(-10f));
-    var scoredDocument2 =
-        scoredDocument(
-            JsonNodeFactory.instance.textNode("id2"), DocumentScores.fromReranking(-10f));
-    var scoredDocument3 =
-        scoredDocument(
-            JsonNodeFactory.instance.textNode("id3"), DocumentScores.fromReranking(-10f));
+    var scoredDocument1 = scoredDocument(ID_1, DocumentScores.fromReranking(-10f));
+    var scoredDocument2 = scoredDocument(ID_2, DocumentScores.fromReranking(-10f));
+    var scoredDocument3 = scoredDocument(ID_3, DocumentScores.fromReranking(-10f));
 
     ScoreTests.threewayScoreComparison(scoredDocument1, scoredDocument2, scoredDocument3);
   }
@@ -96,7 +104,7 @@ public class ScoredDocumentTests {
     var mergedRRF = vectorRead.rrf().merge(bm25Read.rrf()).merge(rerank.rrf());
     var allMerged = vectorRead.merge(bm25Read).merge(rerank);
 
-    var scoredDoc = scoredDocument(JsonNodeFactory.instance.textNode("id1"), DocumentScores.EMPTY);
+    var scoredDoc = scoredDocument(ID_1, DocumentScores.EMPTY);
 
     assertThat(scoredDoc.scores()).as("initial scores empty").isEqualTo(DocumentScores.EMPTY);
 
@@ -121,37 +129,37 @@ public class ScoredDocumentTests {
   @Test
   public void testToString() {
 
-    var id = JsonNodeFactory.instance.textNode("id1");
-    var scoredDocument = scoredDocument(id, DocumentScores.EMPTY);
+    var scoredDocument = scoredDocument(ID_1, DocumentScores.EMPTY);
 
     assertThat(scoredDocument.toString())
         .isEqualTo(
             "ScoredDocument{id=%s, passage='%s', document=%s, scores=%s}"
-                .formatted(id, PASSAGE, DOCUMENT, DocumentScores.EMPTY));
+                .formatted(ID_1, Optional.of(PASSAGE), DOCUMENT, DocumentScores.EMPTY));
   }
 
   @Test
   public void testProperties() {
 
-    var id = JsonNodeFactory.instance.textNode("id1");
-    var scoredDocument = scoredDocument(id, DocumentScores.EMPTY);
+    var scoredDocument = scoredDocument(ID_1, DocumentScores.EMPTY);
 
-    assertThat(scoredDocument.id()).isEqualTo(id);
-    assertThat(scoredDocument.passage()).isEqualTo(PASSAGE);
+    assertThat(scoredDocument.id()).isEqualTo(ID_1);
+    assertThat(scoredDocument.passage()).isEqualTo(Optional.of(PASSAGE));
     assertThat(scoredDocument.document()).isEqualTo(DOCUMENT);
     assertThat(scoredDocument.scores()).isEqualTo(DocumentScores.EMPTY);
   }
 
   @Test
   public void testCtor() {
-    var id = JsonNodeFactory.instance.textNode("id1");
+
+    var nullPassage = new ScoredDocument(ID_1, DOCUMENT, null, DocumentScores.EMPTY);
+    assertThat(nullPassage.passage()).as("passage isEmpty() when passage param is null").isEmpty();
 
     assertThatThrownBy(
             () ->
                 new ScoredDocument(
-                    id, JsonNodeFactory.instance.arrayNode(), PASSAGE, DocumentScores.EMPTY))
+                    ID_1, JsonNodeFactory.instance.arrayNode(), PASSAGE, DocumentScores.EMPTY))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Expected an ObjectNode, got document.getNodeType()=ARRAY");
+        .hasMessage("Expected document to be ObjectNode, got document.getNodeType()=ARRAY");
 
     assertThatThrownBy(
             () ->
@@ -160,14 +168,92 @@ public class ScoredDocumentTests {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("id must be a value node, got id.getNodeType()=OBJECT");
 
-    assertThatThrownBy(() -> new ScoredDocument(id, null, PASSAGE, DocumentScores.EMPTY))
+    assertThatThrownBy(() -> new ScoredDocument(ID_1, null, PASSAGE, DocumentScores.EMPTY))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("document cannot be null");
-    assertThatThrownBy(() -> new ScoredDocument(id, DOCUMENT, null, DocumentScores.EMPTY))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("passage cannot be null");
-    assertThatThrownBy(() -> new ScoredDocument(id, DOCUMENT, PASSAGE, null))
+    assertThatThrownBy(() -> new ScoredDocument(ID_1, DOCUMENT, PASSAGE, null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("scores cannot be null");
+  }
+
+  /** Testing the various ways the passage is extracted */
+  @Test
+  public void testCreatePassageField() {
+
+    var undefinedField =
+        ScoredDocument.create(
+            1, Rank.RankSource.VECTOR, DOCUMENT, PathMatchLocator.forPath("missing"));
+    assertThat(undefinedField.passage())
+        .as("passage missing when field does not exist in document")
+        .isEmpty();
+
+    var docWithNull = baseDocument().putNull(VECTOR_EMBEDDING_TEXT_FIELD);
+    var nullField =
+        ScoredDocument.create(1, Rank.RankSource.VECTOR, docWithNull, VECTORIZE_LOCATOR);
+    assertThat(nullField.passage()).as("passage missing when field is null").isEmpty();
+
+    var docWithEmpty = baseDocument().put(VECTOR_EMBEDDING_TEXT_FIELD, "");
+    var emptyField =
+        ScoredDocument.create(1, Rank.RankSource.VECTOR, docWithEmpty, VECTORIZE_LOCATOR);
+    assertThat(emptyField.passage()).as("passage missing when field is empty string").isEmpty();
+
+    var docWithBlank = baseDocument().put(VECTOR_EMBEDDING_TEXT_FIELD, " ");
+    var blankField =
+        ScoredDocument.create(1, Rank.RankSource.VECTOR, docWithBlank, VECTORIZE_LOCATOR);
+    assertThat(blankField.passage())
+        .as("passage missing when field is single space (blank)")
+        .isEmpty();
+
+    var textField = ScoredDocument.create(1, Rank.RankSource.VECTOR, DOCUMENT, VECTORIZE_LOCATOR);
+    assertThat(textField.passage())
+        .as("passage is present and correct when field is a string")
+        .isPresent()
+        .hasValue(PASSAGE);
+
+    var docWithNumber = baseDocument().put(VECTOR_EMBEDDING_TEXT_FIELD, 1);
+    var numberField =
+        ScoredDocument.create(1, Rank.RankSource.VECTOR, docWithNumber, VECTORIZE_LOCATOR);
+    assertThat(numberField.passage())
+        .as("passage is present and correct when field is a number")
+        .isPresent()
+        .hasValue("1");
+
+    var docWithBoolean = baseDocument().put(VECTOR_EMBEDDING_TEXT_FIELD, true);
+    var booleanField =
+        ScoredDocument.create(1, Rank.RankSource.VECTOR, docWithBoolean, VECTORIZE_LOCATOR);
+    assertThat(booleanField.passage())
+        .as("passage is present and correct when field is a boolean")
+        .isPresent()
+        .hasValue("true");
+
+    var docWithObjectPassage = baseDocument();
+    docWithObjectPassage.putObject(VECTOR_EMBEDDING_TEXT_FIELD);
+    assertThatThrownBy(
+            () ->
+                ScoredDocument.create(
+                    1, Rank.RankSource.VECTOR, docWithObjectPassage, VECTORIZE_LOCATOR))
+        .as("Cannot use object as passage node")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Passage field %s is present but not null or a valueNode _id=%s , passageField=%s"
+                .formatted(
+                    VECTOR_EMBEDDING_TEXT_FIELD,
+                    ID_1,
+                    docWithObjectPassage.get(VECTOR_EMBEDDING_TEXT_FIELD)));
+
+    var docWithArrayPassage = baseDocument();
+    docWithArrayPassage.putArray(VECTOR_EMBEDDING_TEXT_FIELD);
+    assertThatThrownBy(
+            () ->
+                ScoredDocument.create(
+                    1, Rank.RankSource.VECTOR, docWithArrayPassage, VECTORIZE_LOCATOR))
+        .as("Cannot use array as passage node")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Passage field %s is present but not null or a valueNode _id=%s , passageField=%s"
+                .formatted(
+                    VECTOR_EMBEDDING_TEXT_FIELD,
+                    ID_1,
+                    docWithArrayPassage.get(VECTOR_EMBEDDING_TEXT_FIELD)));
   }
 }


### PR DESCRIPTION
(existing) if vectorize was used in findAndRerank we use that query as the query to rerank on, otherwise use rerankOn option

no matter what, when we get the node to rerank on if it is a value node (text, number , etc) we get the text value of it.

if null or empty string or not defined we drop the doc and do not rerank

otherwise (present but array or object) we error

passage extraction is tested in unit tests, see ScoredDocumentTests

# Examples: 

Inserting 

```json
{
    "insertMany": {
        "documents": [
            {
                "_id": 1,
                "$vectorize": "I like cheese",
                "$lexical": "cheese cows milk",
                "name": "Alice",
                "country": "NZ",
                "age": 40,
                "meta" : {
                    "content" : "I like cheese"
                }
            },
            {
                "_id": 2,
                "$vectorize": "I like monkeys",
                "$lexical": "monkeys bananas",
                "name": "Aaron",
                "country": "NZ",
                "age": 50,
                "meta" : {
                    "content" : "I like monkeys"
                }
            },
            {
                "_id": 3,
                "$vectorize": "I have a neutral opinion on both cheese and monkeys",
                "$lexical": "cheese cows milk monkeys bananas",
                "name": "Bob",
                "country": "AUS",
                "age": 60,
                "meta" : {
                    "content" : "I have a neutral opinion on both cheese and monkeys"
                }
            },
            {
                "_id": 4,
                "$lexical": "cheese cows milk monkeys bananas",
                "name": "Charlie - no vector",
                "country": "AUS",
                "age": 70,
                "meta" : {
                    "content" : 1
                }
            }
        ]
    }
}
```


Reading, not passing a vector, using rerankOn, and the rerankOn value for doc 4 is an integer 

```json
{
    "findAndRerank": {
        "filter": {},
        "projection": {
            "_id": 1,
            "name": 1,
            "$vectorize": 1,
            "meta": 1
        },
        "sort": {
            "$hybrid": {
                "$lexical": "monkeys",
                "$vector": [
                    0.030776024,
                    
                    0.008515012
                ]
            }
        },
        "options": {
            "rerankQuery": "I like cheese",
            "rerankOn": "meta.content",
            "limit": 10,
            "hybridLimits" : {
                "$lexical" : 10,
                "$vector" : 14
            },
            "includeScores": true,
            "includeSortVector": false
        }
    }
}
```

Returns: 
Includes doc 4 , even though it was ranked 2 by BMM the Reranker put it last 

```json
{
    "data": {
        "documents": [
            {
                "_id": 1,
                "$vectorize": "I like cheese",
                "name": "Alice",
                "meta": {
                    "content": "I like cheese"
                }
            },
            {
                "_id": 3,
                "$vectorize": "I have a neutral opinion on both cheese and monkeys",
                "name": "Bob",
                "meta": {
                    "content": "I have a neutral opinion on both cheese and monkeys"
                }
            },
            {
                "_id": 2,
                "$vectorize": "I like monkeys",
                "name": "Aaron",
                "meta": {
                    "content": "I like monkeys"
                }
            },
            {
                "_id": 4,
                "name": "Charlie - no vector",
                "meta": {
                    "content": 1
                }
            }
        ],
        "nextPageState": null
    },
    "status": {
"documentResponses": [
            {
                "scores": {
                    "$rerank": 9.1015625,
                    "$vector": 0.7426339,
                    "$vectorRank": 3,
                    "$bm25Rank": null,
                    "$rrf": 0.015873017
                }
            },
            {
                "scores": {
                    "$rerank": 1.0664062,
                    "$vector": 0.8216057,
                    "$vectorRank": 2,
                    "$bm25Rank": 3,
                    "$rrf": 0.032002047
                }
            },
            {
                "scores": {
                    "$rerank": -5.6875,
                    "$vector": 1.0,
                    "$vectorRank": 1,
                    "$bm25Rank": 1,
                    "$rrf": 0.032786883
                }
            },
            {
                "scores": {
                    "$rerank": -7.9648438,
                    "$vector": -2.1474836E9,
                    "$vectorRank": null,
                    "$bm25Rank": 2,
                    "$rrf": 0.016129032
                }
            }
        ]
    }
}
```

Tracing shows the rerank passage for doc 4 was "1", text value of it's numeric node value for `meta.content`

```json
 {
    "TraceEvent": {
        "eventId": "01961281-f240-73c5-b6d1-b7da1e8a5b84",
        "timestamp": "2025-04-07T23:07:08.224896Z",
        "elapsedMicroseconds": 375373.0,
        "message": "De-duplicated for reranking, reads=2, total documents=6, dropped documents=0, deduplicated documents=4",
        "data": null
    }
},
{
    "TraceEvent": {
        "eventId": "01961281-f241-7ed0-b6ce-c13cc8026618",
        "timestamp": "2025-04-07T23:07:08.225159Z",
        "elapsedMicroseconds": 375640.0,
        "message": "Reranking 4 passages using NvidiaRerankingProvider with model nvidia/llama-3.2-nv-rerankqa-1b-v2",
        "data": {
            "RecordableMap": {
                "limit": 10.0,
                "passages": [
                    "I like cheese",
                    "I like monkeys",
                    "I have a neutral opinion on both cheese and monkeys",
                    "1"
                ],
                "query": "I like cheese"
            }
        }
    }
},
{
    "TraceEvent": {
        "eventId": "01961281-f474-700e-a28b-fad927ef2bd4",
        "timestamp": "2025-04-07T23:07:08.788997Z",
        "elapsedMicroseconds": 939481.0,
        "message": "Processing reranking response with 4 scores using NvidiaRerankingProvider with model nvidia/llama-3.2-nv-rerankqa-1b-v2",
        "data": {
            "RecordableMap": {
                "scores": [
                    "Rank[index=0, score=9.1015625]",
                    "Rank[index=1, score=-5.6875]",
                    "Rank[index=2, score=1.0664062]",
                    "Rank[index=3, score=-7.9648438]"
                ]
            }
        }
    }
},
```

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #1954

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
