### PR TITLE
Update ubi9/jdk21 base image from v1.23 to v1.24

### DIFF
--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -9,7 +9,7 @@
 # Note, github actions docker-image-publish and release will hang when switch to ubi9
 # Use ubi8 for now just to unblock the workflow.
 # see https://catalog.redhat.com/en/software/containers/ubi8/openjdk-21-runtime/653fd184292263c0a2f14d69
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.23
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.24
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -79,10 +79,10 @@
 ###
 
 # see https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.23
+# see https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
-
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/


### PR DESCRIPTION
**What this PR does**:

Updates service docker base image from v1.23 to v1.24 to solve CVEs

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
