### PR TITLE
Update to latest ubi8/ubi9 openjdk packages: use full versions

### DIFF
--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -8,7 +8,7 @@
 # Use ubi8 for now just to unblock the workflow.
 # see https://catalog.redhat.com/en/software/containers/ubi8/openjdk-21/653fb7e21b2ec10f7dfc10d0
 #
-# Last updated: 2026-02-25:
+# Last updated: 2026-02-25 / tatu
 #
 FROM registry.access.redhat.com/ubi8/openjdk-21:1.23-4.1771813042
 

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -81,7 +81,7 @@
 # see https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814
 # see https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f
 #
-# Last updated: 2026-02-25:
+# Last updated: 2026-02-25 / tatu
 #
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1771324986
 


### PR DESCRIPTION
**What this PR does**:

Updates Docker base image definitions with full version (not floating); fix links, add comment on last update

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
