### PR TITLE
Fix #2164: Map<K, Boolean> into Map<K, String> + post-process for config handling

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.config.feature;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Accessor for combined state of feature flags; typically based on static configuration (with its
@@ -16,11 +15,11 @@ import java.util.Optional;
  * io.stargate.sgv2.jsonapi.api.model.command.CommandContext#apiFeatures()}
  */
 public class ApiFeatures {
-  private final Map<ApiFeature, Optional<Boolean>> fromConfig;
+  private final Map<ApiFeature, String> fromConfig;
   private final RequestContext.HttpHeaderAccess httpHeaders;
 
   private ApiFeatures(
-      Map<ApiFeature, Optional<Boolean>> fromConfig, RequestContext.HttpHeaderAccess httpHeaders) {
+      Map<ApiFeature, String> fromConfig, RequestContext.HttpHeaderAccess httpHeaders) {
     this.fromConfig = fromConfig;
     this.httpHeaders = httpHeaders;
   }
@@ -31,7 +30,7 @@ public class ApiFeatures {
 
   public static ApiFeatures fromConfigAndRequest(
       FeaturesConfig config, RequestContext.HttpHeaderAccess httpHeaders) {
-    Map<ApiFeature, Optional<Boolean>> fromConfig = config.flags();
+    Map<ApiFeature, String> fromConfig = config.flags();
     if (fromConfig == null) {
       fromConfig = Collections.emptyMap();
     }
@@ -40,8 +39,7 @@ public class ApiFeatures {
 
   public boolean isFeatureEnabled(ApiFeature flag) {
     // First check if there is definition from configuration
-    Optional<Boolean> optB = fromConfig.get(flag);
-    Boolean b = optB != null ? optB.orElse(null) : null;
+    Boolean b = booleanFromString(fromConfig.get(flag));
     if (b == null) {
       // and only if not, allow per-request specification
       if (httpHeaders != null) {
@@ -52,5 +50,19 @@ public class ApiFeatures {
       return b.booleanValue();
     }
     return flag.enabledByDefault();
+  }
+
+  private Boolean booleanFromString(String str) {
+    if (str == null || str.isBlank()) {
+      return null; // no value, so not enabled
+    }
+    if ("true".equals(str)) {
+      return Boolean.TRUE;
+    }
+    if ("false".equals(str)) {
+      return Boolean.FALSE;
+    }
+    throw new IllegalArgumentException(
+        "Invalid `Boolean` value: '" + str + "'. Expected 'true' or 'false'.");
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.config.feature;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Accessor for combined state of feature flags; typically based on static configuration (with its
@@ -15,11 +16,11 @@ import java.util.Map;
  * io.stargate.sgv2.jsonapi.api.model.command.CommandContext#apiFeatures()}
  */
 public class ApiFeatures {
-  private final Map<ApiFeature, Boolean> fromConfig;
+  private final Map<ApiFeature, Optional<Boolean>> fromConfig;
   private final RequestContext.HttpHeaderAccess httpHeaders;
 
   private ApiFeatures(
-      Map<ApiFeature, Boolean> fromConfig, RequestContext.HttpHeaderAccess httpHeaders) {
+      Map<ApiFeature, Optional<Boolean>> fromConfig, RequestContext.HttpHeaderAccess httpHeaders) {
     this.fromConfig = fromConfig;
     this.httpHeaders = httpHeaders;
   }
@@ -30,7 +31,7 @@ public class ApiFeatures {
 
   public static ApiFeatures fromConfigAndRequest(
       FeaturesConfig config, RequestContext.HttpHeaderAccess httpHeaders) {
-    Map<ApiFeature, Boolean> fromConfig = config.flags();
+    Map<ApiFeature, Optional<Boolean>> fromConfig = config.flags();
     if (fromConfig == null) {
       fromConfig = Collections.emptyMap();
     }
@@ -39,7 +40,8 @@ public class ApiFeatures {
 
   public boolean isFeatureEnabled(ApiFeature flag) {
     // First check if there is definition from configuration
-    Boolean b = fromConfig.get(flag);
+    Optional<Boolean> optB = fromConfig.get(flag);
+    Boolean b = optB != null ? optB.orElse(null) : null;
     if (b == null) {
       // and only if not, allow per-request specification
       if (httpHeaders != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
@@ -53,8 +53,9 @@ public class ApiFeatures {
   }
 
   private Boolean booleanFromString(String str) {
-    if (str == null || str.isBlank()) {
-      return null; // no value, so not enabled
+    // We will allow "*" as an alias in case config file cannot contain blank String value
+    if (str == null || str.isBlank() || "*".equals(str)) {
+      return null; // undefined
     }
     if ("true".equals(str)) {
       return Boolean.TRUE;
@@ -63,6 +64,8 @@ public class ApiFeatures {
       return Boolean.FALSE;
     }
     throw new IllegalArgumentException(
-        "Invalid `Boolean` value: '" + str + "'. Expected 'true' or 'false'.");
+        "Invalid `Boolean` value: '"
+            + str
+            + "'. Expected 'true', 'false' or blank String (undefined).");
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/FeaturesConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/FeaturesConfig.java
@@ -2,7 +2,6 @@ package io.stargate.sgv2.jsonapi.config.feature;
 
 import io.smallrye.config.ConfigMapping;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Configuration mapping for Data API Feature flags as read from main application configuration
@@ -15,7 +14,7 @@ import java.util.Optional;
  */
 @ConfigMapping(prefix = "stargate.feature")
 public interface FeaturesConfig {
-  // Quarkus/SmallRye Config won't accept use of `null` values, so we use Optional
-  // to indicate "undefined" state (i.e. not set).
-  Map<ApiFeature, Optional<Boolean>> flags();
+  // Quarkus/SmallRye Config won't accept use of `null` values, so we must bind
+  // as Strings and only convert to Boolean when needed.
+  Map<ApiFeature, String> flags();
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/FeaturesConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/FeaturesConfig.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.config.feature;
 
 import io.smallrye.config.ConfigMapping;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Configuration mapping for Data API Feature flags as read from main application configuration
@@ -14,5 +15,7 @@ import java.util.Map;
  */
 @ConfigMapping(prefix = "stargate.feature")
 public interface FeaturesConfig {
-  Map<ApiFeature, Boolean> flags();
+  // Quarkus/SmallRye Config won't accept use of `null` values, so we use Optional
+  // to indicate "undefined" state (i.e. not set).
+  Map<ApiFeature, Optional<Boolean>> flags();
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RerankFeatureDisabledIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RerankFeatureDisabledIntegrationTest.java
@@ -30,7 +30,8 @@ public class RerankFeatureDisabledIntegrationTest extends AbstractKeyspaceIntegr
 
     @Override
     public String getFeatureFlagReranking() {
-      // return BLANK String to leave feature "undefined" (disabled unless per-request header override)
+      // return BLANK String to leave feature "undefined" (disabled unless per-request header
+      // override)
       // ("false" would be "disabled" for all tests, regardless of headers)
       return " ";
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RerankFeatureDisabledIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RerankFeatureDisabledIntegrationTest.java
@@ -30,9 +30,9 @@ public class RerankFeatureDisabledIntegrationTest extends AbstractKeyspaceIntegr
 
     @Override
     public String getFeatureFlagReranking() {
-      // return empty to leave feature "undefined" (disabled unless per-request header override)
+      // return BLANK String to leave feature "undefined" (disabled unless per-request header override)
       // ("false" would be "disabled" for all tests, regardless of headers)
-      return "";
+      return " ";
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/TableFeatureDisabledIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/TableFeatureDisabledIntegrationTest.java
@@ -29,9 +29,9 @@ public class TableFeatureDisabledIntegrationTest extends AbstractTableIntegratio
 
     @Override
     public String getFeatureFlagTables() {
-      // return empty to leave feature "undefined" (disabled unless per-request header override)
+      // return BLANK String to leave feature "undefined" (disabled unless per-request header override)
       // ("false" would be "disabled" for all tests, regardless of headers)
-      return "";
+      return " ";
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/TableFeatureDisabledIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/TableFeatureDisabledIntegrationTest.java
@@ -29,7 +29,8 @@ public class TableFeatureDisabledIntegrationTest extends AbstractTableIntegratio
 
     @Override
     public String getFeatureFlagTables() {
-      // return BLANK String to leave feature "undefined" (disabled unless per-request header override)
+      // return BLANK String to leave feature "undefined" (disabled unless per-request header
+      // override)
       // ("false" would be "disabled" for all tests, regardless of headers)
       return " ";
     }


### PR DESCRIPTION
**What this PR does**:

Uses `Map<ApiFeature, String>` instead of `Map<ApiFeature, Boolean>` for configuration, with bit of post-processing.

**Which issue(s) this PR fixes**:
Fixes #2164

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
