### PR TITLE
Fix #1457: store name of the CollectionIdType values in the Enum

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionIdType.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionIdType.java
@@ -1,38 +1,42 @@
 package io.stargate.sgv2.jsonapi.service.schema.collections;
 
 import io.stargate.sgv2.jsonapi.exception.ServerException;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Collection Id Type enum, UNDEFINED represents unwrapped id */
 public enum CollectionIdType {
-  OBJECT_ID,
-  UUID,
-  UUID_V6,
-  UUID_V7,
-  UNDEFINED;
+  OBJECT_ID("objectId"),
+  UUID("uuid"),
+  UUID_V6("uuidv6"),
+  UUID_V7("uuidv7"),
+  UNDEFINED("");
 
-  // TODO: store the name of the enum in the enum itself
+  private static final Map<String, CollectionIdType> BY_API_NAME = new HashMap<>();
+
+  static {
+    for (CollectionIdType type : values()) {
+      BY_API_NAME.put(type.apiName, type);
+    }
+  }
+
+  private final String apiName;
+
+  CollectionIdType(String apiName) {
+    this.apiName = apiName;
+  }
 
   public static CollectionIdType fromString(String idType) {
     if (idType == null) return UNDEFINED;
-    return switch (idType) {
-      case "objectId" -> OBJECT_ID;
-      case "uuid" -> UUID;
-      case "uuidv6" -> UUID_V6;
-      case "uuidv7" -> UUID_V7;
-      case "" -> UNDEFINED;
-      default ->
-          throw ServerException.internalServerError(
-              "Invalid Collection _id type: '%s'".formatted(idType));
-    };
+    CollectionIdType type = BY_API_NAME.get(idType);
+    if (type == null) {
+      throw ServerException.internalServerError(
+          "Invalid Collection _id type: '%s'".formatted(idType));
+    }
+    return type;
   }
 
   public String toString() {
-    return switch (this) {
-      case OBJECT_ID -> "objectId";
-      case UUID -> "uuid";
-      case UUID_V6 -> "uuidv6";
-      case UUID_V7 -> "uuidv7";
-      case UNDEFINED -> "";
-    };
+    return apiName;
   }
 }


### PR DESCRIPTION
**What this PR does**:

Minor code tidy to store type as "apiName" in `CollectionIdType` itself

**Which issue(s) this PR fixes**:
Fixes #1457

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
