### PR TITLE
(WIP) Fix #2175: add error checking for Lexical Table Filter handling

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindWithLexicalFilterTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/FindWithLexicalFilterTableIntegrationTest.java
@@ -107,10 +107,6 @@ public class FindWithLexicalFilterTableIntegrationTest extends AbstractTableInte
   @Nested
   @Order(10)
   class SadLexicalFilter {
-    // 21-Aug-2025, tatu: Disabled for now to get working cases in: enable when
-    //   https://github.com/stargate/data-api/issues/2175
-    //   implemented
-    @Disabled("Disabled until [https://github.com/stargate/data-api/issues/2175] implemented")
     @Test
     void failOnMissingColumn() {
       assertTableCommand(keyspaceName, TABLE_NAME)
@@ -123,10 +119,6 @@ public class FindWithLexicalFilterTableIntegrationTest extends AbstractTableInte
               "defines the columns: ");
     }
 
-    // 21-Aug-2025, tatu: Disabled for now to get working cases in: enable when
-    //   https://github.com/stargate/data-api/issues/2175
-    //   implemented
-    @Disabled("Disabled until [https://github.com/stargate/data-api/issues/2175] implemented")
     @Test
     void failOnNonIndexedColumn() {
       assertTableCommand(keyspaceName, TABLE_NAME)


### PR DESCRIPTION
(follow-up to #2053 which handles "happy" cases)

**What this PR does**:

Adds error checking (and matching tests) for Table Lexical Filter (`$match` operator).

**Which issue(s) this PR fixes**:
Fixes #2175

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
