### PR TITLE
Fixes the response from `findEmbeddingProviders`: the parameters type - from "NUMBER" to "number"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProvidersConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/configuration/EmbeddingProvidersConfig.java
@@ -279,15 +279,14 @@ public interface EmbeddingProvidersConfig {
       NUMBER("number"),
       BOOLEAN("boolean");
 
-      private final String type;
+      private final String apiName;
 
-      ParameterType(final String type) {
-        this.type = type;
+      ParameterType(final String apiName) {
+        this.apiName = apiName;
       }
 
-      @Override
-      public String toString() {
-        return type;
+      public String getApiName() {
+        return apiName;
       }
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/embeddings/FindEmbeddingProvidersOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/embeddings/FindEmbeddingProvidersOperation.java
@@ -189,7 +189,7 @@ public record FindEmbeddingProvidersOperation(
 
       return new ParameterConfigResponse(
           sourceParameterConfig.name(),
-          sourceParameterConfig.type().name(),
+          sourceParameterConfig.type().getApiName(),
           sourceParameterConfig.required(),
           sourceParameterConfig.defaultValue(),
           validationMap,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/VectorizeConfigValidator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/VectorizeConfigValidator.java
@@ -308,7 +308,7 @@ public class VectorizeConfigValidator {
     if (typeMismatch) {
       throw ErrorCodeV1.INVALID_CREATE_COLLECTION_OPTIONS.toApiException(
           "The provided parameter '%s' type is incorrect. Expected: '%s'",
-          expectedParamConfig.name(), expectedParamType);
+          expectedParamConfig.name(), expectedParamType.getApiName());
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Our previous format is 
```
                        "parameters": [
                            {
                                "name": "vectorDimension",
                                "type": "number",
                                "required": true,
                                "defaultValue": null,
                                "validation": {
                                    "numericRange": [
                                        2,
                                        3072
                                    ]
                                },
                                "help": "Vector dimension to use in the database, should be the same as the model used by the endpoint."
                            }
                        ]
```

now the format is:
```
                        "parameters": [
                            {
                                "name": "vectorDimension",
                                "type": "NUMBER",
                                "required": true,
                                "defaultValue": null,
                                "validation": {
                                    "numericRange": [
                                        2,
                                        3072
                                    ]
                                },
                                "help": "Vector dimension to use in the database, should be the same as the model used by the endpoint."
                            }
                        ]
```

The "number" is all uppercase

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
