### PR TITLE
Fix #2487: add 3 more vector indexing options for CreateCollection (out of 5 possible)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <stargate.int-test.cassandra.auth-enabled>true</stargate.int-test.cassandra.auth-enabled>
     <!-- Defaults are for DSE which does not support (full) lexical feature set so: -->
     <stargate.int-test.lexical-disabled>true</stargate.int-test.lexical-disabled>
+    <!-- DSE 6.9 SAI does not support the 'enable_hierarchy' vector index option so: -->
+    <stargate.int-test.vector-hierarchy-disabled>true</stargate.int-test.vector-hierarchy-disabled>
     <!-- 14-Mar-2025, tatu: no more use of Stargate Coordinator -->
     <!-- Cassandra driver -->
     <driver.version>4.17.0</driver.version>
@@ -477,6 +479,7 @@
                 <testing.containers.cluster-hcd>${stargate.int-test.cluster.hcd}</testing.containers.cluster-hcd>
                 <testing.package.type>${quarkus.package.type}</testing.package.type>
                 <testing.db.lexical-disabled>${stargate.int-test.lexical-disabled}</testing.db.lexical-disabled>
+                <testing.db.vector-hierarchy-disabled>${stargate.int-test.vector-hierarchy-disabled}</testing.db.vector-hierarchy-disabled>
                 <maven.home>${maven.home}</maven.home>
               </systemPropertyVariables>
               <includes>
@@ -607,6 +610,8 @@
         <stargate.int-test.cluster.hcd>false</stargate.int-test.cluster.hcd>
         <!-- No lexical-sort on DSE: -->
         <stargate.int-test.lexical-disabled>true</stargate.int-test.lexical-disabled>
+        <!-- No 'enable_hierarchy' vector index option on DSE 6.9: -->
+        <stargate.int-test.vector-hierarchy-disabled>true</stargate.int-test.vector-hierarchy-disabled>
       </properties>
     </profile>
     <profile>
@@ -626,6 +631,8 @@
         <stargate.int-test.cluster.hcd>true</stargate.int-test.cluster.hcd>
         <!-- HCD does have lexical-sort: -->
         <stargate.int-test.lexical-disabled>false</stargate.int-test.lexical-disabled>
