### PR TITLE
Fix #2449: use "API name" for embedding provider metric tags

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -68,6 +68,10 @@ public abstract class EmbeddingProvider extends ProviderBase {
     return modelConfig.apiModelSupport();
   }
 
+  public String nameForMetrics() {
+    return serviceConfig.modelProvider().apiName();
+  }
+
   public EmbeddingProvidersConfig.EmbeddingProviderConfig providerConfig() {
     return providerConfig;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -68,6 +68,7 @@ public abstract class EmbeddingProvider extends ProviderBase {
     return modelConfig.apiModelSupport();
   }
 
+  /** Accessor for name to use for "embedding.provider" tag value */
   public String nameForMetrics() {
     return serviceConfig.modelProvider().apiName();
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
@@ -146,8 +146,7 @@ public class MeteredEmbeddingProviderWrapper {
     Tag commandTag = Tag.of(jsonApiMetricsConfig.command(), commandName);
     Tag tenantTag = Tag.of(TENANT_TAG, requestContext.tenant().toString());
     Tag embeddingProviderTag =
-        Tag.of(
-            jsonApiMetricsConfig.embeddingProvider(), embeddingProvider.getClass().getSimpleName());
+        Tag.of(jsonApiMetricsConfig.embeddingProvider(), embeddingProvider.nameForMetrics());
     return Tags.of(commandTag, tenantTag, embeddingProviderTag);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/SyncServiceCredentialResolvingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/SyncServiceCredentialResolvingProvider.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * entry in the authentication map, then passing the resolved credentials to the delegate provider.
  */
 public class SyncServiceCredentialResolvingProvider extends EmbeddingProvider {
-
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SyncServiceCredentialResolvingProvider.class);
 
@@ -58,6 +57,11 @@ public class SyncServiceCredentialResolvingProvider extends EmbeddingProvider {
   protected String errorMessageJsonPtr() {
     // Not used directly — this wrapper never makes HTTP calls itself
     return "";
+  }
+
+  @Override
+  public String nameForMetrics() {
+    return delegate.nameForMetrics();
   }
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -289,7 +289,7 @@ public class VectorizeSearchIntegrationTest extends AbstractKeyspaceIntegrationT
               lines -> {
                 lines.forEach(
                     line -> {
-                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("embedding_provider=\"custom\"");
                       assertThat(line).contains("module=\"sgv2-jsonapi\"");
                       assertThat(line).contains("tenant=\"SINGLE-TENANT\"");
 
@@ -318,7 +318,7 @@ public class VectorizeSearchIntegrationTest extends AbstractKeyspaceIntegrationT
                 // percentiles and is very very fragle to include in a test
                 lines.forEach(
                     line -> {
-                      assertThat(line).contains("embedding_provider=\"CustomITEmbeddingProvider\"");
+                      assertThat(line).contains("embedding_provider=\"custom\"");
                       assertThat(line).contains("module=\"sgv2-jsonapi\"");
                       assertThat(line).contains("tenant=\"SINGLE-TENANT\"");
 
@@ -1200,7 +1200,7 @@ public class VectorizeSearchIntegrationTest extends AbstractKeyspaceIntegrationT
     return findCountFromMetrics(
         metrics,
         Arrays.asList(
-            "embedding_provider=\"CustomITEmbeddingProvider\"",
+            "embedding_provider=\"custom\"",
             "module=\"sgv2-jsonapi\"",
             "tenant=\"SINGLE-TENANT\""));
   }
@@ -1223,7 +1223,7 @@ public class VectorizeSearchIntegrationTest extends AbstractKeyspaceIntegrationT
     return findSumFromMetrics(
         metrics,
         Arrays.asList(
-            "embedding_provider=\"CustomITEmbeddingProvider\"",
+            "embedding_provider=\"custom\"",
             "module=\"sgv2-jsonapi\"",
             "tenant=\"SINGLE-TENANT\""));
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapperTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapperTest.java
@@ -1,0 +1,70 @@
+package io.stargate.sgv2.jsonapi.service.embedding.operation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.sgv2.jsonapi.TestConstants;
+import io.stargate.sgv2.jsonapi.api.request.RequestContext;
+import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MeteredEmbeddingProviderWrapperTest {
+
+  private static final TestConstants TEST_CONSTANTS = new TestConstants();
+
+  private SimpleMeterRegistry meterRegistry;
+  private JsonApiMetricsConfig metricsConfig;
+  private RequestContext requestContext;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+
+    metricsConfig = mock(JsonApiMetricsConfig.class);
+    when(metricsConfig.command()).thenReturn("command");
+    when(metricsConfig.embeddingProvider()).thenReturn("embedding.provider");
+    when(metricsConfig.vectorizeInputBytesMetrics()).thenReturn("vectorize.input.bytes");
+
+    requestContext = TEST_CONSTANTS.requestContext();
+  }
+
+  @Test
+  void shouldTagMetricsWithProviderApiName() {
+    var provider = new TestEmbeddingProvider();
+    var wrapper =
+        new MeteredEmbeddingProviderWrapper(
+            meterRegistry, metricsConfig, requestContext, provider, "testCommand");
+
+    wrapper
+        .vectorize(
+            List.of("hello world"),
+            TEST_CONSTANTS.EMBEDDING_CREDENTIALS,
+            EmbeddingProvider.EmbeddingRequestType.INDEX)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .awaitItem();
+
+    // Verify that at least one metric was recorded with the provider API name tag
+    List<Meter> meters = meterRegistry.getMeters();
+    assertThat(meters).isNotEmpty();
+
+    // Find the embedding.provider tag value across all registered meters
+    var providerTagValues =
+        meters.stream()
+            .flatMap(m -> m.getId().getTags().stream())
+            .filter(tag -> "embedding.provider".equals(tag.getKey()))
+            .map(Tag::getValue)
+            .distinct()
+            .toList();
+
+    // Should be the API name "custom", NOT the class name "TestEmbeddingProvider"
+    assertThat(providerTagValues).containsExactly("custom");
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/SyncServiceCredentialResolvingProviderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/SyncServiceCredentialResolvingProviderTest.java
@@ -292,4 +292,16 @@ class SyncServiceCredentialResolvingProviderTest {
       assertThat(provider.maxBatchSize()).isEqualTo(delegate.maxBatchSize());
     }
   }
+
+  @Nested
+  class NameForMetrics {
+
+    @Test
+    void shouldDelegateNameForMetrics() {
+      var provider = createProvider(Map.of("providerKey", "cred"));
+      // delegate is a TestEmbeddingProvider using ModelProvider.CUSTOM → apiName "custom"
+      assertThat(provider.nameForMetrics()).isEqualTo("custom");
+      assertThat(provider.nameForMetrics()).isEqualTo(delegate.nameForMetrics());
+    }
+  }
 }


### PR DESCRIPTION
**What this PR does**:

As per title: change to use "API name" for embedding provider metric tags

**Which issue(s) this PR fixes**:
Fixes #2449

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
