### PR TITLE
Update mockito version override (old) to let quarkus-bom bring right version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,12 @@
     <quarkus.platform.version>3.28.3</quarkus.platform.version>
     <!-- miscellaneous -->
     <wiremock.version>3.4.2</wiremock.version>
+    <!-- 17-Oct-2025, tatu: Although quarkus-bom provides for Mockito version,
+       matching property is NOT available when we import it (instead of using as parent pom.
+       But we need version for "maven-surefire-plugin" config! So we have no choice
+       but duplicate this, unfortunately & need to keep things in sync manually
+      -->
+    <mockito.version>5.19.0</mockito.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <!-- Integration test props -->
     <!-- Please update github workflows that build docker images if changing image/additional tags -->
@@ -272,6 +278,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -302,7 +309,11 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
-          <argLine>-Xmx4g</argLine>
+          <!-- 17-Oct-2025, tatu: agent settings needed to get rid of "inline mock" warning by Mockito;
+              leading to duplication of "mockito.version".
+              See: https://github.com/stargate/data-api/pull/2233
+            -->
+          <argLine>-Xmx4g -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>


### PR DESCRIPTION
**What this PR does**:

Removes mockito version override -- using old (5.12.0) version, and `quarkus-bom` would already bring in newer (5.19.0).
So let's remove version override to let Quarkus provide compatible version unless we actually need override (right now we don't).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
