### PR TITLE
Convert config key to map<string, String> and provide custom unmarsha…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,9 @@ nb-configuration.xml
 .env
 !/docker-compose/.env
 
+# AI Tools
+.claude
+.bob
+
 # NoSQLBench
 logs/

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/ApiFeatures.java
@@ -18,9 +18,8 @@ public class ApiFeatures {
   private final Map<ApiFeature, String> fromConfig;
   private final RequestContext.HttpHeaderAccess httpHeaders;
 
-  private ApiFeatures(
-      Map<ApiFeature, String> fromConfig, RequestContext.HttpHeaderAccess httpHeaders) {
-    this.fromConfig = fromConfig;
+  private ApiFeatures(Map<String, String> fromConfig, RequestContext.HttpHeaderAccess httpHeaders) {
+    this.fromConfig = marshallFromConfig(fromConfig);
     this.httpHeaders = httpHeaders;
   }
 
@@ -28,9 +27,44 @@ public class ApiFeatures {
     return new ApiFeatures(Collections.emptyMap(), null);
   }
 
+  protected Map<ApiFeature, String> marshallFromConfig(Map<String, String> fromConfig) {
+    if (fromConfig == null || fromConfig.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<ApiFeature, String> result = new java.util.HashMap<>();
+    for (Map.Entry<String, String> entry : fromConfig.entrySet()) {
+      String key = entry.getKey();
+      ApiFeature feature = findFeatureByName(key);
+      if (feature == null) {
+        throw new IllegalArgumentException(
+            "Invalid feature flag key: '"
+                + key
+                + "'. Expected one of: "
+                + java.util.Arrays.stream(ApiFeature.values())
+                    .map(
+                        f ->
+                            "STARGATE_FEATURE_FLAGS_"
+                                + f.featureName().toUpperCase().replace('-', '_'))
+                    .collect(java.util.stream.Collectors.joining(", ")));
+      }
+      result.put(feature, entry.getValue());
+    }
+    return result;
+  }
+
+  private ApiFeature findFeatureByName(String name) {
+    for (ApiFeature feature : ApiFeature.values()) {
+      if (feature.featureName().equals(name)) {
+        return feature;
+      }
+    }
+    return null;
+  }
+
   public static ApiFeatures fromConfigAndRequest(
       FeaturesConfig config, RequestContext.HttpHeaderAccess httpHeaders) {
-    Map<ApiFeature, String> fromConfig = config.flags();
+    Map<String, String> fromConfig = config.flags();
     if (fromConfig == null) {
       fromConfig = Collections.emptyMap();
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/feature/FeaturesConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/feature/FeaturesConfig.java
@@ -7,14 +7,49 @@ import java.util.Map;
  * Configuration mapping for Data API Feature flags as read from main application configuration
  * (with possible property / sysenv overrides).
  *
- * <p>NOTE: actual keys in YAML or similar configuration file would be {@code
- * stargate.feature.<feature-name>}, where {@code <feature-name>} comes from {@link
- * ApiFeature#featureName()} (which is always lower-case). So, for example, to enable {@link
- * ApiFeature#TABLES} feature, one would use: {@code stargate.feature.flags.tables} as the key.
+ * <p>Feature flags can be configured using either property file format (with dots) or environment
+ * variables (with underscores). The configuration uses the prefix {@code stargate.feature.flags}
+ * followed by the feature name from {@link ApiFeature#featureName()} (always in lower-case
+ * kebab-case format).
+ *
+ * <p><b>Property File Examples (application.yaml, application.properties):</b>
+ *
+ * <pre>
+ * stargate.feature.flags.lexical=true
+ * stargate.feature.flags.tables=false
+ * stargate.feature.flags.reranking=true
+ * stargate.feature.flags.mcp=false
+ * stargate.feature.flags.request-tracing=true
+ * stargate.feature.flags.billing-events-logging=true
+ * </pre>
+ *
+ * <p><b>Environment Variable Examples:</b>
+ *
+ * <pre>
+ * export STARGATE_FEATURE_FLAGS_LEXICAL=true
+ * export STARGATE_FEATURE_FLAGS_TABLES=false
+ * export STARGATE_FEATURE_FLAGS_RERANKING=true
+ * export STARGATE_FEATURE_FLAGS_MCP=false
+ * export STARGATE_FEATURE_FLAGS_REQUEST_TRACING=true
+ * export STARGATE_FEATURE_FLAGS_BILLING_EVENTS_LOGGING=true
+ * </pre>
+ *
+ * <p><b>Note:</b> Quarkus/SmallRye Config automatically translates underscores ({@code _}) in
+ * environment variable names to dots ({@code .}) when matching configuration keys. Feature flag
+ * values are bound as Strings and converted to Boolean when needed. Null values are not accepted.
+ *
+ * @see ApiFeature for available feature flags
+ * @see ApiFeatures for runtime feature flag evaluation
  */
 @ConfigMapping(prefix = "stargate.feature")
 public interface FeaturesConfig {
-  // Quarkus/SmallRye Config won't accept use of `null` values, so we must bind
-  // as Strings and only convert to Boolean when needed.
-  Map<ApiFeature, String> flags();
+
+  /**
+   * Returns a map of feature flag names to their configured values. Keys are feature names in
+   * kebab-case format (e.g., "lexical", "billing-events-logging"). Values are string
+   * representations of boolean flags ("true", "false", or blank for undefined).
+   *
+   * @return map of feature flag configurations, never null but may be empty
+   */
+  Map<String, String> flags();
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/provider/BillingTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/provider/BillingTest.java
@@ -77,7 +77,7 @@ class BillingTest {
   @Test
   void createConfigEnabledIsNotOverriddenByHeader() {
     var config = mock(FeaturesConfig.class);
-    when(config.flags()).thenReturn(Map.of(ApiFeature.BILLING_EVENTS_LOGGING, "true"));
+    when(config.flags()).thenReturn(Map.of("billing-events-logging", "true"));
 
     var headers = MultiMap.caseInsensitiveMultiMap();
     headers.add(ApiFeature.BILLING_EVENTS_LOGGING.httpHeaderName(), "false");
@@ -126,8 +126,7 @@ class BillingTest {
 
   private static ApiFeatures featuresWithBilling(boolean enabled) {
     var config = mock(FeaturesConfig.class);
-    when(config.flags())
-        .thenReturn(Map.of(ApiFeature.BILLING_EVENTS_LOGGING, String.valueOf(enabled)));
+    when(config.flags()).thenReturn(Map.of("billing-events-logging", String.valueOf(enabled)));
     return ApiFeatures.fromConfigAndRequest(config, null);
   }
 


### PR DESCRIPTION
## What This PR Does

This PR resolves a configuration mismatch when setting API feature flags via environment variables.

Previously, feature flags whose enum names contained underscores (for example, `BILLING_EVENTS_LOGGING`) could not be configured correctly through environment variables. This occurred because SmallRye Config automatically translates underscores (`_`) to dots (`.`), which conflicted with the existing enum-to-string conversion logic.

By changing feature flag configuration keys from enum types to strings at the configuration boundary and performing explicit conversion at runtime, both property-based and environment-variable-based configuration now work consistently.

## Related Issue

Fixes #2506

## Changes

### 1. `FeaturesConfig.java`

- Changed the configuration mapping from:

  ```java
  Map<ApiFeature, String> flags()
  ```

  to:

  ```java
  Map<String, String> flags()
  ```

- Added comprehensive JavaDoc documentation covering:
  - Configuration using property files
  - Configuration using environment variables
  - SmallRye Config's automatic underscore-to-dot translation behavior
- Added configuration examples for both approaches

### 2. `ApiFeatures.java`

- Added `marshallFromConfig(Map<String, String>)` to convert configuration keys to `ApiFeature` enums
- Added `findFeatureByName(String)` helper method to support kebab-case feature flag lookup
- Updated the constructor to accept `Map<String, String>` and perform explicit marshalling
- Added robust validation and error handling that:
  - Detects invalid feature flag names
  - Provides clear, actionable error messages
  - Lists all supported feature flag names

### 3. `BillingTest.java`

- Updated test mocks to use string-based feature flag keys (for example, `"billing-events-logging"`) instead of enum values
- Verified configuration values take precedence over request headers
- Verified request headers can enable features when configuration is not set
- Preserved all existing test coverage

## Configuration Examples

### Property File (`application.yaml`)

```yaml
stargate.feature.flags.lexical: true
stargate.feature.flags.billing-events-logging: true
```

### Environment Variables

```bash
export STARGATE_FEATURE_FLAGS_LEXICAL=true
export STARGATE_FEATURE_FLAGS_BILLING_EVENTS_LOGGING=true
```

## Checklist

- [x] Changes manually tested
- [x] Automated tests added/updated
- [x] Documentation added/updated
- [x] https://cla.datastax.com/