### PR TITLE
(WIP) Fixes #1967: no "sort" on "$hybrid" (for Collections)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializer.java
@@ -15,6 +15,7 @@ import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
 import io.stargate.sgv2.jsonapi.service.schema.collections.DocumentPath;
 import io.stargate.sgv2.jsonapi.service.schema.naming.NamingRules;
+import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,8 +65,9 @@ public class SortClauseDeserializer extends StdDeserializer<SortClause> {
       }
       if (!lexicalValue.isTextual()) {
         throw ErrorCodeV1.INVALID_SORT_CLAUSE.toApiException(
-            "if sorting by '%s' value must be STRING, not %s",
-            DocumentConstants.Fields.LEXICAL_CONTENT_FIELD, lexicalValue.getNodeType());
+            "if sorting by '%s' value must be String, not %s",
+            DocumentConstants.Fields.LEXICAL_CONTENT_FIELD,
+            JsonUtil.nodeTypeAsString(lexicalValue));
       }
       // We cannot yet determine if lexical sort supported by the collection, just
       // construct clause

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializerTest.java
@@ -373,7 +373,7 @@ class SortClauseDeserializerTest {
     }
 
     @Test
-    public void invalidPathName() {
+    public void invalidPathNameOperator() {
       String json =
           """
               {"$gt": 1}
@@ -383,6 +383,41 @@ class SortClauseDeserializerTest {
       assertThat(throwable).isInstanceOf(JsonApiException.class);
       assertThat(throwable)
           .hasMessageContaining("Invalid sort clause path: path ('$gt') cannot start with `$`");
+    }
+
+    // [data-api#1967] - Not allowed to use "$hybrid"; either with 1/-1 or with String
+    @Test
+    public void invalidPathNameHybridWithNumber() {
+      // First test with regular 1/-1 value
+      Throwable t =
+          catchThrowable(
+              () ->
+                  objectMapper.readValue(
+                      """
+                          {"$hybrid": 1}
+                      """,
+                      SortClause.class));
+
+      assertThat(t).isInstanceOf(JsonApiException.class);
+      assertThat(t)
+          .hasMessageContaining("Invalid sort clause path: path ('$hybrid') cannot start with `$`");
+    }
+
+    // [data-api#1967] - Not allowed to use "$hybrid"; either with 1/-1 or with String
+    @Test
+    public void invalidPathNameHybridWithString() {
+      Throwable t =
+          catchThrowable(
+              () ->
+                  objectMapper.readValue(
+                      """
+                  {"$hybrid": "tokens are tasty"}
+              """,
+                      SortClause.class));
+
+      assertThat(t).isInstanceOf(JsonApiException.class);
+      assertThat(t)
+          .hasMessageContaining("Invalid sort clause path: path ('$hybrid') cannot start with `$`");
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Adds checks to prevent Collection "sort" on "$hybrid" pseudo-field.

**Which issue(s) this PR fixes**:
Fixes #1967

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
