### PR TITLE
Fix #2423: bad error for reranking wrt disabled lexical

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionRerankDef.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionRerankDef.java
@@ -283,10 +283,10 @@ public class CollectionRerankDef {
       CreateCollectionCommand.Options.RerankDesc rerankingDesc,
       RerankingProvidersConfig providerConfigs) {
 
-    // If reranking is not enabled for the API, error out if user provides desc or return disabled
-    // configuration.
+    // If reranking is not enabled for the API, allow explicit "enabled: false" but error out
+    // if user tries to enable it (fix for #2423).
     if (!isRerankingEnabledForAPI) {
-      if (rerankingDesc != null) {
+      if (rerankingDesc != null && !Boolean.FALSE.equals(rerankingDesc.enabled())) {
         throw SchemaException.Code.RERANKING_FEATURE_NOT_ENABLED.get();
       }
       return DISABLED;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RerankFeatureDisabledIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/RerankFeatureDisabledIntegrationTest.java
@@ -62,8 +62,57 @@ public class RerankFeatureDisabledIntegrationTest extends AbstractKeyspaceIntegr
         .wasSuccessful();
   }
 
-  // By default, collection creation should fail
+  // [data-api#2423]: explicit "enabled: false" should succeed even when feature is disabled
   @Order(3)
+  @Test
+  public void okCreateWithRerankExplicitlyDisabled() {
+    final String collName = "coll_rerank_explicit_off";
+    assertNamespaceCommand(keyspaceName)
+        .postCreateCollection(
+                """
+                    {
+                      "name": "%s",
+                      "options": {
+                        "rerank": {
+                          "enabled": false
+                        }
+                      }
+                    }
+                    """
+                .formatted(collName))
+        .wasSuccessful();
+  }
+
+  // [data-api#2423]: both lexical and rerank explicitly disabled (original reporter scenario)
+  @Order(4)
+  @Test
+  public void okCreateWithLexicalAndRerankExplicitlyDisabled() {
+    final String collName = "coll_lex_rerank_off";
+    assertNamespaceCommand(keyspaceName)
+        .postCreateCollection(
+                """
+                    {
+                      "name": "%s",
+                      "options": {
+                        "vector": {
+                          "dimension": 14,
+                          "metric": "cosine"
+                        },
+                        "lexical": {
+                          "enabled": false
+                        },
+                        "rerank": {
+                          "enabled": false
+                        }
+                      }
+                    }
+                    """
+                .formatted(collName))
+        .wasSuccessful();
+  }
+
+  // By default, collection creation with rerank enabled should fail
+  @Order(5)
   @Test
   public void failCreateWithoutFeatureEnabled() {
 
@@ -74,7 +123,7 @@ public class RerankFeatureDisabledIntegrationTest extends AbstractKeyspaceIntegr
   }
 
   // But with header override, should succeed
-  @Order(4)
+  @Order(6)
   @Test
   public void okCreateWithFeatureEnabledViaHeader() {
     assertNamespaceCommand(keyspaceName)
@@ -84,7 +133,7 @@ public class RerankFeatureDisabledIntegrationTest extends AbstractKeyspaceIntegr
   }
 
   // But even with collection, findAndRerank() should fail without Feature enabled
-  @Order(5)
+  @Order(7)
   @Test
   public void failFindWithoutFeature() {
     // Temporarily create the command string, refactor when we have templates for FindAndRerank

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionRerankDefTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionRerankDefTest.java
@@ -59,7 +59,6 @@ class CollectionRerankDefTest {
 
       // This should NOT throw — the user is saying "I don't want reranking"
       // which matches the server state (reranking not available).
-      // BUG: currently throws SchemaException RERANKING_FEATURE_NOT_ENABLED
       CollectionRerankDef result =
           CollectionRerankDef.fromApiDesc(
               false, // reranking NOT enabled

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionRerankDefTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionRerankDefTest.java
@@ -1,0 +1,93 @@
+package io.stargate.sgv2.jsonapi.service.schema.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateCollectionCommand;
+import io.stargate.sgv2.jsonapi.exception.SchemaException;
+import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CollectionRerankDef#fromApiDesc} focusing on behavior when the reranking
+ * feature is disabled at the API level.
+ *
+ * <p>Reproduces <a href="https://github.com/stargate/data-api/issues/2423">#2423</a>: when
+ * reranking feature is not enabled, explicitly passing {@code "rerank": {"enabled": false}} should
+ * succeed (return disabled config) instead of throwing RERANKING_FEATURE_NOT_ENABLED.
+ */
+class CollectionRerankDefTest {
+
+  // Minimal stub: no providers configured
+  private static final RerankingProvidersConfig EMPTY_PROVIDERS_CONFIG =
+      new RerankingProvidersConfig() {
+        @Override
+        public Map<String, RerankingProviderConfig> providers() {
+          return Map.of();
+        }
+      };
+
+  @Nested
+  class WhenRerankingFeatureDisabled {
+
+    /**
+     * Baseline: null rerank desc (user omits "rerank" entirely) should return disabled config —
+     * this already works.
+     */
+    @Test
+    void shouldReturnDisabledWhenNoDescProvided() {
+      CollectionRerankDef result =
+          CollectionRerankDef.fromApiDesc(
+              false, // reranking NOT enabled
+              null, // no rerank desc
+              EMPTY_PROVIDERS_CONFIG);
+
+      assertThat(result).isNotNull();
+      assertThat(result.enabled()).isFalse();
+    }
+
+    /**
+     * Reproduces issue #2423: user explicitly passes {"enabled": false} for rerank when the feature
+     * is disabled. This should succeed but currently throws RERANKING_FEATURE_NOT_ENABLED.
+     */
+    @Test
+    void shouldReturnDisabledWhenExplicitlyDisabled() {
+      // User sends: "rerank": {"enabled": false}
+      var rerankDesc = new CreateCollectionCommand.Options.RerankDesc(false, null);
+
+      // This should NOT throw — the user is saying "I don't want reranking"
+      // which matches the server state (reranking not available).
+      // BUG: currently throws SchemaException RERANKING_FEATURE_NOT_ENABLED
+      CollectionRerankDef result =
+          CollectionRerankDef.fromApiDesc(
+              false, // reranking NOT enabled
+              rerankDesc,
+              EMPTY_PROVIDERS_CONFIG);
+
+      assertThat(result).isNotNull();
+      assertThat(result.enabled()).isFalse();
+    }
+
+    /**
+     * When the feature is disabled, user trying to ENABLE reranking should still fail with
+     * RERANKING_FEATURE_NOT_ENABLED.
+     */
+    @Test
+    void shouldFailWhenTryingToEnableReranking() {
+      // User sends: "rerank": {"enabled": true, "service": {...}}
+      var rerankDesc = new CreateCollectionCommand.Options.RerankDesc(true, null);
+
+      assertThatThrownBy(
+              () ->
+                  CollectionRerankDef.fromApiDesc(
+                      false, // reranking NOT enabled
+                      rerankDesc,
+                      EMPTY_PROVIDERS_CONFIG))
+          .isInstanceOf(SchemaException.class)
+          .hasFieldOrPropertyWithValue(
+              "code", SchemaException.Code.RERANKING_FEATURE_NOT_ENABLED.name());
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Improves reranking error handling wrt "lexical" field

**Which issue(s) this PR fixes**:
Fixes #2423

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
