### PR TITLE
Nvidia provider pass tenant id header

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
@@ -98,6 +98,9 @@ public class NvidiaRerankingProvider extends RerankingProvider {
           "In order to rerank, please provide the reranking API key.");
     }
     var accessToken = HttpConstants.BEARER_PREFIX_FOR_API_KEY + rerankingCredentials.apiKey();
+    
+    // Extract tenant ID from reranking credentials to forward to GPU API Gateway
+    String tenantId = rerankingCredentials.tenant().toString();
 
     var nvidiaRequest =
         new NvidiaRerankingRequest(
@@ -107,7 +110,7 @@ public class NvidiaRerankingProvider extends RerankingProvider {
             TRUNCATE_PASSAGE);
 
     final long callStartNano = System.nanoTime();
-    return retryHTTPCall(nvidiaClient.rerank(accessToken, nvidiaRequest))
+    return retryHTTPCall(nvidiaClient.rerank(accessToken, tenantId, nvidiaRequest))
         .onItem()
         .transform(
             jakartaResponse -> {
@@ -145,7 +148,9 @@ public class NvidiaRerankingProvider extends RerankingProvider {
     @POST
     @ClientHeaderParam(name = HttpHeaders.CONTENT_TYPE, value = MediaType.APPLICATION_JSON)
     Uni<Response> rerank(
-        @HeaderParam("Authorization") String accessToken, NvidiaRerankingRequest request);
+        @HeaderParam("Authorization") String accessToken,
+        @HeaderParam("TENANT_ID") String tenantId,
+        NvidiaRerankingRequest request);
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Passes tenant id as a header to be processed by the gpu plane api gateway.

Related Prs:
- https://github.com/riptano/cloud-helm-charts/pull/1066
- https://github.com/riptano/auth-manager/pull/54

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
