### PR TITLE
Fix #2210: update to latest ubi9 base image

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -78,8 +78,8 @@
 #
 ###
 
-# see https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+# see https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
**What this PR does**:

Updates Docker base image used to latest `ubi9` variant

**Which issue(s) this PR fixes**:
Fixes #2210

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
