### PR TITLE
Update datastax links for asset generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,7 +231,7 @@ jobs:
       - name: Download branding assets
         if: ${{ !inputs.skipPublish }}
         run : |
-          curl https://www.datastax.com/favicon.ico -o ./src/main/resources/META-INF/branding/favicon.ico
+          curl https://www.ibm.com/favicon.ico -o ./src/main/resources/META-INF/branding/favicon.ico
           curl https://cdn.sanity.io/files/bbnkhnhl/production/cf8b48832cfd43cdb24aec0e0d1c656e9234b620.zip -o icons.zip
           unzip -j icons.zip 'Brand\ Icons/astra-square.png' -d ./src/main/resources/META-INF/branding/
           mv ./src/main/resources/META-INF/branding/astra-square.png ./src/main/resources/META-INF/branding/logo.png
@@ -242,9 +242,9 @@ jobs:
         env:
           QUARKUS_APPLICATION_NAME: 'Astra DB Serverless Data API'
           QUARKUS_SMALLRYE_OPENAPI_INFO_DESCRIPTION: 'The Astra DB Serverless Data API modifies and queries data stored as unstructured JSON documents in collections. See the [documentation site](https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api.html) for additional information.'
-          QUARKUS_SMALLRYE_OPENAPI_INFO_TERMS_OF_SERVICE: 'https://www.datastax.com/legal'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_TERMS_OF_SERVICE: 'https://www.ibm.com/legal'
           QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_NAME: 'DataStax'
-          QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_URL: 'https://www.datastax.com/contact-us'
+          QUARKUS_SMALLRYE_OPENAPI_INFO_CONTACT_URL: 'https://www.ibm.com/products/datastax'
           QUARKUS_SMALLRYE_OPENAPI_INFO_LICENSE_NAME: ''
           QUARKUS_SMALLRYE_OPENAPI_INFO_LICENSE_URL: ''
         run: |


### PR DESCRIPTION
**What this PR does**:

(Ported from https://github.com/stargate/data-api/pull/2226, which was a fork with insufficient permissions.)

Updates www.datastax.com links (favicon, legal, contact us) that are used to generate the swagger asset for the datastax docs. 

I'm not 100% sure I am editing the correct location. I'm trying to update these links in https://github.com/riptano/astra-api-docs, which I think are pulled from here.

**Which issue(s) this PR fixes**:

https://datastax.jira.com/browse/DOC-5454, https://datastax.jira.com/browse/DOC-5439

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
