### PR TITLE
fixes #2000 support $includeScores=false

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/DocumentScores.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/DocumentScores.java
@@ -50,6 +50,16 @@ public class DocumentScores implements Comparable<DocumentScores> {
         Score.RRFScore.create(rank));
   }
 
+  /** When we did a ANN read, but do not have the similarity score */
+  static DocumentScores fromVectorRead(int rank) {
+    return new DocumentScores(
+        Score.EMPTY_RERANK_SCORE,
+        Score.EMPTY_VECTOR_SCORE,
+        Rank.vectorRank(rank),
+        Rank.EMPTY_BM25_RANK,
+        Score.RRFScore.create(rank));
+  }
+
   static DocumentScores fromReranking(float rerank) {
     return new DocumentScores(
         Score.rerankScore(rerank),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/ScoredDocument.java
@@ -92,7 +92,11 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
     DocumentScores vectorScores;
     var similarityField = document.get(VECTOR_FUNCTION_SIMILARITY_FIELD);
     if (rankSource == Rank.RankSource.VECTOR) {
-      if (similarityField instanceof NumericNode numberNode) {
+      if (similarityField == null) {
+        // this can happen when the scores are not going to be returned, OK we only need the rank
+        // for RRF
+        vectorScores = DocumentScores.fromVectorRead(rank);
+      } else if (similarityField instanceof NumericNode numberNode) {
         vectorScores = DocumentScores.fromVectorRead(numberNode.floatValue(), rank);
       } else {
         throw new IllegalArgumentException(
@@ -105,7 +109,7 @@ public class ScoredDocument implements Comparable<ScoredDocument> {
     } else {
       if (similarityField != null) {
         throw new IllegalArgumentException(
-            "rankSource is %s but the document with id '%s' has %s field=%s"
+            "rankSource is %s but the document has similarity score id=%s has %s=%s"
                 .formatted(
                     rankSource, documentId, VECTOR_FUNCTION_SIMILARITY_FIELD, similarityField));
       }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/reranking/DocumentScoresTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/reranking/DocumentScoresTests.java
@@ -37,6 +37,18 @@ public class DocumentScoresTests {
   }
 
   @Test
+  public void testComparisonSameRerankingWithVectorRankOnly() {
+    // duplicate scores tend to be negative
+    // testing what happens with duplicates and only a vector read
+    // note only the RANK of the vector is used with the RRF
+    var score1 = DocumentScores.fromReranking(-18.765f).merge(DocumentScores.fromVectorRead(1));
+    var score2 = DocumentScores.fromReranking(-18.765f).merge(DocumentScores.fromVectorRead(5));
+    var score3 = DocumentScores.fromReranking(-18.765f).merge(DocumentScores.fromVectorRead(10));
+
+    ScoreTests.threewayScoreComparison(score1, score2, score3);
+  }
+
+  @Test
   public void testComparisonSameRerankingWithBM25Only() {
     // duplicate scores tend to be negative
     // testing what happens with duplicates and only a BM25 read


### PR DESCRIPTION
bug in findAndRerank would error when includeScores = false

added support in the ScoredDocument so that if we are doing the ANN read, and we do not have the similarity score, we still track the rank of the ANN read because we need this for the RRF score to tie break the reranking score


**Which issue(s) this PR fixes**:
Fixes #2000

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
