### PR TITLE
Fix Docker/test-containers version problem by raising client version from 1.32 to 1.44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
   <groupId>io.stargate</groupId>
   <artifactId>sgv2-jsonapi</artifactId>
   <version>1.0.39-SNAPSHOT</version>
-  <!-- test change -->
   <properties>
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
**What this PR does**:

Fixes Docker/test-containers version problem by raising client version from 1.32 to 1.44

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
