### PR TITLE
Minor improvement to fail message of metrics verification (used for troubleshooting)

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -6,6 +6,7 @@ import static io.stargate.sgv2.jsonapi.api.v1.util.IntegrationTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
@@ -244,7 +245,15 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
                 line ->
                     line.startsWith("session_cql_requests_seconds") && line.contains("session="))
             .findFirst();
-    assertThat(sessionLevelDriverMetricTenantId.isPresent()).isTrue();
+    if (!sessionLevelDriverMetricTenantId.isPresent()) {
+      List<String> lines = metrics.lines().toList();
+      long buckets =
+          lines.stream().filter(line -> line.startsWith("session_cql_requests_seconds")).count();
+      fail(
+          String.format(
+              "No tenant id found in any of 'session_cql_requests_seconds' entries (%d buckets; %d log lines)",
+              buckets, lines.size()));
+    }
   }
 
   public static void checkVectorMetrics(String commandName, String sortType) {


### PR DESCRIPTION
**What this PR does**:

Adds info on metrics assertion fail message: used with #2049 to try to figure out where missing metrics entries go, but seems generally useful if problem reappears.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
