### PR TITLE
Fixes #2011: Validate LexicalConfig

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionLexicalConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionLexicalConfig.java
@@ -136,7 +136,7 @@ public record CollectionLexicalConfig(
       if (!foundNames.isEmpty()) {
         throw ErrorCodeV1.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
             "Invalid field%s for 'lexical.analyzer'. Valid fields are: %s, found: %s",
-            (foundNames.size() == 1 ? "" : "s"), VALID_ANALYZER_FIELDS, foundNames);
+            (foundNames.size() == 1 ? "" : "s"), VALID_ANALYZER_FIELDS, new TreeSet<>(foundNames));
       }
       // Second: check basic data types for allowed fields
     } else {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
@@ -253,7 +253,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
           .body(
               "errors[0].message",
               containsString(
-                  "When 'lexical' is disabled, 'lexical.analyzer' must either be omitted, JSON null, or an empty JSON object {}."));
+                  "When 'lexical' is disabled, 'lexical.analyzer' must either be omitted or be JSON null, or"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionWithLexicalIntegrationTest.java
@@ -359,7 +359,7 @@ class CreateCollectionWithLexicalIntegrationTest extends AbstractKeyspaceIntegra
           .body(
               "errors[0].message",
               containsString(
-                  "Invalid fields for 'lexical.analyzer'. Valid fields are: [charFilters, filters, tokenizer], found: [tokeniser, extra]"));
+                  "Invalid fields for 'lexical.analyzer'. Valid fields are: [charFilters, filters, tokenizer], found: [extra, tokeniser]"));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds some validation for Analyzer config for $lexical search in `createCollection`: basically checking that if Object value given for `lexical.analyzer`, it has at most 3 known properties:

* `tokenizer` (JSON Object)
* `filters` (JSON Array)
* `charFilters` (JSON Array)

with expected kinds of values. This is expected to avoid common misspelling style mistakes.

**Which issue(s) this PR fixes**:
Fixes #2011

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