+        <!-- HCD does support the 'enable_hierarchy' vector index option: -->
+        <stargate.int-test.vector-hierarchy-disabled>false</stargate.int-test.vector-hierarchy-disabled>
       </properties>
     </profile>
   </profiles>

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/CommandObjectMapperHandler.java
@@ -43,7 +43,13 @@ public class CommandObjectMapperHandler extends DeserializationProblemHandler {
     if (CreateCollectionCommand.Options.VectorSearchDesc.class.equals(deserializer.handledType())) {
       throw RequestException.Code.INVALID_CREATE_COLLECTION_FIELD.get(
           "message",
-          "Unrecognized field \"%s\" for `createCollection.options.vector` (known fields: \"dimension\", \"metric\", \"service\", \"sourceModel\")"
+          "Unrecognized field \"%s\" for `createCollection.options.vector` (known fields: \"dimension\", \"indexOptions\", \"metric\", \"service\", \"sourceModel\")"
+              .formatted(propertyName));
+    }
+    if (CreateCollectionCommand.Options.VectorIndexDesc.class.equals(deserializer.handledType())) {
+      throw RequestException.Code.INVALID_CREATE_COLLECTION_FIELD.get(
+          "message",
+          "Unrecognized field \"%s\" for `createCollection.options.vector.indexOptions` (known fields: \"constructionBeamWidth\", \"enableHierarchy\", \"maximumNodeConnections\")"
               .formatted(propertyName));
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -127,7 +127,53 @@ public record CreateCollectionCommand(
                 description = "Optional vectorize configuration to provide embedding service",
                 type = SchemaType.OBJECT)
             @JsonProperty("service")
-            VectorizeConfig vectorizeConfig) {}
+            VectorizeConfig vectorizeConfig,
+        // -----
+        @Valid
+            @Nullable
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @Schema(
+                description =
+                    "Optional advanced tuning options for the underlying vector (ANN) index",
+                type = SchemaType.OBJECT)
+            @JsonProperty("indexOptions")
+            CreateCollectionCommand.Options.VectorIndexDesc indexOptions) {}
+
+    /**
+     * Advanced tuning options for the underlying vector (SAI ANN) index. All options are optional;
+     * when omitted the database defaults are used. See issue #2487 and the Cassandra SAI VECTOR.md.
+     */
+    public record VectorIndexDesc(
+        @Nullable
+            @Min(value = 1, message = "maximumNodeConnections must be between 1 and 512")
+            @Max(value = 512, message = "maximumNodeConnections must be between 1 and 512")
+            @Schema(
+                description =
+                    "Maximum number of connections per node in the vector index graph (HNSW 'M'). Valid range 1-512, default 16.",
+                defaultValue = "16",
+                type = SchemaType.INTEGER)
+            @JsonProperty("maximumNodeConnections")
+            Integer maximumNodeConnections,
+        // -----
+        @Nullable
+            @Min(value = 1, message = "constructionBeamWidth must be between 1 and 3200")
+            @Max(value = 3200, message = "constructionBeamWidth must be between 1 and 3200")
+            @Schema(
+                description =
+                    "Beam width used while building the vector index graph (HNSW 'ef_construction'). Valid range 1-3200, default 100.",
+                defaultValue = "100",
+                type = SchemaType.INTEGER)
+            @JsonProperty("constructionBeamWidth")
+            Integer constructionBeamWidth,
+        // -----
+        @Nullable
+            @Schema(
+                description =
+                    "Whether to enable hierarchical graph layers in the vector index. Default false.",
+                defaultValue = "false",
+                type = SchemaType.BOOLEAN)
+            @JsonProperty("enableHierarchy")
+            Boolean enableHierarchy) {}
 
     /** --- */
     public record IndexingDesc(

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/VectorConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/VectorConstants.java
@@ -13,5 +13,9 @@ public interface VectorConstants {
   interface CQLAnnIndex {
     String SOURCE_MODEL = "source_model";
     String SIMILARITY_FUNCTION = "similarity_function";
+    // Additional vector index tuning options (see Cassandra SAI VECTOR.md), issue #2487
+    String MAXIMUM_NODE_CONNECTIONS = "maximum_node_connections";
+    String CONSTRUCTION_BEAM_WIDTH = "construction_beam_width";
+    String ENABLE_HIERARCHY = "enable_hierarchy";
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperation.java
@@ -26,6 +26,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.tracing.RequestTracing;
 import io.stargate.sgv2.jsonapi.api.request.RequestContext;
 import io.stargate.sgv2.jsonapi.config.DatabaseLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.TableCommentConstants;
+import io.stargate.sgv2.jsonapi.config.constants.VectorConstants;
 import io.stargate.sgv2.jsonapi.exception.DatabaseException;
 import io.stargate.sgv2.jsonapi.exception.SchemaException;
 import io.stargate.sgv2.jsonapi.service.cqldriver.CQLSessionCache;
@@ -605,6 +606,26 @@ public record CreateCollectionOperation(
       }
       if (vectorDesc.sourceModel() != null && !vectorDesc.sourceModel().isBlank()) {
         vectorOptions.put("source_model", vectorDesc.sourceModel());
+      }
+      // Additional vector index tuning options (issue #2487). SAI index OPTIONS values must be
+      // strings, so convert to String to have them rendered as quoted CQL values.
+      var indexOptions = vectorDesc.indexOptions();
+      if (indexOptions != null) {
+        if (indexOptions.maximumNodeConnections() != null) {
+          vectorOptions.put(
+              VectorConstants.CQLAnnIndex.MAXIMUM_NODE_CONNECTIONS,
+              String.valueOf(indexOptions.maximumNodeConnections()));
+        }
+        if (indexOptions.constructionBeamWidth() != null) {
+          vectorOptions.put(
+              VectorConstants.CQLAnnIndex.CONSTRUCTION_BEAM_WIDTH,
+              String.valueOf(indexOptions.constructionBeamWidth()));
+        }
+        if (indexOptions.enableHierarchy() != null) {
+          vectorOptions.put(
+              VectorConstants.CQLAnnIndex.ENABLE_HIERARCHY,
+              String.valueOf(indexOptions.enableHierarchy()));
+        }
       }
       statements.add(
           buildSaiIndex(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolver.java
@@ -171,7 +171,11 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
       vectorDimension = validateVectorize.validateService(service, vectorDimension);
       vector =
           new CreateCollectionCommand.Options.VectorSearchDesc(
-              vectorDimension, metric, sourceModel, vector.vectorizeConfig());
+              vectorDimension,
+              metric,
+              sourceModel,
+              vector.vectorizeConfig(),
+              vector.indexOptions());
     } else {
       // Ensure vector dimension is provided when service configuration is absent.
       if (vectorDimension == null) {
@@ -188,7 +192,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
       }
       vector =
           new CreateCollectionCommand.Options.VectorSearchDesc(
-              vectorDimension, metric, sourceModel, null);
+              vectorDimension, metric, sourceModel, null, vector.indexOptions());
     }
     return vector;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSchemaObject.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/collections/CollectionSchemaObject.java
@@ -355,7 +355,10 @@ public final class CollectionSchemaObject extends TableBasedSchemaObject {
               vectorColumnDefinition.vectorSize(),
               vectorColumnDefinition.similarityFunction().name().toLowerCase(),
               vectorColumnDefinition.sourceModel().apiName(),
-              vectorizeConfig);
+              vectorizeConfig,
+              // Advanced vector index tuning options (issue #2487) are write-only: they are not
+              // read back from the CQL index metadata, so they are not echoed in findCollections.
+              null);
     }
 
     // populate the indexingConfig

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -47,6 +47,11 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
   // Property to disable lexical search tests when lexical/BM25 functionality not available
   public static final String TEST_PROP_LEXICAL_DISABLED = "testing.db.lexical-disabled";
 
