### PR TITLE
remove empty message for SUPPORTED model in FindRerankingProviders

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderConfigProducer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderConfigProducer.java
@@ -194,7 +194,9 @@ public class RerankingProviderConfigProducer {
                         model.getName(),
                         new ModelSupport.ModelSupportImpl(
                             ModelSupport.SupportStatus.valueOf(model.getModelSupport().getStatus()),
-                            Optional.of(model.getModelSupport().getMessage())),
+                            model.getModelSupport().hasMessage()
+                                ? Optional.of(model.getModelSupport().getMessage())
+                                : Optional.empty()),
                         model.getIsDefault(),
                         model.getUrl(),
                         new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl


### PR DESCRIPTION
The gPRC response from EGW set empty string for model support message when it is not provided.
We need to construct Option.empty(), instead of Option.of("") for the message.

Previous:
```
              "modelSupport": {
                  "status": "SUPPORTED",
                  "message": ""
              },
```

Now:
```
              "modelSupport": {
                  "status": "SUPPORTED"
              },
```


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
