### PR TITLE
Fix #2442: NPE for "createIndex" with empty definition

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateIndexCommand.java
@@ -12,6 +12,7 @@ import io.stargate.sgv2.jsonapi.config.constants.TableDescConstants;
 import io.stargate.sgv2.jsonapi.config.constants.TableDescDefaults;
 import io.stargate.sgv2.jsonapi.service.schema.tables.ApiIndexType;
 import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -30,6 +31,7 @@ public record CreateIndexCommand(
         String name,
     //
     @NotNull
+        @Valid
         @Schema(description = "Definition of the index to create.", type = SchemaType.OBJECT)
         @JsonProperty(TableDescConstants.IndexDesc.DEFINITION)
         RegularIndexDefinitionDesc definition,

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTextIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateTextIndexCommand.java
@@ -12,6 +12,7 @@ import io.stargate.sgv2.jsonapi.config.constants.TableDescConstants;
 import io.stargate.sgv2.jsonapi.config.constants.TableDescDefaults;
 import io.stargate.sgv2.jsonapi.service.schema.tables.ApiIndexType;
 import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -31,6 +32,7 @@ public record CreateTextIndexCommand(
         @JsonProperty(TableDescConstants.IndexDesc.NAME)
         String name,
     @NotNull
+        @Valid
         @Schema(description = "Definition of the index to create.", type = SchemaType.OBJECT)
         @JsonProperty(TableDescConstants.IndexDesc.DEFINITION)
         TextIndexDefinitionDesc definition,

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateVectorIndexCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateVectorIndexCommand.java
@@ -12,6 +12,7 @@ import io.stargate.sgv2.jsonapi.config.constants.TableDescConstants;
 import io.stargate.sgv2.jsonapi.config.constants.TableDescDefaults;
 import io.stargate.sgv2.jsonapi.service.schema.tables.ApiIndexType;
 import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -30,6 +31,7 @@ public record CreateVectorIndexCommand(
         String name,
     //
     @NotNull
+        @Valid
         @Schema(description = "Definition of the index to create.", type = SchemaType.OBJECT)
         @JsonProperty(TableDescConstants.IndexDesc.DEFINITION)
         VectorIndexDefinitionDesc definition,

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
@@ -955,7 +955,7 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
 
     // Reproduction for https://github.com/stargate/data-api/issues/2442
     @Test
-    public void createIndexWithEmptyDefinition() {
+    public void invalidCreateIndexWithEmptyDefinition() {
       assertTableCommand(keyspaceName, testTableName)
           .postCreateIndex(
               """
@@ -999,7 +999,7 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   class CreateVectorIndexFailure {
     // Reproduction for https://github.com/stargate/data-api/issues/2442
     @Test
-    public void createVectorIndexWithEmptyDefinition() {
+    public void invalidCreateVectorIndexWithEmptyDefinition() {
       assertTableCommand(keyspaceName, vectorTableName)
           .postCreateVectorIndex(
               """
@@ -1182,7 +1182,7 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   class CreateTextIndexFailure {
     // Reproduction for https://github.com/stargate/data-api/issues/2442
     @Test
-    public void createTextIndexWithEmptyDefinition() {
+    public void invalidCreateTextIndexWithEmptyDefinition() {
       assertTableCommand(keyspaceName, lexicalTableName)
           .postCreateTextIndex(
               """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
@@ -953,6 +953,23 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
               "Index function `entries` can not apply to map column when analyze options are specified.");
     }
 
+    // Reproduction for https://github.com/stargate/data-api/issues/2442
+    @Test
+    public void createIndexWithEmptyDefinition() {
+      assertTableCommand(keyspaceName, testTableName)
+          .postCreateIndex(
+              """
+                  {
+                    "name": "empty_def_idx",
+                    "definition": {}
+                  }
+                  """)
+          .hasSingleApiError(
+              RequestException.Code.COMMAND_FIELD_VALUE_INVALID,
+              RequestException.class,
+              "must not be null");
+    }
+
     @Test
     public void emptyOptionsForEntriesIndexOnMap() {
       // Test for issue #1911: empty options object should be treated same as omitting options
@@ -980,6 +997,23 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   @Nested
   @Order(5)
   class CreateVectorIndexFailure {
+    // Reproduction for https://github.com/stargate/data-api/issues/2442
+    @Test
+    public void createVectorIndexWithEmptyDefinition() {
+      assertTableCommand(keyspaceName, vectorTableName)
+          .postCreateVectorIndex(
+              """
+                  {
+                    "name": "empty_def_vector_idx",
+                    "definition": {}
+                  }
+                  """)
+          .hasSingleApiError(
+              RequestException.Code.COMMAND_FIELD_VALUE_INVALID,
+              RequestException.class,
+              "must not be null");
+    }
+
     @Test
     public void createIndexWithEmptyName() {
       assertTableCommand(keyspaceName, vectorTableName)
@@ -1146,6 +1180,23 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   @Nested
   @Order(6)
   class CreateTextIndexFailure {
+    // Reproduction for https://github.com/stargate/data-api/issues/2442
+    @Test
+    public void createTextIndexWithEmptyDefinition() {
+      assertTableCommand(keyspaceName, lexicalTableName)
+          .postCreateTextIndex(
+              """
+                  {
+                    "name": "empty_def_text_idx",
+                    "definition": {}
+                  }
+                  """)
+          .hasSingleApiError(
+              RequestException.Code.COMMAND_FIELD_VALUE_INVALID,
+              RequestException.class,
+              "must not be null");
+    }
+
     // Definition of the text index must be JSON String or Object; fail if not
     @Test
     public void failForDefNotStringOrObject() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/tables/CreateTableIndexIntegrationTest.java
@@ -676,6 +676,23 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
   @Nested
   @Order(4)
   class CreateRegularIndexFailure {
+    // Reproduction for https://github.com/stargate/data-api/issues/2442
+    @Test
+    public void invalidCreateIndexWithEmptyDefinition() {
+      assertTableCommand(keyspaceName, testTableName)
+          .postCreateIndex(
+              """
+                  {
+                    "name": "empty_def_idx",
+                    "definition": {}
+                  }
+                  """)
+          .hasSingleApiError(
+              RequestException.Code.COMMAND_FIELD_VALUE_INVALID,
+              RequestException.class,
+              "must not be null");
+    }
+
     @Test
     public void createIndexWithEmptyName() {
 
@@ -951,23 +968,6 @@ class CreateTableIndexIntegrationTest extends AbstractTableIntegrationTestBase {
               SchemaException.Code.CANNOT_ANALYZE_ENTRIES_ON_MAP_COLUMNS,
               SchemaException.class,
               "Index function `entries` can not apply to map column when analyze options are specified.");
-    }
-
-    // Reproduction for https://github.com/stargate/data-api/issues/2442
-    @Test
-    public void invalidCreateIndexWithEmptyDefinition() {
-      assertTableCommand(keyspaceName, testTableName)
-          .postCreateIndex(
-              """
-                  {
-                    "name": "empty_def_idx",
-                    "definition": {}
-                  }
-                  """)
-          .hasSingleApiError(
-              RequestException.Code.COMMAND_FIELD_VALUE_INVALID,
-              RequestException.class,
-              "must not be null");
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Reproduces and fixes issue #2442

**Which issue(s) this PR fixes**:
#2442

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