+  // Property to disable tests using the 'enable_hierarchy' vector index option when the backend's
+  // SAI does not support it (e.g. DSE 6.9 rejects it; HCD supports it)
+  public static final String TEST_PROP_VECTOR_HIERARCHY_DISABLED =
+      "testing.db.vector-hierarchy-disabled";
+
   // keyspace automatically created in this test
   protected static final String keyspaceName =
       "ks" + RandomStringUtils.insecure().nextAlphanumeric(16);
@@ -380,6 +385,14 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
   /** Helper method for determining if lexical search is available for the database backend */
   protected boolean isLexicalAvailableForDB() {
     return !"true".equals(System.getProperty(TEST_PROP_LEXICAL_DISABLED));
+  }
+
+  /**
+   * Helper method for determining if the 'enable_hierarchy' vector index option is supported by the
+   * database backend (DSE 6.9 does not support it, HCD does).
+   */
+  protected boolean isVectorHierarchyAvailableForDB() {
+    return !"true".equals(System.getProperty(TEST_PROP_VECTOR_HIERARCHY_DISABLED));
   }
 
   /** Utility method for reducing boilerplate code for sending JSON commands */

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -93,7 +93,10 @@ class CreateCollectionIntegrationTest extends AbstractKeyspaceIntegrationTestBas
 
     @Test
     public void vectorCollectionWithIndexOptions() {
-      // Vector collection with the additional SAI vector index tuning options (issue #2487)
+      // Vector collection with the additional SAI vector index tuning options (issue #2487).
+      // NOTE: 'enableHierarchy' is intentionally NOT used here -- it is not supported by all
+      // backends (e.g. DSE 6.9); it is exercised separately in
+      // vectorCollectionWithHierarchyOption().
       final String collectionName = "col" + RandomStringUtils.insecure().nextNumeric(16);
       givenHeadersPostJsonThenOk(
                   """
@@ -106,7 +109,35 @@ class CreateCollectionIntegrationTest extends AbstractKeyspaceIntegrationTestBas
                               "metric" : "cosine",
                               "indexOptions" : {
                                 "maximumNodeConnections" : 32,
-                                "constructionBeamWidth" : 200,
+                                "constructionBeamWidth" : 200
+                              }
+                            }
+                          }
+                        }
+                      }
+                      """
+                  .formatted(collectionName))
+          .body("$", responseIsDDLSuccess())
+          .body("status.ok", is(1));
+      deleteCollection(collectionName);
+    }
+
+    @Test
+    public void vectorCollectionWithHierarchyOption() {
+      // 'enable_hierarchy' is only supported on newer backends (e.g. HCD), not DSE 6.9, so skip
+      // where unavailable rather than failing.
+      Assumptions.assumeTrue(isVectorHierarchyAvailableForDB());
+      final String collectionName = "col" + RandomStringUtils.insecure().nextNumeric(16);
+      givenHeadersPostJsonThenOk(
+                  """
+                      {
+                        "createCollection": {
+                          "name": "%s",
+                          "options" : {
+                            "vector" : {
+                              "dimension" : 5,
+                              "metric" : "cosine",
+                              "indexOptions" : {
                                 "enableHierarchy" : true
                               }
                             }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -92,6 +92,64 @@ class CreateCollectionIntegrationTest extends AbstractKeyspaceIntegrationTestBas
     }
 
     @Test
+    public void vectorCollectionWithIndexOptions() {
+      // Vector collection with the additional SAI vector index tuning options (issue #2487)
+      final String collectionName = "col" + RandomStringUtils.insecure().nextNumeric(16);
+      givenHeadersPostJsonThenOk(
+                  """
+                      {
+                        "createCollection": {
+                          "name": "%s",
+                          "options" : {
+                            "vector" : {
+                              "dimension" : 5,
+                              "metric" : "cosine",
+                              "indexOptions" : {
+                                "maximumNodeConnections" : 32,
+                                "constructionBeamWidth" : 200,
+                                "enableHierarchy" : true
+                              }
+                            }
+                          }
+                        }
+                      }
+                      """
+                  .formatted(collectionName))
+          .body("$", responseIsDDLSuccess())
+          .body("status.ok", is(1));
+      deleteCollection(collectionName);
+    }
+
+    @Test
+    public void vectorCollectionWithInvalidIndexOptions() {
+      // maximumNodeConnections out of the valid 1-512 range must be rejected
+      final String collectionName = "col" + RandomStringUtils.insecure().nextNumeric(16);
+      givenHeadersPostJsonThenOk(
+                  """
+                      {
+                        "createCollection": {
+                          "name": "%s",
+                          "options" : {
+                            "vector" : {
+                              "dimension" : 5,
+                              "metric" : "cosine",
+                              "indexOptions" : {
+                                "maximumNodeConnections" : 1000
+                              }
+                            }
+                          }
+                        }
+                      }
+                      """
+                  .formatted(collectionName))
+          .body("$", responseIsError())
+          .body("errors[0].errorCode", is(RequestException.Code.COMMAND_FIELD_VALUE_INVALID.name()))
+          .body(
+              "errors[0].message",
+              containsString("maximumNodeConnections must be between 1 and 512"));
+    }
+
+    @Test
     public void caseSensitive() {
       givenHeadersPostJsonThenOk(
                   """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/collections/CreateCollectionOperationTest.java
@@ -132,6 +132,19 @@ public class CreateCollectionOperationTest extends OperationTestBase {
     return memento;
   }
 
+  /** Captures the full CQL of every schema-change statement (table + indexes) that is executed. */
+  private List<String> captureSchemaChangeQueries(QueryExecutor queryExecutor) {
+    List<String> queries = new ArrayList<>();
+    when(queryExecutor.executeCreateSchemaChange(eq(requestContext), any()))
+        .then(
+            invocation -> {
+              SimpleStatement statement = invocation.getArgument(1);
+              queries.add(statement.getQuery());
+              return Uni.createFrom().item(mockSuccessSchemaResultset());
+            });
+    return queries;
+  }
+
   private void addKeyspaceSchema(QueryExecutor queryExecutor) {
 
     var driverMetadata = mock(Metadata.class);
@@ -222,7 +235,8 @@ public class CreateCollectionOperationTest extends OperationTestBase {
     // aaron - 19-nov-2025 - best I can tell the sessionCache is not used but we need to pass it
     // :(
 
-    var vectorDesc = new CreateCollectionCommand.Options.VectorSearchDesc(5, "cosine", null, null);
+    var vectorDesc =
+        new CreateCollectionCommand.Options.VectorSearchDesc(5, "cosine", null, null, null);
     // Must use validateVectorOptions() because it will cleanup defaults, the resolver normally does
     // this.
     vectorDesc = createCollectionCommandResolver.validateVectorOptions(vectorDesc);
@@ -274,6 +288,56 @@ public class CreateCollectionOperationTest extends OperationTestBase {
     assertThat(vectorColumnDefinition.vectorizeDefinition())
         .as("Vectorize definition from table comment matches")
         .isNull();
+  }
+
+  @Test
+  public void createCollectionVectorWithIndexOptions() {
+
+    var queryExecutor = mock(QueryExecutor.class);
+    var queries = captureSchemaChangeQueries(queryExecutor);
+    addKeyspaceSchema(queryExecutor);
+
+    var indexOptions = new CreateCollectionCommand.Options.VectorIndexDesc(32, 200, Boolean.TRUE);
+    var vectorDesc =
+        new CreateCollectionCommand.Options.VectorSearchDesc(5, "cosine", null, null, indexOptions);
+    // Must use validateVectorOptions() because it will cleanup defaults, the resolver normally does
+    // this.
+    vectorDesc = createCollectionCommandResolver.validateVectorOptions(vectorDesc);
+
+    var operation =
+        new CreateCollectionOperation(
+            KEYSPACE_CONTEXT,
+            databaseLimitsConfig,
+            mock(CQLSessionCache.class),
+            TEST_CONSTANTS.COLLECTION_IDENTIFIER.table(),
+            10,
+            false,
+            null,
+            null,
+            vectorDesc,
+            CollectionLexicalDefSchemaFactory.FOR_TESTING_ENABLED.currentVersion(null),
+            CollectionRerankDefSchemaFactory.FOR_TESTING_ENABLED.currentVersion(null));
+
+    operation
+        .execute(requestContext, queryExecutor)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .awaitItem();
+
+    // Find the vector index statement and check it carries the new tuning options (as quoted
+    // string values, alongside the existing similarity_function/source_model options).
+    var vectorIndexCql =
+        queries.stream()
+            .filter(q -> q.startsWith("CREATE CUSTOM INDEX") && q.contains("query_vector_value"))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(vectorIndexCql)
+        .as("Vector index CQL carries the advanced tuning options")
+        .contains("'maximum_node_connections':'32'")
+        .contains("'construction_beam_width':'200'")
+        .contains("'enable_hierarchy':'true'")
+        .contains("'similarity_function':'cosine'");
   }
 
   @Test
@@ -337,7 +401,8 @@ public class CreateCollectionOperationTest extends OperationTestBase {
     var schemaChangeMemento = addSchemaChangeMomento(queryExecutor);
     addKeyspaceSchema(queryExecutor);
 
-    var vectorDesc = new CreateCollectionCommand.Options.VectorSearchDesc(5, "cosine", null, null);
+    var vectorDesc =
+        new CreateCollectionCommand.Options.VectorSearchDesc(5, "cosine", null, null, null);
     // Must use validateVectorOptions() because it will cleanup defaults, the resolver normally does
     // this.
     vectorDesc = createCollectionCommandResolver.validateVectorOptions(vectorDesc);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/CreateCollectionCommandResolverTest.java
@@ -103,6 +103,44 @@ class CreateCollectionCommandResolverTest {
     }
 
     @Test
+    public void happyPathVectorSearchWithIndexOptions() throws Exception {
+      var json =
+          TEST_CONSTANTS.subsRawNames(
+              """
+          {
+            "createCollection": {
+              "name" : "${collection}",
+              "options": {
+                "vector": {
+                  "dimension": 4,
+                  "metric": "cosine",
+                  "indexOptions": {
+                    "maximumNodeConnections": 32,
+                    "constructionBeamWidth": 200,
+                    "enableHierarchy": true
+                  }
+                }
+              }
+            }
+          }
+          """);
+
+      var command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      var operation = resolver.resolveCommand(commandContext, command);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              CreateCollectionOperation.class,
+              op -> {
+                assertThat(op.vectorDesc()).isNotNull();
+                assertThat(op.vectorDesc().indexOptions()).isNotNull();
+                assertThat(op.vectorDesc().indexOptions().maximumNodeConnections()).isEqualTo(32);
+                assertThat(op.vectorDesc().indexOptions().constructionBeamWidth()).isEqualTo(200);
+                assertThat(op.vectorDesc().indexOptions().enableHierarchy()).isTrue();
+              });
+    }
+
+    @Test
     public void happyPathVectorizeSearch() throws Exception {
       var json =
           TEST_CONSTANTS.subsRawNames(
@@ -137,7 +175,8 @@ class CreateCollectionCommandResolverTest {
                   "azureOpenAI",
                   "text-embedding-3-small",
                   null,
-                  Map.of("resourceName", "test", "deploymentId", "test")));
+                  Map.of("resourceName", "test", "deploymentId", "test")),
+              null);
 
       var command = objectMapper.readValue(json, CreateCollectionCommand.class);
       var operation = resolver.resolveCommand(commandContext, command);


### PR DESCRIPTION
**What this PR does**:

Adds 3 new Vector index options:

* `maximum_node_connections`
* `construction_beam_width`
* `enable_hierarchy`

**EDIT**: options only available on HCD, not DSE-6.9. Not sure how to go about that.

**Which issue(s) this PR fixes**:
Fixes #2487 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
