### PR TITLE
Revert change to dockerfile/profiling; latest is still v1.23 no v1.24 available

### DIFF
--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -9,7 +9,7 @@
 # Note, github actions docker-image-publish and release will hang when switch to ubi9
 # Use ubi8 for now just to unblock the workflow.
 # see https://catalog.redhat.com/en/software/containers/ubi8/openjdk-21-runtime/653fd184292263c0a2f14d69
-FROM registry.access.redhat.com/ubi8/openjdk-21:1.24
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.23
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
**What this PR does**:

Reverts part of earlier PR #2349 where 2 base images updated; one should not have been.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
