### PR TITLE
Fixes #2057: findAndRerank, NPE for empty object

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/sort/FindAndRerankSort.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/sort/FindAndRerankSort.java
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public record FindAndRerankSort(String vectorizeSort, String lexicalSort, float[] vectorSort)
     implements Recordable {
 
-  static final FindAndRerankSort NO_ARG_SORT = new FindAndRerankSort(null, null, null);
+  public static final FindAndRerankSort NO_ARG_SORT = new FindAndRerankSort(null, null, null);
 
   @Override
   public DataRecorder recordTo(DataRecorder dataRecorder) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindAndRerankCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindAndRerankCommand.java
@@ -36,6 +36,9 @@ public record FindAndRerankCommand(
     @Valid @JsonProperty("sort") FindAndRerankSort sortClause,
     @Valid @Nullable Options options)
     implements ReadCommand, Filterable, Projectable, Windowable {
+  public FindAndRerankCommand {
+    sortClause = (sortClause == null) ? FindAndRerankSort.NO_ARG_SORT : sortClause;
+  }
 
   // NOTE: is not VectorSortable because it has its own sort clause.
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingQuery.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingQuery.java
@@ -55,13 +55,10 @@ public class RerankingQuery implements Recordable {
       return new RerankingQuery(rerankQuery, Source.OPTIONS);
     }
 
-    var sortClause = command.sortClause();
-    if (sortClause != null) {
-      var vectorizeQuery = sortClause.vectorizeSort();
-      // will never be blank, but double-checking for safety
-      if (vectorizeQuery != null && !vectorizeQuery.isBlank()) {
-        return new RerankingQuery(vectorizeQuery, Source.VECTORIZE);
-      }
+    var vectorizeQuery = command.sortClause().vectorizeSort();
+    // will never be blank, but double-checking for safety
+    if (vectorizeQuery != null && !vectorizeQuery.isBlank()) {
+      return new RerankingQuery(vectorizeQuery, Source.VECTORIZE);
     }
 
     throw RequestException.Code.MISSING_RERANK_QUERY_TEXT.get();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingQuery.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingQuery.java
@@ -55,10 +55,13 @@ public class RerankingQuery implements Recordable {
       return new RerankingQuery(rerankQuery, Source.OPTIONS);
     }
 
-    var vectorizeQuery = command.sortClause().vectorizeSort();
-    // will never be blank, but double checking for safety
-    if (vectorizeQuery != null && !vectorizeQuery.isBlank()) {
-      return new RerankingQuery(vectorizeQuery, Source.VECTORIZE);
+    var sortClause = command.sortClause();
+    if (sortClause != null) {
+      var vectorizeQuery = sortClause.vectorizeSort();
+      // will never be blank, but double-checking for safety
+      if (vectorizeQuery != null && !vectorizeQuery.isBlank()) {
+        return new RerankingQuery(vectorizeQuery, Source.VECTORIZE);
+      }
     }
 
     throw RequestException.Code.MISSING_RERANK_QUERY_TEXT.get();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindAndRerankOperationBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindAndRerankOperationBuilder.java
@@ -400,14 +400,14 @@ class FindAndRerankOperationBuilder {
   }
 
   private boolean isLexicalSort() {
-    return command.sortClause().lexicalSort() != null;
+    return command.sortClause() != null && command.sortClause().lexicalSort() != null;
   }
 
   private boolean isVectorizeSort() {
-    return command.sortClause().vectorizeSort() != null;
+    return command.sortClause() != null && command.sortClause().vectorizeSort() != null;
   }
 
   private boolean isVectorSort() {
-    return command.sortClause().vectorSort() != null;
+    return command.sortClause() != null && command.sortClause().vectorSort() != null;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindAndRerankOperationBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/FindAndRerankOperationBuilder.java
@@ -400,14 +400,14 @@ class FindAndRerankOperationBuilder {
   }
 
   private boolean isLexicalSort() {
-    return command.sortClause() != null && command.sortClause().lexicalSort() != null;
+    return command.sortClause().lexicalSort() != null;
   }
 
   private boolean isVectorizeSort() {
-    return command.sortClause() != null && command.sortClause().vectorizeSort() != null;
+    return command.sortClause().vectorizeSort() != null;
   }
 
   private boolean isVectorSort() {
-    return command.sortClause() != null && command.sortClause().vectorSort() != null;
+    return command.sortClause().vectorSort() != null;
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndRerankCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndRerankCollectionIntegrationTest.java
@@ -98,6 +98,7 @@ public class FindAndRerankCollectionIntegrationTest extends AbstractCollectionIn
         "Lexical search is not enabled for collection");
   }
 
+  // https://github.com/stargate/data-api/issues/2057
   @Test
   void failOnEmptyRequest() {
     // Must not fail for "no lexical available", so skip on DSE

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndRerankCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndRerankCollectionIntegrationTest.java
@@ -9,6 +9,7 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.exception.RequestException;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -99,6 +100,9 @@ public class FindAndRerankCollectionIntegrationTest extends AbstractCollectionIn
 
   @Test
   void failOnEmptyRequest() {
+    // Must not fail for "no lexical available", so skip on DSE
+    Assumptions.assumeTrue(isLexicalAvailableForDB());
+
     String collectionName = "find_rerank_empty_request";
     createCollectionWithCleanup(
         collectionName,

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndRerankCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndRerankCollectionIntegrationTest.java
@@ -1,14 +1,11 @@
 package io.stargate.sgv2.jsonapi.api.v1;
 
-import static io.restassured.RestAssured.given;
-import static io.stargate.sgv2.jsonapi.api.v1.ResponseAssertions.responseIsDDLSuccess;
 import static io.stargate.sgv2.jsonapi.api.v1.ResponseAssertions.responseIsError;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,7 +20,7 @@ import org.junit.jupiter.api.Test;
 @WithTestResource(value = DseTestResource.class, restrictToAnnotatedClass = false)
 public class FindAndRerankCollectionIntegrationTest extends AbstractCollectionIntegrationTestBase {
 
-  // used to cleanup the collection from a previous test, if non null
+  // used to cleanup the collection from a previous test, if non-null
   private String cleanupCollectionName = null;
 
   @BeforeAll
@@ -34,54 +31,10 @@ public class FindAndRerankCollectionIntegrationTest extends AbstractCollectionIn
   @AfterEach
   public void cleanup() {
     if (cleanupCollectionName != null) {
-      var json =
-              """
-          {"dropCollection": {"name": "%s"}}
-          """
-              .formatted(cleanupCollectionName);
-      given()
-          .port(getTestPort())
-          .headers(getHeaders())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(KeyspaceResource.BASE_PATH, keyspaceName)
-          .then()
-          .statusCode(200)
-          .body("$", responseIsDDLSuccess());
+      String toDelete = cleanupCollectionName;
+      cleanupCollectionName = null; // clear out just in case
+      deleteCollection(toDelete);
     }
-  }
-
-  public void errorOnNotEnabled(
-      String collectionName, String collectionSpec, String errorCode, String errorMessageContains) {
-
-    var createCollection = collectionSpec.formatted(collectionName);
-    createComplexCollection(createCollection);
-
-    var rerank =
-        """
-      {"findAndRerank": {
-              "filter": {},
-              "projection": {},
-              "sort": {
-                  "$hybrid": "hybrid sort"
-              },
-              "options": {
-                  "limit" : 10,
-                  "hybridLimits" : 10,
-                  "includeScores": true,
-                  "includeSortVector": false
-              }
-          }
-      }
-      """;
-
-    givenHeadersPostJsonThen(keyspaceName, collectionName, rerank)
-        .body("$", responseIsError())
-        .body("errors[0].errorCode", is(errorCode))
-        .body(
-            "errors[0].message",
-            containsString(errorMessageContains.formatted(keyspaceName, collectionName)));
   }
 
   @Test
@@ -141,5 +94,38 @@ public class FindAndRerankCollectionIntegrationTest extends AbstractCollectionIn
         """,
         "LEXICAL_NOT_ENABLED_FOR_COLLECTION",
         "Lexical search is not enabled for collection");
+  }
+
+  private void errorOnNotEnabled(
+      String collectionName, String collectionSpec, String errorCode, String errorMessageContains) {
+
+    var createCollection = collectionSpec.formatted(collectionName);
+    cleanupCollectionName = collectionName;
+    createComplexCollection(createCollection);
+
+    var rerank =
+        """
+          {"findAndRerank": {
+                  "filter": {},
+                  "projection": {},
+                  "sort": {
+                      "$hybrid": "hybrid sort"
+                  },
+                  "options": {
+                      "limit" : 10,
+                      "hybridLimits" : 10,
+                      "includeScores": true,
+                      "includeSortVector": false
+                  }
+              }
+          }
+          """;
+
+    givenHeadersPostJsonThen(keyspaceName, collectionName, rerank)
+        .body("$", responseIsError())
+        .body("errors[0].errorCode", is(errorCode))
+        .body(
+            "errors[0].message",
+            containsString(errorMessageContains.formatted(keyspaceName, collectionName)));
   }
 }


### PR DESCRIPTION
**What this PR does**:

Fixes NPE thrown for `findAndRerank` request like:

```
{
    "findAndRerank": {}
}
```

**Which issue(s) this PR fixes**:
Fixes #2057

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
