### PR TITLE
(WIP) Complete #2054: add Sort on Lexical support for Tables

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/TableSortClauseBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/TableSortClauseBuilder.java
@@ -73,6 +73,7 @@ public class TableSortClauseBuilder extends SortClauseBuilder<TableSchemaObject>
   protected SortExpression buildSortExpression(SortExpressionDefinition exprDef) {
     final String path = exprDef.path();
     final JsonNode innerValue = exprDef.sortValue();
+    final ApiColumnDef column = exprDef.column();
 
     float[] vectorFloats = tryDecodeBinaryVector(path, innerValue);
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/LexicalSortTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/LexicalSortTableIntegrationTest.java
@@ -12,7 +12,6 @@ import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.ClassOrderer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -85,7 +84,6 @@ public class LexicalSortTableIntegrationTest extends AbstractTableIntegrationTes
     }
   }
 
-  @Disabled("Temporarily disabled until Table API supports lexical sort")
   @DisabledIfSystemProperty(named = TEST_PROP_LEXICAL_DISABLED, matches = "true")
   @Nested
   @Order(5)


### PR DESCRIPTION
**What this PR does**:

Adds support for Sort on "Lexical" columns: TEXT/ASCII columns with TextIndex (analyzed text)

**Which issue(s) this PR fixes**:
Fixes #2054

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
