### PR TITLE
Fix #2063: test that max-$lexical length limit is enforced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,12 @@
     </dependency>
     <!-- Test dependencies -->
     <dependency>
+      <groupId>com.github.javafaker</groupId>
+      <artifactId>javafaker</artifactId>
+      <version>1.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertLexicalInCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertLexicalInCollectionIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class InsertLexicalInCollectionIntegrationTest
     extends AbstractCollectionIntegrationTestBase {
-  public static final int MAX_LEXICAL_LENGTH = 8192;
+  private static final int MAX_LEXICAL_LENGTH = 8192;
 
   protected InsertLexicalInCollectionIntegrationTest() {
     super("col_insert_lexical_");

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertLexicalInCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertLexicalInCollectionIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.is;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.exception.ErrorCodeV1;
+import io.stargate.sgv2.jsonapi.fixtures.TestTextUtil;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.ClassOrderer;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class InsertLexicalInCollectionIntegrationTest
     extends AbstractCollectionIntegrationTestBase {
+  public static final int MAX_LEXICAL_LENGTH = 8192;
+
   protected InsertLexicalInCollectionIntegrationTest() {
     super("col_insert_lexical_");
   }
@@ -164,6 +167,30 @@ public class InsertLexicalInCollectionIntegrationTest
     }
 
     @Test
+    public void insertDocWithLongestLexicalOk() {
+      final String docId = "lexical-long-ok";
+      final String text = TestTextUtil.generateTextDoc(MAX_LEXICAL_LENGTH, " ");
+      String doc =
+              """
+              {
+                "_id": "%s",
+                "$lexical": "%s"
+              }
+              """
+              .formatted(docId, text);
+
+      givenHeadersPostJsonThenOkNoErrors("{ \"insertOne\": {  \"document\": %s }}".formatted(doc))
+          .body("$", responseIsWriteSuccess())
+          .body("status.insertedIds[0]", is(docId));
+
+      givenHeadersPostJsonThenOkNoErrors(
+              "{ \"find\": { \"filter\" : { \"_id\" : \"%s\"}}}}".formatted(docId))
+          .body("$", responseIsFindSuccess())
+          // NOTE: "$lexical" is not included in the response by default, ensure
+          .body("data.documents", hasSize(1));
+    }
+
+    @Test
     public void failInsertDocWithLexicalIfNotEnabled() {
       final String COLLECTION_WITHOUT_LEXICAL =
           "coll_insert_no_lexical_" + RandomStringUtils.randomNumeric(16);
@@ -199,6 +226,32 @@ public class InsertLexicalInCollectionIntegrationTest
 
       // And finally, drop the Collection after use
       deleteCollection(COLLECTION_WITHOUT_LEXICAL);
+    }
+
+    @Test
+    public void failInsertDocWithTooLongLexical() {
+      final String docId = "lexical-too-long";
+      // Limit not based on the length of the string, but on total length of unique
+      // tokens. So need to guesstimate "too big" size
+      final String text = TestTextUtil.generateTextDoc((int) (MAX_LEXICAL_LENGTH * 1.5), " ");
+      String doc =
+              """
+              {
+                "_id": "%s",
+                "$lexical": "%s"
+              }
+              """
+              .formatted(docId, text);
+
+      givenHeadersPostJsonThenOk("{ \"insertOne\": {  \"document\": %s }}".formatted(doc))
+          .body("$", responseIsWritePartialSuccess())
+          .body("errors", hasSize(1))
+          // !!! TODO: not rely on DB error, but enforce our own limits
+          .body("errors[0].errorCode", is("INVALID_QUERY"))
+          .body(
+              "errors[0].message",
+              containsString(
+                  "Term's analyzed size for column query_lexical_value exceeds the cumulative limit for index"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/fixtures/TestTextUtil.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/fixtures/TestTextUtil.java
@@ -1,0 +1,23 @@
+package io.stargate.sgv2.jsonapi.fixtures;
+
+import com.github.javafaker.Faker;
+
+/** Helper methods for generating textual data for use in the tests. */
+public class TestTextUtil {
+  /**
+   * Helper method for generating a Document with exactly specified length (in characters), composed
+   * of Latin words in "Lorem Ipsum" style.
+   *
+   * @param targetLength Exact length of the generated string
+   * @param separator Separator between sentences.
+   */
+  public static String generateTextDoc(int targetLength, String separator) {
+    Faker faker = new Faker();
+    StringBuilder sb = new StringBuilder(targetLength + 100);
+
+    while (sb.length() < targetLength) {
+      sb.append(faker.lorem().sentence()).append(separator);
+    }
+    return sb.substring(0, targetLength);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/StargateTestResource.java
@@ -191,7 +191,9 @@ public abstract class StargateTestResource
         "-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.load_ring_state=false -Dcassandra.initial_token=1 -Dcassandra.sai.max_string_term_size_kb=8"
             // 18-Mar-2025, tatu: to work around [https://github.com/riptano/cndb/issues/13330],
             // need to temporarily add this for HCD:
-            + " -Dcassandra.cluster_version_provider.min_stable_duration_ms=-1";
+            + " -Dcassandra.cluster_version_provider.min_stable_duration_ms=-1"
+            // 02-May-2025, tatu: [data-api#2063] force checking of max analyzed text length
+            + " -Dcassandra.sai.validate_max_term_size_at_coordinator=true";
     container
         .withEnv("HEAP_NEWSIZE", "512M")
         .withEnv("MAX_HEAP_SIZE", "2048M")


### PR DESCRIPTION
**What this PR does**:

Adds Integration Tests to verify that maximum length for `$lexical` is enforced.

When writing test it was found out that although there is validation:

1. Exceeding the limit only prevents indexing but DOES NOT FAIL Insert query (by default)
2. Limit checked is NOT simple text length check but calculated on tokenized terms' length: allowing typically somewhat longer content to be indexed (dup tokens removed etc) -- so test needs to use somewhat bigger content to trigger fail.

To solve (1) there is a system property we can set for tests, but also probably want to get added in production (but that may be longer process wrt compatibility constrainsts).

(2) is just a constraints for now.

Further, this PR does not yet add mapping from DB failure into nicer errors -- need a follow-up for that.

**Which issue(s) this PR fixes**:
Fixes #2063

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
