### PR TITLE
Fixes #2068: map INVALID_QUERY into proper LEXICAL_CONTENT_TOO_BIG

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCodeV1.java
@@ -166,6 +166,8 @@ public enum ErrorCodeV1 {
 
   LEXICAL_NOT_AVAILABLE_FOR_DATABASE("Lexical search is not available on this database"),
   LEXICAL_NOT_ENABLED_FOR_COLLECTION("Lexical search is not enabled for the collection"),
+  LEXICAL_CONTENT_TOO_BIG(
+      "Lexical content is too big, please use a smaller value for the $lexical field"),
 
   HYBRID_FIELD_CONFLICT(
       "The '$hybrid' field cannot be used with '$lexical', '$vector', or '$vectorize'."),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -193,6 +193,13 @@ public final class ThrowableToErrorMapper {
           .toApiException()
           .getCommandResultError(message, Response.Status.OK);
     }
+    // [data-api#2068]: Need to convert Lexical-value-too-big failure to something more meaningful
+    if (message.contains(
+        "analyzed size for column query_lexical_value exceeds the cumulative limit for index")) {
+      return ErrorCodeV1.LEXICAL_CONTENT_TOO_BIG
+          .toApiException()
+          .getCommandResultError(Response.Status.OK);
+    }
     return ErrorCodeV1.INVALID_QUERY
         .toApiException()
         .getCommandResultError(message, Response.Status.OK);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertLexicalInCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertLexicalInCollectionIntegrationTest.java
@@ -246,12 +246,8 @@ public class InsertLexicalInCollectionIntegrationTest
       givenHeadersPostJsonThenOk("{ \"insertOne\": {  \"document\": %s }}".formatted(doc))
           .body("$", responseIsWritePartialSuccess())
           .body("errors", hasSize(1))
-          // !!! TODO: not rely on DB error, but enforce our own limits
-          .body("errors[0].errorCode", is("INVALID_QUERY"))
-          .body(
-              "errors[0].message",
-              containsString(
-                  "Term's analyzed size for column query_lexical_value exceeds the cumulative limit for index"));
+          .body("errors[0].errorCode", is(ErrorCodeV1.LEXICAL_CONTENT_TOO_BIG.name()))
+          .body("errors[0].message", containsString("Lexical content is too big"));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Maps `QueryValidationException` with specific message into `LEXICAL_CONTENT_TOO_BIG` to give better message to caller, in case where `$lexical` value exceeds maximum indexable size.

**Which issue(s) this PR fixes**:
Fixes #2068

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
