### PR TITLE
Fix #2325: avoid error on "_id" with "$exists" operator for Collections

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilder.java
@@ -242,7 +242,7 @@ public abstract class FilterClauseBuilder<T extends SchemaObject> {
       String entryKey = validateFilterClausePath(entry.getKey(), operator);
       JsonNode value = updateField.getValue();
       // $exists checks field presence; its operand is always a plain Boolean and must not be
-      // wrapped as a DocumentId even when filtering on `_id` (see issue #2325).
+      // wrapped as a DocumentId even when filtering on `_id`.
       Object valueObject =
           (operator == ElementComparisonOperator.EXISTS)
               ? jsonNodeValue(value)
@@ -294,16 +294,17 @@ public abstract class FilterClauseBuilder<T extends SchemaObject> {
   }
 
   /**
-   * Method to parse each filter clause and return node value.
+   * Method to parse each filter clause and return operand value for operator. Considers special
+   * case of field being Document Id ("_id") to produce {@code DocumentId} otherwise just "natural"
+   * Java value for JSON type (like {@code String} or {@code Boolean}.
    *
-   * @param path - If the path refers to Document Id (see {@link #isDocId}, then the value is
-   *     resolved as DocumentId
+   * @param path - Path for filter clause
    * @param node - JsonNode which has the operand value of a filter clause
-   * @return
+   * @return Value for filter operator to compare
    */
   protected Object jsonNodeValue(String path, JsonNode node) {
-    // If the path is _id, then the value is resolved as DocumentId and Array type handled for `$in`
-    // operator in filter
+    // If the path is _id, then the value is resolved as DocumentId and Array type
+    // handled for `$in` operator in filter
     if (isDocId(path)) {
       if (node.getNodeType() == JsonNodeType.ARRAY) {
         ArrayNode arrayNode = (ArrayNode) node;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilder.java
@@ -241,7 +241,12 @@ public abstract class FilterClauseBuilder<T extends SchemaObject> {
 
       String entryKey = validateFilterClausePath(entry.getKey(), operator);
       JsonNode value = updateField.getValue();
-      Object valueObject = jsonNodeValue(entryKey, value);
+      // $exists checks field presence; its operand is always a plain Boolean and must not be
+      // wrapped as a DocumentId even when filtering on `_id` (see issue #2325).
+      Object valueObject =
+          (operator == ElementComparisonOperator.EXISTS)
+              ? jsonNodeValue(value)
+              : jsonNodeValue(entryKey, value);
       if (operator == ValueComparisonOperator.GT
           || operator == ValueComparisonOperator.GTE
           || operator == ValueComparisonOperator.LT

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilderTest.java
@@ -678,6 +678,85 @@ public class FilterClauseBuilderTest {
           .isEqualTo(expectedResult.getPath());
     }
 
+    // [data-api#2325] $exists on the _id field must accept a Boolean operand, like any other
+    // field. Before the fix, the _id-specific path wrapped the Boolean as a DocumentId, causing
+    // a misleading "$exists operator must have `Boolean`" error.
+    @Test
+    public void mustHandleIdFieldExistsTrue() throws Exception {
+      String json =
+          """
+           {"_id" : {"$exists": true}}
+          """;
+      final ComparisonExpression expectedResult =
+          new ComparisonExpression(
+              "_id",
+              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, true)),
+              null);
+      FilterClause filterClause = readCollectionFilterClause(json);
+      assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
+      assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(1);
+      assertThat(
+              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
+          .isEqualTo(expectedResult.getFilterOperations());
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
+          .isEqualTo(expectedResult.getPath());
+    }
+
+    @Test
+    public void mustHandleIdFieldExistsFalse() throws Exception {
+      String json =
+          """
+           {"_id" : {"$exists": false}}
+          """;
+      final ComparisonExpression expectedResult =
+          new ComparisonExpression(
+              "_id",
+              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, false)),
+              null);
+      FilterClause filterClause = readCollectionFilterClause(json);
+      assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
+      assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(1);
+      assertThat(
+              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
+          .isEqualTo(expectedResult.getFilterOperations());
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
+          .isEqualTo(expectedResult.getPath());
+    }
+
+    @Test
+    public void mustHandleIdFieldExistsCombinedWithOtherField() throws Exception {
+      String json =
+          """
+           {"_id" : {"$exists": true}, "name": "Tim"}
+          """;
+      FilterClause filterClause = readCollectionFilterClause(json);
+      assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
+      assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(2);
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
+          .isEqualTo("_id");
+      assertThat(
+              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
+          .isEqualTo(
+              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, true)));
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(1).getPath())
+          .isEqualTo("name");
+      assertThat(
+              filterClause.logicalExpression().comparisonExpressions.get(1).getFilterOperations())
+          .isEqualTo(List.of(ValueComparisonOperation.build(ValueComparisonOperator.EQ, "Tim")));
+    }
+
+    // $not should flip the boolean operand of $exists; ensure the _id path doesn't break that.
+    @Test
+    public void mustHandleIdFieldExistsUnderNot() throws Exception {
+      String json =
+          """
+           {"$not": {"_id" : {"$exists": true}}}
+          """;
+      FilterClause filterClause = readCollectionFilterClause(json);
+      // $not is inverted away: the inner $exists:true becomes $exists:false on _id
+      assertThat(filterClause.logicalExpression().getTotalComparisonExpressionCount()).isEqualTo(1);
+    }
+
     @Test
     public void mustHandleNonIdFieldIn() throws Exception {
       String json =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilderTest.java
@@ -678,9 +678,6 @@ public class FilterClauseBuilderTest {
           .isEqualTo(expectedResult.getPath());
     }
 
-    // [data-api#2325] $exists on the _id field must accept a Boolean operand, like any other
-    // field. Before the fix, the _id-specific path wrapped the Boolean as a DocumentId, causing
-    // a misleading "$exists operator must have `Boolean`" error.
     @Test
     public void mustHandleIdFieldExistsTrue() throws Exception {
       String json =
@@ -745,7 +742,8 @@ public class FilterClauseBuilderTest {
           .isEqualTo(List.of(ValueComparisonOperation.build(ValueComparisonOperator.EQ, "Tim")));
     }
 
-    // $not should flip the boolean operand of $exists; ensure the _id path doesn't break that.
+    // $not flips the boolean operand of $exists via ComparisonExpression.getFlippedOperandValue,
+    // which casts the operand to Boolean. Guards against regression to DocumentId wrapping.
     @Test
     public void mustHandleIdFieldExistsUnderNot() throws Exception {
       String json =
@@ -753,8 +751,12 @@ public class FilterClauseBuilderTest {
            {"$not": {"_id" : {"$exists": true}}}
           """;
       FilterClause filterClause = readCollectionFilterClause(json);
-      // $not is inverted away: the inner $exists:true becomes $exists:false on _id
       assertThat(filterClause.logicalExpression().getTotalComparisonExpressionCount()).isEqualTo(1);
+      ComparisonExpression expr = filterClause.logicalExpression().comparisonExpressions.get(0);
+      assertThat(expr.getPath()).isEqualTo("_id");
+      assertThat(expr.getFilterOperations())
+          .isEqualTo(
+              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, false)));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/builders/FilterClauseBuilderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
@@ -678,46 +679,18 @@ public class FilterClauseBuilderTest {
           .isEqualTo(expectedResult.getPath());
     }
 
-    @Test
-    public void mustHandleIdFieldExistsTrue() throws Exception {
-      String json =
-          """
-           {"_id" : {"$exists": true}}
-          """;
-      final ComparisonExpression expectedResult =
-          new ComparisonExpression(
-              "_id",
-              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, true)),
-              null);
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void mustHandleIdFieldExists(boolean operand) throws Exception {
+      String json = "{\"_id\" : {\"$exists\": " + operand + "}}";
       FilterClause filterClause = readCollectionFilterClause(json);
       assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
       assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(1);
-      assertThat(
-              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
-          .isEqualTo(expectedResult.getFilterOperations());
-      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
-          .isEqualTo(expectedResult.getPath());
-    }
-
-    @Test
-    public void mustHandleIdFieldExistsFalse() throws Exception {
-      String json =
-          """
-           {"_id" : {"$exists": false}}
-          """;
-      final ComparisonExpression expectedResult =
-          new ComparisonExpression(
-              "_id",
-              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, false)),
-              null);
-      FilterClause filterClause = readCollectionFilterClause(json);
-      assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
-      assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(1);
-      assertThat(
-              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
-          .isEqualTo(expectedResult.getFilterOperations());
-      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
-          .isEqualTo(expectedResult.getPath());
+      ComparisonExpression expr = filterClause.logicalExpression().comparisonExpressions.get(0);
+      assertThat(expr.getPath()).isEqualTo("_id");
+      assertThat(expr.getFilterOperations())
+          .isEqualTo(
+              List.of(ValueComparisonOperation.build(ElementComparisonOperator.EXISTS, operand)));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -543,9 +543,6 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("data.documents", hasSize(1));
     }
 
-    // [data-api#2325] $exists on the _id field used to fail with a misleading
-    // "$exists operator must have `Boolean`" error. After the fix, $exists:true on _id
-    // matches every document (since _id is always present) and $exists:false matches none.
     @Test
     public void withExistOperatorOnIdField() {
       String json =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -543,6 +543,39 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("data.documents", hasSize(1));
     }
 
+    // [data-api#2325] $exists on the _id field used to fail with a misleading
+    // "$exists operator must have `Boolean`" error. After the fix, $exists:true on _id
+    // matches every document (since _id is always present) and $exists:false matches none.
+    @Test
+    public void withExistOperatorOnIdField() {
+      String json =
+          """
+          {
+            "find": {
+              "filter" : {"_id" : {"$exists" : true}}
+            }
+          }
+          """;
+      givenHeadersPostJsonThenOkNoErrors(json)
+          .body("$", responseIsFindSuccess())
+          .body("data.documents", hasSize(6));
+    }
+
+    @Test
+    public void withExistFalseOperatorOnIdField() {
+      String json =
+          """
+          {
+            "find": {
+              "filter" : {"_id" : {"$exists" : false}}
+            }
+          }
+          """;
+      givenHeadersPostJsonThenOkNoErrors(json)
+          .body("$", responseIsFindSuccess())
+          .body("data.documents", hasSize(0));
+    }
+
     @Test
     public void withAllOperator() {
       String json =


### PR DESCRIPTION
**What this PR does**:

Fixes handling of

```
{
  "find": {
    "filter" : {"_id" : {"$exists" : true}}
  }
}
```

case for Collections; allowing trivial usage (all Document have _id, so `true` matches all; `false` matches none), instead of odd failure (as reported in #2325).

**Which issue(s) this PR fixes**:
Fixes #2325

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
