### PR TITLE
Fixes #2056 stop publishing metric histograms

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/metrics/MetricsConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/metrics/MetricsConstants.java
@@ -6,16 +6,17 @@ public interface MetricsConstants {
   String UNKNOWN_VALUE = "unknown";
 
   /** Defines common tag keys used across various metrics. */
-  interface Tags {
+  interface MetricTags {
     String KEYSPACE_TAG = "keyspace";
     String RERANKING_PROVIDER_TAG = "reranking.provider";
     String RERANKING_MODEL_TAG = "reranking.model";
+    String SESSION_TAG = "session";
     String TENANT_TAG = "tenant";
     String TABLE_TAG = "table";
   }
 
   /** Defines metric names that used in the DataAPI */
-  interface Metrics {
+  interface MetricNames {
     String HTTP_SERVER_REQUESTS = "http.server.requests";
     String RERANK_ALL_CALL_DURATION_METRIC = "rerank.all.call.duration";
     String RERANK_ALL_PASSAGE_COUNT_METRIC = "rerank.all.passage.count";

--- a/src/main/java/io/stargate/sgv2/jsonapi/metrics/MicrometerConfiguration.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/metrics/MicrometerConfiguration.java
@@ -1,10 +1,5 @@
 package io.stargate.sgv2.jsonapi.metrics;
 
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Metrics.HTTP_SERVER_REQUESTS;
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Metrics.RERANK_ALL_CALL_DURATION_METRIC;
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Metrics.RERANK_TENANT_CALL_DURATION_METRIC;
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Metrics.VECTORIZE_CALL_DURATION_METRIC;
-
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -13,10 +8,16 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.smallrye.config.SmallRyeConfig;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.MetricsConfig;
 import jakarta.enterprise.inject.Produces;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.MetricTags.SESSION_TAG;
+import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.MetricTags.TENANT_TAG;
 
 /**
  * Centralized configuration of Micrometer {@link MeterFilter}s.
@@ -25,15 +26,13 @@ import org.eclipse.microprofile.config.ConfigProvider;
  *
  * <ul>
  *   <li>Apply global tags (e.g., {@code module=sgv2-jsonapi}) to all metrics based on configuration
- *       provided by {@link MetricsConfig}.
- *   <li>Configure distribution statistics (client-side percentiles, Prometheus histogram buckets)
- *       for specific timer metrics using constants defined in {@link MetricsConstants}.
+ *       provided by {@link MetricsConfig}, see {@link #globalTagsMeterFilter()}.</li>
+ *   <li>Configure distribution statistics percentiles for timer metrics such as HTTP server
+ *   see {@link #configureDistributionStatistics()}.</li>
  * </ul>
  */
-public final class MicrometerConfiguration {
-
-  // Private constructor to prevent instantiation
-  private MicrometerConfiguration() {}
+public class MicrometerConfiguration {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicrometerConfiguration.class);
 
   /**
    * Produces a meter filter that applies configured global tags (e.g., {@code module=sgv2-jsonapi})
@@ -43,6 +42,7 @@ public final class MicrometerConfiguration {
    *     are configured.
    */
   @Produces
+  @SuppressWarnings("unused")
   public MeterFilter globalTagsMeterFilter() {
     MetricsConfig metricsConfig =
         ConfigProvider.getConfig()
@@ -50,15 +50,14 @@ public final class MicrometerConfiguration {
             .getConfigMapping(MetricsConfig.class);
 
     Map<String, String> globalTags = metricsConfig.globalTags();
+    LOGGER.info("Configuring metrics with common global tags: {}", globalTags);
 
     // if we have no global tags, use empty (no-op filter)
     if (null == globalTags || globalTags.isEmpty()) {
       return new MeterFilter() {};
     }
 
-    // transform to tags
-    Collection<Tag> tags =
-        globalTags.entrySet().stream()
+    var tags = globalTags.entrySet().stream()
             .map(e -> Tag.of(e.getKey(), e.getValue()))
             .collect(Collectors.toList());
 
@@ -70,72 +69,78 @@ public final class MicrometerConfiguration {
   }
 
   /**
-   * Produces a meter filter to configure distribution statistics for key timer metrics such as HTTP
+   * Produces a meter filter to configure distribution statistics for timer metrics such as HTTP
    * server requests, vectorization duration, and reranking calls.
    *
-   * <p>This filter enables Prometheus-compatible histogram buckets (allowing server-side {@code
-   * histogram_quantile} calculations) and configures specific client-side percentiles.
+   * <p>
+   * Tests in {@link MicrometerConfigurationTests} show what is expected to output for the different
+   * metric types.
    *
-   * <p>The percentile configuration strategy aims to balance detail with monitoring system load,
-   * particularly concerning metric cardinality:
+   * </p>
+   * <p>For all distribution metrics, we supress the full histogram buckets to reduce overhead. And then
+   * we configure the percentiles based on the metric type:
    *
    * <ul>
-   *   <li>Metrics with high-cardinality tags (e.g., including {@code tenant}) like {@value
-   *       MetricsConstants.Metrics#RERANK_TENANT_CALL_DURATION_METRIC} are configured with a
-   *       limited set of essential percentiles (e.g., P98) to minimize overhead.
-   *   <li>Metrics aggregated across tenants or with lower cardinality tags, such as {@value
-   *       MetricsConstants.Metrics#HTTP_SERVER_REQUESTS} and {@value
-   *       MetricsConstants.Metrics#RERANK_ALL_CALL_DURATION_METRIC}, receive a more comprehensive
-   *       set of standard percentiles (e.g., P50, P90, P95, P99).
+   *   <li>Per tenant metrics (see {@link IsPerTenantPredicate}) have fewer percentiles because there will be
+   *   many more metrics of these types. </li>
+   *   <li>Non per tenant metrics have more percentiles because they are less numerous.</li>
    * </ul>
-   *
-   * Note: The percentiles Pxx correspond to the quantiles 0.xx used in configuration.
+   * This is applied to all metrics, including the driver metrics.
    *
    * @return A {@link MeterFilter} for configuring distribution statistics.
    */
   @Produces
+  @SuppressWarnings("unused")
   public MeterFilter configureDistributionStatistics() {
-    // --- Define Percentile Values ---
-    final double[] allTenantLatencyPercentiles = {0.5, 0.90, 0.95, 0.99};
-    final double[] perTenantLatencyPercentiles = {0.98};
 
-    // --- Create A Map For Value Look Up ---
-    final Map<String, double[]> percentileConfigs =
-        Map.of(
-            HTTP_SERVER_REQUESTS,
-            allTenantLatencyPercentiles,
-            VECTORIZE_CALL_DURATION_METRIC,
-            allTenantLatencyPercentiles,
-            RERANK_TENANT_CALL_DURATION_METRIC,
-            perTenantLatencyPercentiles,
-            RERANK_ALL_CALL_DURATION_METRIC,
-            allTenantLatencyPercentiles);
+    final double[] allTenantLatencyPercentiles = {0.5, 0.90, 0.95, 0.98, 0.99};
+    final double[] perTenantLatencyPercentiles = {0.5, 0.98, 0.99};
+    final Predicate<Meter.Id> isPerTenantPredicate = new IsPerTenantPredicate();
 
     return new MeterFilter() {
       @Override
-      public DistributionStatisticConfig configure(
-          Meter.Id id, DistributionStatisticConfig config) {
+      public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
 
-        // Look up using the above map to find the specific percentiles for the metric
-        double[] specificPercentiles = percentileConfigs.get(id.getName());
-
-        // If a specific configuration was found for this metric name
-        if (specificPercentiles != null) {
-          return DistributionStatisticConfig.builder()
-              .percentiles(specificPercentiles)
-              // Enable Prometheus histogram buckets (_bucket metrics) for this timer.
-              // This allows accurate server-side aggregation and enables the use of
-              // Prometheus's histogram_quantile() function for flexible quantile querying
-              // in Grafana, complementing the fixed client-side percentiles.
-              .percentilesHistogram(true)
-              .build()
-              // Merge the specific config with the existing/default config
-              .merge(config);
+        var builder = DistributionStatisticConfig.builder();
+        if (isPerTenantPredicate.test(id)){
+          builder = builder.percentiles(perTenantLatencyPercentiles);
+        }
+        else {
+          builder = builder.percentiles(allTenantLatencyPercentiles);
         }
 
-        // For all other metrics, return the default configuration
-        return config;
+        // make sure we do not publish the histogram buckets for all distribution metrics
+        // that can be 70 lines long for a single metric, and we don't need them because we have calc'd
+        // the percentiles
+        builder = builder.percentilesHistogram(false);
+
+        return builder
+            .build()
+            .merge(config);
       }
     };
+  }
+
+  static class IsPerTenantPredicate implements Predicate<Meter.Id>{
+
+    @Override
+    public boolean test(Meter.Id id) {
+
+      // if the Metric has a "tenant" or "session" tag we assume it is a per-tenant metric
+      // the API code will use tenant, the Driver uses session
+      // getTags() iterates over the tags, but there will never be too many for it to be a problem
+      // and sanity check they are not blank strings
+
+      var tenantTag =  id.getTag(TENANT_TAG);
+      if (tenantTag != null && !tenantTag.isBlank()) {
+        return true;
+      }
+
+      var sessionTag =  id.getTag(SESSION_TAG);
+      if (sessionTag != null && !sessionTag.isBlank()) {
+        return true;
+      }
+      return false;
+    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProvider.java
@@ -1,6 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Tags.TENANT_TAG;
+import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.MetricTags.TENANT_TAG;
 import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.UNKNOWN_VALUE;
 
 import com.google.common.collect.Lists;
@@ -104,7 +104,7 @@ public class MeteredEmbeddingProvider extends EmbeddingProvider {
             () ->
                 sample.stop(
                     meterRegistry.timer(
-                        MetricsConstants.Metrics.VECTORIZE_CALL_DURATION_METRIC, tags)));
+                        MetricsConstants.MetricNames.VECTORIZE_CALL_DURATION_METRIC, tags)));
   }
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingMetrics.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/reranking/RerankingMetrics.java
@@ -1,7 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.operation.reranking;
 
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Metrics.*;
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Tags.*;
+import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.MetricNames.*;
+import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.MetricTags.*;
 import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.UNKNOWN_VALUE;
 import static io.stargate.sgv2.jsonapi.util.ClassUtils.classSimpleName;
 
@@ -72,12 +72,12 @@ public class RerankingMetrics {
    * <p>This involves recording the count against two distinct metrics:
    *
    * <ul>
-   *   <li>Tenant-specific: {@value MetricsConstants.Metrics#RERANK_TENANT_PASSAGE_COUNT_METRIC}
-   *       with tags {@value MetricsConstants.Tags#TENANT_TAG} and {@value
-   *       MetricsConstants.Tags#TABLE_TAG}.
-   *   <li>Overall: {@value MetricsConstants.Metrics#RERANK_ALL_PASSAGE_COUNT_METRIC} with tags
-   *       {@value MetricsConstants.Tags#RERANKING_PROVIDER_TAG} and {@value
-   *       MetricsConstants.Tags#RERANKING_MODEL_TAG}.
+   *   <li>Tenant-specific: {@value MetricsConstants.MetricNames#RERANK_TENANT_PASSAGE_COUNT_METRIC}
+   *       with tags {@value MetricsConstants.MetricTags#TENANT_TAG} and {@value
+   *       MetricsConstants.MetricTags#TABLE_TAG}.
+   *   <li>Overall: {@value MetricsConstants.MetricNames#RERANK_ALL_PASSAGE_COUNT_METRIC} with tags
+   *       {@value MetricsConstants.MetricTags#RERANKING_PROVIDER_TAG} and {@value
+   *       MetricsConstants.MetricTags#RERANKING_MODEL_TAG}.
    * </ul>
    *
    * @param passageCount The number of passages.
@@ -120,12 +120,12 @@ public class RerankingMetrics {
    * <p>This ensures the identical duration value is recorded for:
    *
    * <ul>
-   *   <li>Tenant-specific: {@value MetricsConstants.Metrics#RERANK_TENANT_CALL_DURATION_METRIC}
-   *       with tags {@value MetricsConstants.Tags#TENANT_TAG} and {@value
-   *       MetricsConstants.Tags#TABLE_TAG}.
-   *   <li>Overall: {@value MetricsConstants.Metrics#RERANK_ALL_CALL_DURATION_METRIC} with tags
-   *       {@value MetricsConstants.Tags#RERANKING_PROVIDER_TAG} and {@value
-   *       MetricsConstants.Tags#RERANKING_MODEL_TAG}.
+   *   <li>Tenant-specific: {@value MetricsConstants.MetricNames#RERANK_TENANT_CALL_DURATION_METRIC}
+   *       with tags {@value MetricsConstants.MetricTags#TENANT_TAG} and {@value
+   *       MetricsConstants.MetricTags#TABLE_TAG}.
+   *   <li>Overall: {@value MetricsConstants.MetricNames#RERANK_ALL_CALL_DURATION_METRIC} with tags
+   *       {@value MetricsConstants.MetricTags#RERANKING_PROVIDER_TAG} and {@value
+   *       MetricsConstants.MetricTags#RERANKING_MODEL_TAG}.
    * </ul>
    *
    * @param sample The {@link Timer.Sample} started by {@link #startCallLatency()}. Must not be

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CommandResolver.java
@@ -2,7 +2,7 @@ package io.stargate.sgv2.jsonapi.service.resolver;
 
 import static io.stargate.sgv2.jsonapi.exception.ErrorFormatters.errFmtJoin;
 import static io.stargate.sgv2.jsonapi.exception.ErrorFormatters.errVars;
-import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.Tags.TENANT_TAG;
+import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.MetricTags.TENANT_TAG;
 import static io.stargate.sgv2.jsonapi.metrics.MetricsConstants.UNKNOWN_VALUE;
 
 import io.micrometer.core.instrument.MeterRegistry;

--- a/src/test/java/io/stargate/sgv2/jsonapi/metrics/MicrometerConfigurationTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/metrics/MicrometerConfigurationTests.java
@@ -1,0 +1,254 @@
+package io.stargate.sgv2.jsonapi.metrics;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.*;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MicrometerConfigurationTests {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicrometerConfigurationTests.class);
+
+
+  private static final JsonFactory JSON_FACTORY = JsonFactory.builder()
+      .enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
+      .build();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(JSON_FACTORY);
+
+  @Test
+  public void allTenantTimerPercentiles(){
+
+    var registry = newRegistry();
+    var timer = registry.timer("all.tenant.metric", "tag1", "value1");
+    fillMetric(timer);
+
+    var expected = """
+    all_tenant_metric_seconds{tag1="value1",quantile="0.5",} 1.040154624
+    all_tenant_metric_seconds{tag1="value1",quantile="0.9",} 1.81190656
+    all_tenant_metric_seconds{tag1="value1",quantile="0.95",} 1.946124288
+    all_tenant_metric_seconds{tag1="value1",quantile="0.98",} 2.013233152
+    all_tenant_metric_seconds{tag1="value1",quantile="0.99",} 2.013233152
+    all_tenant_metric_seconds_count{tag1="value1",} 5120.0
+    all_tenant_metric_seconds_sum{tag1="value1",} 5180.291
+    all_tenant_metric_seconds_max{tag1="value1",} 2.0
+    """;
+    assertPublishing(registry, expected, "all tenant timer");
+  }
+
+  @Test
+  public void perTenantTimerPercentiles(){
+
+    var registry = newRegistry();
+    var timer = registry.timer("per.tenant.metric", "tag1", "value1", "tenant", "1234");
+    fillMetric(timer);
+
+    var expected = """
+    per_tenant_metric_seconds{tag1="value1",tenant="1234",quantile="0.5",} 1.040154624
+    per_tenant_metric_seconds{tag1="value1",tenant="1234",quantile="0.98",} 2.013233152
+    per_tenant_metric_seconds{tag1="value1",tenant="1234",quantile="0.99",} 2.013233152
+    per_tenant_metric_seconds_count{tag1="value1",tenant="1234",} 5120.0
+    per_tenant_metric_seconds_sum{tag1="value1",tenant="1234",} 5180.291
+    per_tenant_metric_seconds_max{tag1="value1",tenant="1234",} 2.0
+    """;
+    assertPublishing(registry, expected, "per tenant timer");
+  }
+
+
+  @Test
+  public void perSessionTimerPercentiles(){
+
+    var registry = newRegistry();
+    var timer = registry.timer("per.session.metric", "tag1", "value1", "session", "1234");
+    fillMetric(timer);
+
+    var expected = """
+    per_session_metric_seconds{session="1234",tag1="value1",quantile="0.5",} 1.040154624
+    per_session_metric_seconds{session="1234",tag1="value1",quantile="0.98",} 2.013233152
+    per_session_metric_seconds{session="1234",tag1="value1",quantile="0.99",} 2.013233152
+    per_session_metric_seconds_count{session="1234",tag1="value1",} 5120.0
+    per_session_metric_seconds_sum{session="1234",tag1="value1",} 5180.291
+    per_session_metric_seconds_max{session="1234",tag1="value1",} 2.0
+    """;
+    assertPublishing(registry, expected, "per session timer");
+  }
+  
+  @Test
+  public void perTenantDistributionSummary(){
+
+    var registry = newRegistry();
+    var metric = registry.summary("per.tenant.metric", "tag1", "value1", "tenant", "1234");
+    fillMetric(metric);
+
+    var expected = """
+    per_tenant_metric_count{tag1="value1",tenant="1234",}
+    per_tenant_metric_max{tag1="value1",tenant="1234",}
+    per_tenant_metric_sum{tag1="value1",tenant="1234",}
+    per_tenant_metric{tag1="value1",tenant="1234",quantile="0.5",}
+    per_tenant_metric{tag1="value1",tenant="1234",quantile="0.98",}
+    per_tenant_metric{tag1="value1",tenant="1234",quantile="0.99",}
+    """;
+    assertPublishing(registry, expected, "per tenant summary");
+  }
+
+  @Test
+  public void perSessionDistributionSummary(){
+
+    var registry = newRegistry();
+    var metric = registry.summary("per.tenant.metric", "tag1", "value1", "session", "1234");
+    fillMetric(metric);
+
+    var expected = """
+    per_tenant_metric_count{session="1234",tag1="value1",}
+    per_tenant_metric_max{session="1234",tag1="value1",}
+    per_tenant_metric_sum{session="1234",tag1="value1",}
+    per_tenant_metric{session="1234",tag1="value1",quantile="0.5",}
+    per_tenant_metric{session="1234",tag1="value1",quantile="0.98",}
+    per_tenant_metric{session="1234",tag1="value1",quantile="0.99",}
+    """;
+    assertPublishing(registry, expected, "per tenant summary");
+  }
+
+  @Test
+  public void allTenantDistributionSummary(){
+
+    var registry = newRegistry();
+    var metric = registry.summary("per.tenant.metric", "tag1", "value1");
+    fillMetric(metric);
+
+    var expected = """
+    per_tenant_metric_count{tag1="value1",}
+    per_tenant_metric_max{tag1="value1",}
+    per_tenant_metric_sum{tag1="value1",}
+    per_tenant_metric{tag1="value1",quantile="0.5",}
+    per_tenant_metric{tag1="value1",quantile="0.9",}
+    per_tenant_metric{tag1="value1",quantile="0.95",}
+    per_tenant_metric{tag1="value1",quantile="0.98",}
+    per_tenant_metric{tag1="value1",quantile="0.99",}
+    """;
+    assertPublishing(registry, expected, "per tenant summary");
+  }
+
+  private void assertPublishing(PrometheusMeterRegistry registry, String expectedLines, String context ){
+
+    var actual = cleanMetricLines(registry.scrape());
+    var expected = cleanMetricLines(expectedLines);
+
+    assertThat(actual)
+        .as(context)
+        .isEqualTo(expected);
+  }
+
+  private PrometheusMeterRegistry newRegistry() {
+    var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    registry.config()
+        .meterFilter(new MicrometerConfiguration().configureDistributionStatistics());
+    return registry;
+  }
+
+  private void fillMetric(Timer timer) {
+    // record some values so there is data to be published
+    for (int i = 0; i < (1024 * 5); i++) {
+      long value = ThreadLocalRandom.current().nextLong(1, 2001); // 1 to 2000 ms
+      timer.record(value, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void fillMetric(DistributionSummary distributionSummary) {
+    // record some values so there is data to be published
+    for (int i = 0; i < (1024 * 5); i++) {
+      double value = ThreadLocalRandom.current().nextDouble(1, 2001); // 1 to 2000 ms
+      distributionSummary.record(value);
+    }
+  }
+
+  private String cleanMetricLines(String input){
+
+    // # is used for comments, remove those lines and remove the value which is after the  " " at end
+    // e.g. all_tenant_metric_seconds{tag1="value1",quantile="0.5",} 1.040154624
+    // and then sort for comparison
+    return input.lines()
+        .filter(line -> !line.startsWith("#"))
+        .map(line -> {
+          int lastBrace = line.lastIndexOf('}');
+          int lastSpace = line.lastIndexOf(' ');
+          return (lastBrace >= 0 && lastSpace > lastBrace)
+              ? line.substring(0, lastSpace)
+              : line;
+        })
+        .sorted()
+        .collect(Collectors.joining("\n"));
+
+  }
+  @ParameterizedTest
+  @MethodSource("testIsPerTenantPredicateArgs")
+  public void testIsPerTenantPredicateArgs(String slug, boolean isTenant) {
+
+    var predicate = new MicrometerConfiguration.IsPerTenantPredicate();
+    var id = slugToId(slug);
+    assertThat(predicate.test(id))
+        .as("isTenant=%s for slug %s", isTenant, slug)
+        .isEqualTo(isTenant);
+
+  }
+
+  private static Stream<Arguments> testIsPerTenantPredicateArgs() {
+    return Stream.of(
+        Arguments.of("""
+            http_server_requests_seconds_bucket{method="POST",module="sgv2-jsonapi",outcome="SUCCESS",status="200",tenant="5d9bf1c5-bead-48ec-ac04-6662c2ae9cff",uri="/v1/{keyspace}/{collection}",user_agent="astrapy",le="2.505397588"}""", true),
+        Arguments.of("""
+                session_cql_requests_seconds{module="sgv2-jsonapi",session="default_tenant",quantile="0.98"}""", true),
+        Arguments.of("cache_gets_total{cache=\"cql_sessions_cache\",module=\"sgv2-jsonapi\",result=\"hit\"} ", false)
+    );
+  }
+
+  /**
+   * Pass in a metric from the /metrics and it will create the ID
+   * e.g.
+   * <pre>
+   *   http_server_requests_seconds_bucket{method="POST",module="sgv2-jsonapi",outcome="SUCCESS",status="200",tenant="5d9bf1c5-bead-48ec-ac04-6662c2ae9cff",uri="/v1/{keyspace}/{collection}",user_agent="astrapy",le="2.505397588"}
+   * </pre>
+   */
+  private Meter.Id slugToId(String slug)  {
+
+    int braceIndex = slug.indexOf('{');
+    String name = slug.substring(0, braceIndex);
+    String metadata = slug.substring(braceIndex).replaceAll("=", ":");
+
+    Map<String, String> rawTags = Map.of();
+    try {
+      rawTags = OBJECT_MAPPER
+          .readValue(metadata, new TypeReference<Map<String, String>>() {
+          });
+
+    }
+    catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    var tags = Tags.of(
+        rawTags.entrySet().stream()
+            .map(e -> Tag.of(e.getKey(), e.getValue()))
+            .collect(Collectors.toList())
+    );
+    LOGGER.info("slugToId - slug {} -> name {} tags {}", slug, name, tags);
+
+    return  new Meter.Id(name, tags, null, null, Meter.Type.OTHER);
+  }
+}


### PR DESCRIPTION
This PR ensures that we only publish  percentiles for distribution metrics, such as the p98 etc. And prevent publishing histograms which can be 70 lines long.

NOTE: this means the _buckets metric is NOT PUBLISHED.

If we think a metric is per tenant then we publish a limited number of percentiles because there will be a lot of tenants. For all tenant metrics we publish more percentiles.

See tests in MicrometerConfigurationTests that show the metrics we publish.


**Which issue(s) this PR fixes**:
Fixes #2056

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
