### PR TITLE
Fixes #2241: remove `spotbugs-annotations` from inclusion in Docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,10 @@
           <groupId>org.hdrhistogram</groupId>
           <artifactId>HdrHistogram</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -235,6 +239,15 @@
       <groupId>org.mongodb</groupId>
       <artifactId>bson</artifactId>
       <version>5.0.0</version>
+    </dependency>
+    <!-- 04-Nov-2025, tatu: [data-api#2241] SpotBugs annotations for compile-time
+         only (excluded from runtime)
+      -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>3.1.12</version>
+      <scope>provided</scope>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
**What this PR does**:

Changes Maven scope of `spotbugs-annotations` from `compile` to `provided` to prevent inclusion of jar in Docker image built

**Which issue(s) this PR fixes**:
Fixes #2241 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
