### PR TITLE
fix: remove global driver request page-size

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -51,7 +51,6 @@ datastax-java-driver {
     }
   }
   basic.request.timeout = 20 seconds
-  basic.request.page-size = 50
 
   # see https://github.com/stargate/data-api/pull/2250 description
   advanced.resolve-contact-points = false


### PR DESCRIPTION
**What this PR does**:

Removes the global `basic.request.page-size = 50` added in #2461. The `count` execution profile does not set its own page size, so it inherited the global value and `countDocuments` stopped counting past the first page of 50 keys (the regression reported against 1.0.47). Removing the global restores the driver default page size for the count profile, which is the pre-1.0.47 behavior. The `table-read` profile keeps its explicit page size and collection reads set the page size per statement, so read pagination is unchanged. The root cause of counting stopping at the first page is fixed separately in #2497.

**Which issue(s) this PR fixes**:
Fixes the `countDocuments` regression #2496   reported against 1.0.47.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)