### PR TITLE
(WIP) Support `$match` on Collections

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ValueComparisonOperator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ValueComparisonOperator.java
@@ -12,7 +12,8 @@ public enum ValueComparisonOperator implements FilterOperator {
   GT("$gt"),
   GTE("$gte"),
   LT("$lt"),
-  LTE("$lte");
+  LTE("$lte"),
+  MATCH("$match");
 
   private String operator;
 
@@ -44,6 +45,8 @@ public enum ValueComparisonOperator implements FilterOperator {
         return GTE;
       case LTE:
         return GT;
+      case MATCH:
+        return this; // MATCH operator doesn't have a logical inverse
     }
     return this;
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpressionTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ComparisonExpressionTest.java
@@ -105,6 +105,23 @@ public class ComparisonExpressionTest {
       assertThat(result.getFilterOperations()).isEqualTo(expectedResult.getFilterOperations());
       assertThat(result.getPath()).isEqualTo(expectedResult.getPath());
     }
+
+    @Test
+    public void matchValueComparisonExpression() throws Exception {
+      final ComparisonExpression expectedResult =
+          new ComparisonExpression(
+              "content",
+              List.of(
+                  new ValueComparisonOperation(
+                      ValueComparisonOperator.MATCH,
+                      new JsonLiteral("search text", JsonType.STRING))),
+              null);
+
+      ComparisonExpression result = new ComparisonExpression("content", new ArrayList<>(), null);
+      result.add(ValueComparisonOperator.MATCH, "search text");
+      assertThat(result.getFilterOperations()).isEqualTo(expectedResult.getFilterOperations());
+      assertThat(result.getPath()).isEqualTo(expectedResult.getPath());
+    }
   }
 
   @Nested


### PR DESCRIPTION
**What this PR does**:

Tries to add support for `$match` textual match filter operator,  using GenAI.

**Which issue(s) this PR fixes**:
Fixes #2025

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
