### PR TITLE
fix: truncate oversized reranking passages instead of failing the request

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
@@ -64,13 +64,16 @@ public class NvidiaRerankingProvider extends RerankingProvider {
   /**
    * Nvidia Reranking Service supports truncation or error behavior when the passage is too long.
    *
-   * <p>The Data API uses {@code NONE} as the default, which means the reranking request will error
-   * out if there is a query and passage pair that exceeds the allowed token size of 8192.
+   * <p>The Data API uses {@code END}, which truncates the end of any query and passage pair that
+   * exceeds the model's allowed token size (8192). With {@code NONE} a single oversized pair fails
+   * the whole reranking request (HTTP 400), and because batches are dispatched fail-fast, the
+   * entire findAndRerank command fails deterministically for any query whose candidate set contains
+   * one oversized document.
    *
    * <p>See:
    * https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/using-reranking.html#token-limits-truncation
    */
-  private static final String TRUNCATE_PASSAGE = "NONE";
+  private static final String TRUNCATE_PASSAGE = "END";
 
   public NvidiaRerankingProvider(
       RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig) {


### PR DESCRIPTION
**What this PR does**:

Changes the NVIDIA reranking request's `truncate` option from `NONE` to `END`.

With `NONE`, a single query+passage pair over the model's 8192-token limit fails the whole batch with HTTP 400 (`Input length 16384 exceeds maximum allowed token size 8192`), and because rerank batches are dispatched fail-fast, the entire `findAndRerank` command fails — deterministically, for any query whose candidate set contains one oversized document. No `hybridLimits` setting avoids it when the oversized document ranks highly.

Observed against a production collection containing large OCR'd table chunks (13–15k chars, digit/punctuation-heavy): ~3% of eval queries fail 100% of the time with `RERANKING_PROVIDER_CLIENT_ERROR`. With `END`, the NIM truncates the oversized pair and scores the remaining tokens — a strictly better outcome than failing the whole command.

One-line constant change plus javadoc; no config surface added while findAndRerank is still stabilizing. If per-model configurability is wanted later, `truncate` can move into `reranking-providers-config.yaml` as a follow-up.

Validation:

- `NvidiaRerankingProviderTest` + `RerankingProviderTest` pass (4 tests)
- formatting clean (`fmt:format`)

**Which issue(s) this PR fixes**:

N/A — follow-up to the GPU-plane concurrency investigation (same series as #2530).

**Checklist**
- [ ] Changes manually tested after deployment
- [ ] Automated Tests added/updated (no existing test exercises the wire payload; not adding mock-server scaffolding for a constant)
- [x] Documentation added/updated (javadoc)
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
