### PR TITLE
Fix #2253; prevent AIOOBE for CqlCredentials

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlCredentialsFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlCredentialsFactory.java
@@ -35,7 +35,7 @@ public class CqlCredentialsFactory implements CQLSessionCache.CredentialsFactory
     this.fixedUserName = fixedUserName;
     this.fixedPassword = fixedPassword;
 
-    if (fixedToken != null && LOGGER.isWarnEnabled()) {
+    if (fixedToken != null) {
       LOGGER.warn("Fixed token is set, all tokens will be validated against this token.");
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlCredentialsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlCredentialsTest.java
@@ -1,0 +1,17 @@
+package io.stargate.sgv2.jsonapi.service.cqldriver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link CqlCredentials}. */
+public class CqlCredentialsTest {
+  // [databind#2253]: triggered by logging
+  @Test
+  public void toStringOkForShort() {
+    assertThat(new CqlCredentials.TokenCredentials("a").toString())
+        .isEqualTo("TokenCredentials{token='a', isAnonymous=false}");
+    assertThat(new CqlCredentials.TokenCredentials("abcdefgh").toString())
+        .isEqualTo("TokenCredentials{token='abcd...', isAnonymous=false}");
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Handles "too short" tokens appropriately to avoid `ArrayIndexOutOfBoundsException` seen in logs.

**Which issue(s) this PR fixes**:
Fixes #2253

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
