### PR TITLE
Fix #2164 by adding custom Boolean converter which accepts "" as `null`

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/NullableBooleanConverter.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/NullableBooleanConverter.java
@@ -1,0 +1,23 @@
+package io.stargate.sgv2.jsonapi.config;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.spi.Converter;
+
+@ApplicationScoped
+public class NullableBooleanConverter implements Converter<Boolean> {
+
+  @Override
+  public Boolean convert(String value) {
+    if (value == null || value.isBlank()) {
+      return null; // Return null for empty or null strings
+    }
+    if ("true".equals(value)) {
+      return true;
+    }
+    if ("false".equals(value)) {
+      return false;
+    }
+    throw new IllegalArgumentException(
+        "Invalid `Boolean` value: '" + value + "'. Expected 'true' or 'false'.");
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Adds custom `Converter<Boolean>` to accept empty String as `null` value

**Which issue(s) this PR fixes**:
Fixes #2164

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
