### PR TITLE
fix: accept Docker Compose newer than 2.x in docker-compose start scripts

### DIFF
--- a/docker-compose/start_dse69.sh
+++ b/docker-compose/start_dse69.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# require Docker Compose v2
-if [[ ! $(docker compose version --short) =~ ^2. ]]; then
-  echo "Docker compose v2 required. Please upgrade Docker Desktop to the latest version."
+# require Docker Compose v2 or newer (rejects v1 and a missing compose plugin)
+COMPOSE_VERSION="$(docker compose version --short 2>/dev/null || true)"
+COMPOSE_VERSION="${COMPOSE_VERSION#v}"
+if [[ ! "${COMPOSE_VERSION%%.*}" =~ ^[0-9]+$ ]] || (( ${COMPOSE_VERSION%%.*} < 2 )); then
+  echo "Docker Compose v2 or newer required (found: ${COMPOSE_VERSION:-none})."
   exit 1
 fi
 

--- a/docker-compose/start_hcd.sh
+++ b/docker-compose/start_hcd.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# require Docker Compose v2
-if [[ ! $(docker compose version --short) =~ ^2. ]]; then
-  echo "Docker compose v2 required. Please upgrade Docker Desktop to the latest version."
+# require Docker Compose v2 or newer (rejects v1 and a missing compose plugin)
+COMPOSE_VERSION="$(docker compose version --short 2>/dev/null || true)"
+COMPOSE_VERSION="${COMPOSE_VERSION#v}"
+if [[ ! "${COMPOSE_VERSION%%.*}" =~ ^[0-9]+$ ]] || (( ${COMPOSE_VERSION%%.*} < 2 )); then
+  echo "Docker Compose v2 or newer required (found: ${COMPOSE_VERSION:-none})."
   exit 1
 fi
 


### PR DESCRIPTION
## What this fixes

`start_dse69.sh` and `start_hcd.sh` gate on Docker Compose v2 with:

```bash
if [[ ! $(docker compose version --short) =~ ^2. ]]; then
```

The regex matches the literal prefix `2.`, so any Compose release past the 2.x line — e.g. current Homebrew `docker-compose` 5.1.4 — is rejected with *"Docker compose v2 required. Please upgrade Docker Desktop to the latest version."* The original intent was to reject Compose **v1**, not to pin to 2.x forever.

The old check also fails confusingly when the compose CLI plugin isn't discoverable at all (common with a brew-installed docker CLI, where the plugin lands in `/opt/homebrew/lib/docker/cli-plugins`, a directory the CLI doesn't search by default):

```
unknown flag: --short

Usage:  docker [OPTIONS] COMMAND [ARG...]
...
Docker compose v2 required. Please upgrade Docker Desktop to the latest version.
```

## The change

Both scripts now parse the major version and require it to be **>= 2**, tolerate a leading `v`, and report what was actually found when rejecting:

```
Docker Compose v2 or newer required (found: none).
```

| `docker compose version --short` | before | after |
|---|---|---|
| `2.39.2` | accept | accept |
| `v2.24.5` | accept | accept |
| `5.1.4` | **reject** | accept |
| `1.29.2` | reject | reject |
| (plugin missing) | stray `unknown flag` + misleading hint | reject with `found: none` |

## Test plan

- [x] `bash -n` on both scripts
- [x] Gate logic exercised against the version strings in the table above
- [x] `./start_dse69.sh -d` end-to-end with Compose 5.1.4 on macOS (colima): DSE container starts and reaches healthy via `--wait`
- [ ] `./start_hcd.sh` smoke run (same gate, identical change)