### PR TITLE
fix: don't retry rerank timeouts, raise read timeout to 20s

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java
@@ -92,12 +92,13 @@ public interface RerankingProvidersConfig {
         int initialBackOffMillis();
 
         /**
-         * The maximum duration for a request to complete in milliseconds. Default is 5000 ms (5
-         * seconds), ensuring retries are likely within general gateway timeouts.
+         * The maximum duration for a request to complete in milliseconds. Default is 20000 ms (20
+         * seconds). Rerank calls are not retried, so the single attempt needs to cover time spent
+         * queued at a busy reranker.
          *
          * @return The request timeout in milliseconds.
          */
-        @WithDefault("5000")
+        @WithDefault("20000")
         int readTimeoutMillis();
 
         /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java
@@ -93,8 +93,7 @@ public interface RerankingProvidersConfig {
 
         /**
          * The maximum duration for a request to complete in milliseconds. Default is 20000 ms (20
-         * seconds). Rerank calls are not retried, so the single attempt needs to cover time spent
-         * queued at a busy reranker.
+         * seconds).
          *
          * @return The request timeout in milliseconds.
          */

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProvider.java
@@ -122,10 +122,9 @@ public abstract class RerankingProvider extends ProviderBase {
 
   @Override
   protected boolean decideRetry(Throwable throwable) {
-    boolean retry =
-        throwable instanceof RerankingProviderException rpe
-            && RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.name().equals(rpe.code);
-    return retry || super.decideRetry(throwable);
+    // Never retry. A timeout usually means the reranker is saturated and the original request
+    // is still queued there - retrying just adds more load.
+    return false;
   }
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProvider.java
@@ -122,8 +122,7 @@ public abstract class RerankingProvider extends ProviderBase {
 
   @Override
   protected boolean decideRetry(Throwable throwable) {
-    // Never retry. A timeout usually means the reranker is saturated and the original request
-    // is still queued there - retrying just adds more load.
+    // Don't retry since timeout implies saturated reranker service
     return false;
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderTest.java
@@ -7,8 +7,11 @@ import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.sgv2.jsonapi.TestConstants;
 import io.stargate.sgv2.jsonapi.api.request.RerankingCredentials;
+import io.stargate.sgv2.jsonapi.exception.RerankingProviderException;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
@@ -98,5 +101,25 @@ public class RerankingProviderTest {
     // passage order
     IntStream.range(0, 15)
         .forEach(i -> assertThat(finalResult.ranks().get(i).index()).isEqualTo(i));
+  }
+
+  // Timeouts should fail fast, not retry - retries just add load to a saturated reranker.
+  @Test
+  void timeoutsAreNotRetried() {
+    TestRerankingProvider mockRerankingProvider = new TestRerankingProvider(10);
+
+    var providerTimeout =
+        RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.get(
+            Map.of(
+                "modelProvider", "nvidia",
+                "httpStatus", "504",
+                "errorMessage", "gateway timeout"));
+
+    assertThat(mockRerankingProvider.decideRetry(providerTimeout))
+        .as("provider-reported timeout is not retried")
+        .isFalse();
+    assertThat(mockRerankingProvider.decideRetry(new TimeoutException("read timed out")))
+        .as("client-side read timeout is not retried")
+        .isFalse();
   }
 }


### PR DESCRIPTION
Increase the timeout and remove retries from the `/v1/reranking` call.

## Changes

- Don't retry rerank calls. Timeouts were the only retried failure and saturated an already saturated queue
- Raise the default read timeout from 5s to 20s, roughly the old worst-case budget (4 attempts x 5s). Overridable in `reranking-providers-config.yaml`.
- NOTE: better queue drain algos in 2.0.0 rust NIMs, investigate after upgrade

## Testing

New `RerankingProviderTest#timeoutsAreNotRetried`; all rerank provider tests pass.