### PR TITLE
Implement #2456: include model name tag in vectorize metrics

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
@@ -72,6 +72,14 @@ public interface JsonApiMetricsConfig {
   String embeddingProvider();
 
   @NotBlank
+  @WithDefault("embedding.model")
+  String embeddingModel();
+
+  /** Whether to include the embedding model name as a metric tag. Defaults to true. */
+  @WithDefault("true")
+  boolean embeddingModelTagEnabled();
+
+  @NotBlank
   @WithDefault("index.usage.count")
   String indexUsageCounterMetrics();
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/metrics/JsonApiMetricsConfig.java
@@ -73,7 +73,7 @@ public interface JsonApiMetricsConfig {
 
   @NotBlank
   @WithDefault("embedding.model")
-  String embeddingModel();
+  String embeddingModelTag();
 
   /** Whether to include the embedding model name as a metric tag. Defaults to true. */
   @WithDefault("true")

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
@@ -152,7 +152,7 @@ public class MeteredEmbeddingProviderWrapper {
         jsonApiMetricsConfig.embeddingModelTagEnabled()
             ? embeddingProvider.modelName()
             : MetricsConstants.UNKNOWN_VALUE;
-    tags = tags.and(jsonApiMetricsConfig.embeddingModel(), modelValue);
+    tags = tags.and(jsonApiMetricsConfig.embeddingModelTag(), modelValue);
     return tags;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
@@ -147,12 +147,11 @@ public class MeteredEmbeddingProviderWrapper {
     Tag tenantTag = Tag.of(TENANT_TAG, requestContext.tenant().toString());
     Tag embeddingProviderTag =
         Tag.of(jsonApiMetricsConfig.embeddingProvider(), embeddingProvider.nameForMetrics());
-    Tags tags = Tags.of(commandTag, tenantTag, embeddingProviderTag);
     String modelValue =
         jsonApiMetricsConfig.embeddingModelTagEnabled()
             ? embeddingProvider.modelName()
             : MetricsConstants.UNKNOWN_VALUE;
-    tags = tags.and(jsonApiMetricsConfig.embeddingModelTag(), modelValue);
-    return tags;
+    Tag embeddingModelTag = Tag.of(jsonApiMetricsConfig.embeddingModelTag(), modelValue);
+    return Tags.of(commandTag, tenantTag, embeddingProviderTag, embeddingModelTag);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapper.java
@@ -147,6 +147,12 @@ public class MeteredEmbeddingProviderWrapper {
     Tag tenantTag = Tag.of(TENANT_TAG, requestContext.tenant().toString());
     Tag embeddingProviderTag =
         Tag.of(jsonApiMetricsConfig.embeddingProvider(), embeddingProvider.nameForMetrics());
-    return Tags.of(commandTag, tenantTag, embeddingProviderTag);
+    Tags tags = Tags.of(commandTag, tenantTag, embeddingProviderTag);
+    String modelValue =
+        jsonApiMetricsConfig.embeddingModelTagEnabled()
+            ? embeddingProvider.modelName()
+            : MetricsConstants.UNKNOWN_VALUE;
+    tags = tags.and(jsonApiMetricsConfig.embeddingModel(), modelValue);
+    return tags;
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapperTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapperTest.java
@@ -11,6 +11,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.sgv2.jsonapi.TestConstants;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import io.stargate.sgv2.jsonapi.api.v1.metrics.JsonApiMetricsConfig;
+import io.stargate.sgv2.jsonapi.metrics.MetricsConstants;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ class MeteredEmbeddingProviderWrapperTest {
     metricsConfig = mock(JsonApiMetricsConfig.class);
     when(metricsConfig.command()).thenReturn("command");
     when(metricsConfig.embeddingProvider()).thenReturn("embedding.provider");
+    when(metricsConfig.embeddingModel()).thenReturn("embedding.model");
+    when(metricsConfig.embeddingModelTagEnabled()).thenReturn(true);
     when(metricsConfig.vectorizeInputBytesMetrics()).thenReturn("vectorize.input.bytes");
 
     requestContext = TEST_CONSTANTS.requestContext();
@@ -66,5 +69,44 @@ class MeteredEmbeddingProviderWrapperTest {
 
     // Should be the API name "custom", NOT the class name "TestEmbeddingProvider"
     assertThat(providerTagValues).containsExactly("custom");
+
+    // Verify embedding.model tag is present with the model name
+    var modelTagValues =
+        meters.stream()
+            .flatMap(m -> m.getId().getTags().stream())
+            .filter(tag -> "embedding.model".equals(tag.getKey()))
+            .map(Tag::getValue)
+            .distinct()
+            .toList();
+    assertThat(modelTagValues).containsExactly("testModel");
+  }
+
+  @Test
+  void shouldUseUnknownModelTagWhenDisabled() {
+    when(metricsConfig.embeddingModelTagEnabled()).thenReturn(false);
+
+    var provider = new TestEmbeddingProvider();
+    var wrapper =
+        new MeteredEmbeddingProviderWrapper(
+            meterRegistry, metricsConfig, requestContext, provider, "testCommand");
+
+    wrapper
+        .vectorize(
+            List.of("hello world"),
+            TEST_CONSTANTS.EMBEDDING_CREDENTIALS,
+            EmbeddingProvider.EmbeddingRequestType.INDEX)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .awaitItem();
+
+    List<Meter> meters = meterRegistry.getMeters();
+    var modelTagValues =
+        meters.stream()
+            .flatMap(m -> m.getId().getTags().stream())
+            .filter(tag -> "embedding.model".equals(tag.getKey()))
+            .map(Tag::getValue)
+            .distinct()
+            .toList();
+    assertThat(modelTagValues).containsExactly(MetricsConstants.UNKNOWN_VALUE);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapperTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/MeteredEmbeddingProviderWrapperTest.java
@@ -31,7 +31,7 @@ class MeteredEmbeddingProviderWrapperTest {
     metricsConfig = mock(JsonApiMetricsConfig.class);
     when(metricsConfig.command()).thenReturn("command");
     when(metricsConfig.embeddingProvider()).thenReturn("embedding.provider");
-    when(metricsConfig.embeddingModel()).thenReturn("embedding.model");
+    when(metricsConfig.embeddingModelTag()).thenReturn("embedding.model");
     when(metricsConfig.embeddingModelTagEnabled()).thenReturn(true);
     when(metricsConfig.vectorizeInputBytesMetrics()).thenReturn("vectorize.input.bytes");
 


### PR DESCRIPTION
**What this PR does**:

As title says, adds "embedding.model" tag in vectorize metrics

**Which issue(s) this PR fixes**:
Fixes #2456

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
