### PR TITLE
Add simple IT to check that stemming/stop-word config works for $lexical Collection

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
@@ -104,6 +104,35 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
     }
 
     @Test
+    void createLexicalAdvancedCustom() {
+      Assumptions.assumeTrue(isLexicalAvailableForDB());
+
+      final String collectionName = "coll_lexical_advanced_" + RandomStringUtils.randomNumeric(16);
+      String json =
+          createRequestWithLexical(
+              collectionName,
+              """
+                      {
+                        "enabled": true,
+                        "analyzer": {
+                          "tokenizer" : {"name" : "standard"},
+                          "filters": [
+                            { "name": "lowercase" },
+                            { "name": "stop" },
+                            { "name": "porterstem" },
+                            { "name": "asciifolding" }
+                          ]
+                          }
+                        }
+                    """);
+
+      givenHeadersPostJsonThenOkNoErrors(json)
+          .body("$", responseIsDDLSuccess())
+          .body("status.ok", is(1));
+      deleteCollection(collectionName);
+    }
+
+    @Test
     void createLexicalSimpleDisabled() {
       // Fine regardless of whether Lexical available for DB or not
 


### PR DESCRIPTION
**What this PR does**:

Adds an IT testing Analyzer config for createCollection(), $lexical

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
