### PR TITLE
Fix #2231: handle missing 'udtName' gracefully

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/table/definition/datatype/UdtRefColumnDesc.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/table/definition/datatype/UdtRefColumnDesc.java
@@ -96,6 +96,12 @@ public class UdtRefColumnDesc extends ComplexColumnDesc {
       // the Missing node will return an empty text
       var udtName = columnDescNode.path(TableDescConstants.ColumnDesc.UDT_NAME).asText();
 
+      // Validate that udtName is not empty or blank to avoid StringIndexOutOfBoundsException
+      if (udtName == null || udtName.isBlank()) {
+        throw SchemaException.Code.INVALID_USER_DEFINED_TYPE_NAME.get(
+            TableDescConstants.ColumnDesc.UDT_NAME, udtName);
+      }
+
       return new UdtRefColumnDesc(schemaDescSource, cqlIdentifierFromUserInput(udtName));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UDTIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UDTIntegrationTest.java
@@ -117,6 +117,40 @@ public class UDTIntegrationTest extends AbstractTableIntegrationTestBase {
     }
 
     @Test
+    public void emptyUdtName() {
+      assertNamespaceCommand(keyspaceName)
+          .templated()
+          .createTable(
+              "emptyUdtName",
+              // empty "udtName" value
+              Map.ofEntries(
+                  Map.entry("id", "text"),
+                  Map.entry("address", Map.of("type", "userDefined", "udtName", ""))),
+              "id")
+          .hasSingleApiError(
+              SchemaException.Code.INVALID_USER_DEFINED_TYPE_NAME,
+              SchemaException.class,
+              "The user defined type name \"udtName\" must not be empty");
+    }
+
+    @Test
+    public void blankUdtName() {
+      assertNamespaceCommand(keyspaceName)
+          .templated()
+          .createTable(
+              "blankUdtName",
+              // blank/whitespace "udtName" value
+              Map.ofEntries(
+                  Map.entry("id", "text"),
+                  Map.entry("address", Map.of("type", "userDefined", "udtName", "   "))),
+              "id")
+          .hasSingleApiError(
+              SchemaException.Code.INVALID_USER_DEFINED_TYPE_NAME,
+              SchemaException.class,
+              "The user defined type name \"udtName\" must not be empty");
+    }
+
+    @Test
     public void unKnownUserDefinedType() {
       assertNamespaceCommand(keyspaceName)
           .templated()


### PR DESCRIPTION
**What this PR does**:

Adds handling of missing/blank "udtName" to avoid HTTP 500.

**Which issue(s) this PR fixes**:
Fixes #2231

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
