### PR TITLE
Fix, collection DocumentID range filter with different dataType values.

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/matcher/CollectionFilterResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/matcher/CollectionFilterResolver.java
@@ -272,6 +272,23 @@ public class CollectionFilterResolver<T extends Command & Filterable>
                     idRangeGroup.consumeAllCaptures(
                         expression -> {
                           final DocumentId value = (DocumentId) expression.value();
+                          // E.G. {"_id":{"$gt":true}}
+                          if (value.value() instanceof Boolean) {
+                            dbLogicalExpression.addFilter(
+                                new BoolCollectionFilter(
+                                    DocumentConstants.Fields.DOC_ID,
+                                    getMapFilterBaseOperator(expression.operator()),
+                                    (Boolean) value.value()));
+                          }
+                          // E.G. {"_id":{"$gt":"apple"}}
+                          if (value.value() instanceof String) {
+                            dbLogicalExpression.addFilter(
+                                new TextCollectionFilter(
+                                    DocumentConstants.Fields.DOC_ID,
+                                    getMapFilterBaseOperator(expression.operator()),
+                                    (String) value.value()));
+                          }
+                          // E.G. {"_id":{"$gt":123}}
                           if (value.value() instanceof BigDecimal bdv) {
                             dbLogicalExpression.addFilter(
                                 new NumberCollectionFilter(
@@ -279,6 +296,7 @@ public class CollectionFilterResolver<T extends Command & Filterable>
                                     getMapFilterBaseOperator(expression.operator()),
                                     bdv));
                           }
+                          // E.G. {"_id":{"$gt":{"$date":1672531200000}}}
                           if (value.value() instanceof Map) {
                             dbLogicalExpression.addFilter(
                                 new DateCollectionFilter(


### PR DESCRIPTION
This PR will fix the range filter against collection "_id" field.

The correct behavior is to successfully work against Date/String/Boolean/BigDecimal values, and error out as `INVALID_FILTER_EXPRESSION`

E.G. 
- {"_id":{"$gt":true}}
- {"_id":{"$gt":"apple"}}
- {"_id":{"$gt":123}}
- {"_id":{"$gt":{"$date":1672531200000}}}

Also, added parameterize tests to validate.

**Which issue(s) this PR fixes**:
Fixes #1992

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
