### PR TITLE
Fix #1629: verify proper exception

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UpdateTableIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/UpdateTableIntegrationTest.java
@@ -7,6 +7,7 @@ import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.stargate.sgv2.jsonapi.api.v1.util.DataApiCommandSenders;
 import io.stargate.sgv2.jsonapi.exception.FilterException;
+import io.stargate.sgv2.jsonapi.exception.RequestException;
 import io.stargate.sgv2.jsonapi.exception.UpdateException;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import java.util.stream.Stream;
@@ -441,6 +442,26 @@ public class UpdateTableIntegrationTest extends AbstractTableIntegrationTestBase
     var expectedUpdatedRowWithNull = DOC_JSON_DEFAULT_ROW_TEMPLATE.formatted(null, null);
     checkUpdatedData(
         FULL_PRIMARY_KEY_FILTER_DEFAULT_ROW, removeNullValues(expectedUpdatedRowWithNull));
+  }
+
+  // ==================================================================================================================
+  // UpdateMany not (yet?) supported
+  // ==================================================================================================================
+
+  @Test
+  public void updateManyNotSupported() {
+    String updateClauseJSON = "{ \"$set\": { \"not_indexed_column\": \"def\"}}";
+
+    DataApiCommandSenders.assertTableCommand(keyspaceName, TABLE_WITH_COMPLEX_PRIMARY_KEY)
+        .templated()
+        .updateMany(FULL_PRIMARY_KEY_FILTER_DEFAULT_ROW, updateClauseJSON)
+        .hasSingleApiError(
+            RequestException.Code.UNSUPPORTED_TABLE_COMMAND,
+            RequestException.class,
+            "The command is not supported by tables in the API",
+            "While many commands operate on both tables and collections",
+            "The commands supported by tables are: ")
+        .hasNoWarnings();
   }
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiTableCommandSender.java
@@ -28,6 +28,10 @@ public class DataApiTableCommandSender extends DataApiCommandSenderBase<DataApiT
     return postCommand(CommandName.UPDATE_ONE, jsonClause);
   }
 
+  public DataApiResponseValidator postUpdateMany(String jsonClause) {
+    return postCommand(CommandName.UPDATE_MANY, jsonClause);
+  }
+
   public DataApiResponseValidator postDeleteMany(String jsonClause) {
     return postCommand(CommandName.DELETE_MANY, jsonClause);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/TableTemplates.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/TableTemplates.java
@@ -148,6 +148,18 @@ public class TableTemplates extends TemplateRunner {
     return asJSON(clause);
   }
 
+  public DataApiResponseValidator updateMany(String filter, String update) {
+    var json =
+            """
+                 {
+                  "filter": %s ,
+                  "update": %s
+                 }
+              """
+            .formatted(filter, update);
+    return sender.postUpdateMany(json);
+  }
+
   public DataApiResponseValidator deleteMany(String filter) {
     var json =
             """


### PR DESCRIPTION
**What this PR does**:

Verifies Exception and Error code returned for "updateMany" attempt on Table: not yet supported but should not be `SERVER_INTERNAL_ERROR` but supported `RequestException.Code.UNSUPPORTED_TABLE_COMMAND`.

**Which issue(s) this PR fixes**:
Fixes #1629

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
