### PR TITLE
ECR login changed to federated 

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -97,7 +97,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build and push image for profiling (Amazon ECR)
         run: |
-          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm -Dquarkus.confirm=true ${{ matrix.profile }}
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm ${{ matrix.profile }}
 
 
   # signs docker image with cosign

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build and push image for profiling (Amazon ECR)
         run: |
-          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm ${{ matrix.profile }}
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm -Dquarkus.container-image.verbose=true ${{ matrix.profile }}
 
 
   # signs docker image with cosign

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build and push image for profiling (Amazon ECR)
         run: |
-          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm -Dquarkus.container-image.verbose=true ${{ matrix.profile }}
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm -Dquarkus.confirm=true ${{ matrix.profile }}
 
 
   # signs docker image with cosign

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -93,13 +93,6 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
           role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
           aws-region: us-east-1
 

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -9,6 +9,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+# needed when a workflow wants to use OIDC (OpenID Connect) to authenticate to cloud
+permissions:
+  id-token: write
+  contents: read
 
 # global env vars, available in all jobs and steps
 env:
@@ -47,7 +51,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
@@ -90,7 +94,7 @@ jobs:
         with:
           cosign-release: ${COSIGN_VERSION}
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -50,8 +50,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -96,6 +95,12 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -10,6 +10,11 @@ on:
     - cron: '0 0 * * SUN'
   workflow_dispatch:
 
+# needed when a workflow wants to use OIDC (OpenID Connect) to authenticate to cloud
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   # Runs Postman Collection against local Stargate instance using docker compose scripts
@@ -31,12 +36,10 @@ jobs:
           java-version: '21'
           cache: maven
 
-      # login to ECR to we can pull coord image from there
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,11 @@ on:
         required: true
         type: string
 
+# needed when a workflow wants to use OIDC (OpenID Connect) to authenticate to cloud
+permissions:
+  id-token: write
+  contents: read
+
 # global env vars, available in all jobs and steps
 env:
   MAVEN_OPTS: '-Xmx4g'
@@ -208,11 +213,10 @@ jobs:
           ./mvnw -B -ntp versions:set -DremoveSnapshot versions:commit
 
       # build and push Astra image to Amazon ECR
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -267,11 +271,10 @@ jobs:
         with:
           cosign-release: ${COSIGN_VERSION}
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_KEY }}
+          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -216,7 +216,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -274,7 +274,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::237073351946:role/stargate_git_ecr
+          role-to-assume: ${{ secrets.ECR_FEDERATED_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -3,7 +3,7 @@
 # based on less minimal UBI8 OpenJDK 17 image
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
 # See https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
 # FROM registry.access.redhat.com/ubi9/openjdk-21:1.22
 

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -3,10 +3,9 @@
 # based on less minimal UBI8 OpenJDK 17 image
 #
 ###
-#FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
 # See https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
-ENV CI=true
+# FROM registry.access.redhat.com/ubi9/openjdk-21:1.22
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -3,9 +3,10 @@
 # based on less minimal UBI8 OpenJDK 17 image
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
+#FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
 # See https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
-# FROM registry.access.redhat.com/ubi9/openjdk-21:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
+ENV CI=true
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -3,9 +3,12 @@
 # based on less minimal UBI8 OpenJDK 17 image
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
+
 # See https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
 # FROM registry.access.redhat.com/ubi9/openjdk-21:1.22
+# Note, github actions docker-image-publish and release will hang when switch to ubi9
+# Use ubi8 for now just to unblock the workflow.
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -3,8 +3,9 @@
 # based on less minimal UBI8 OpenJDK 17 image
 #
 ###
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 # See https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22
+# FROM registry.access.redhat.com/ubi9/openjdk-21:1.22
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
As part of security concern, Data API images related workflow will change into federated access for ECR login.

impacted GH workflow:
- release.yaml
- postman-docker.yaml
- docker-image-publish.yaml

We also need to roll back to ubi8 jdk for profiling image. Since, github actions of building profiling image will hang when switch to ubi9. Use ubi8 for now just to unblock the workflow.
`FROM registry.access.redhat.com/ubi8/openjdk-21:1.21-2`
 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
