### PR TITLE
Add driver config `advanced.resolve-contact-points = false`

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -52,6 +52,7 @@ datastax-java-driver {
   }
   basic.request.timeout = 20 seconds
 
+  # see https://github.com/stargate/data-api/pull/2250 description
   advanced.resolve-contact-points = false
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
As detailed in issue #2246, the Data API can fail to recover after its backend Cassandra cluster's pods are recycled. The application-level fix is in PR #2244. This PR just adds a driver config to make the initial connection process more robust.

**Why this Change is Important**
By default, the Java driver resolves a contact point's hostname to an IP address once and then caches that IP internally for all subsequent connection attempts during the session bootstrap.

In a dynamic environment like Kubernetes, where service IPs can change (e.g., during pod restarts or network events), this default behavior can cause the driver to get "stuck" trying to connect to a stale, non-existent IP addres

Setting `resolve-contact-points = false` instructs the driver to re-resolve the DNS name for each connection attempt during the bootstrap phase.

**Which issue(s) this PR fixes**:
Fixes #2246

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
