### PR TITLE
Minor fix related to #2028 (but not fixing it) -- VoyageAI provider not checking for EOL

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/VoyageAIEmbeddingProvider.java
@@ -85,6 +85,7 @@ public class VoyageAIEmbeddingProvider extends EmbeddingProvider {
       EmbeddingCredentials embeddingCredentials,
       EmbeddingRequestType embeddingRequestType) {
 
+    checkEOLModelUsage();
     checkEmbeddingApiKeyHeader(embeddingCredentials.apiKey());
 
     // TODO: remove the requestTypeQuery and requestTypeIndex from config !


### PR DESCRIPTION
**What this PR does**:

Adds missing check for VoyageAI provider to check for EOL

**Which issue(s) this PR fixes**:
Related to #2028 (but not implementation of it)

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
