### PR TITLE
feat: allow custom NIM-compatible external reranking endpoints (BYO reranker)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
@@ -26,6 +26,9 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 /**
  * The Reranking Nvidia Client that sends the request to the Nvidia Reranking Service.
  *
+ * <p>Also used for {@link ModelProvider#CUSTOM}: an externally hosted endpoint that speaks the same
+ * NIM wire format. Only the {@link ModelProvider} used for metrics/usage attribution differs.
+ *
  * <p>Sample http request to self hosted nvidia model - nvidia/llama-3.2-nv-rerankqa-1b-v2:
  *
  * <pre>{@code
@@ -73,8 +76,9 @@ public class NvidiaRerankingProvider extends RerankingProvider {
   private static final String TRUNCATE_PASSAGE = "NONE";
 
   public NvidiaRerankingProvider(
+      ModelProvider modelProvider,
       RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig) {
-    super(ModelProvider.NVIDIA, modelConfig);
+    super(modelProvider, modelConfig);
 
     nvidiaClient =
         QuarkusRestClientBuilder.newBuilder()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactory.java
@@ -11,6 +11,7 @@ import io.stargate.sgv2.jsonapi.service.reranking.gateway.RerankingEGWClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +28,26 @@ public class RerankingProviderFactory {
   @FunctionalInterface
   interface ProviderConstructor {
     RerankingProvider create(
+        ModelProvider modelProvider,
         RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig);
   }
 
+  // CUSTOM is an externally hosted endpoint that speaks the same NIM wire format, so it reuses
+  // the Nvidia client.
   private static final Map<ModelProvider, ProviderConstructor> RERANKING_PROVIDER_CTORS =
-      Map.ofEntries(Map.entry(ModelProvider.NVIDIA, NvidiaRerankingProvider::new));
+      Map.ofEntries(
+          Map.entry(ModelProvider.NVIDIA, NvidiaRerankingProvider::new),
+          Map.entry(ModelProvider.CUSTOM, NvidiaRerankingProvider::new));
+
+  /**
+   * Cache of direct (non-gateway) providers, keyed by provider + model, so their HTTP clients and
+   * connection pools are reused across requests. Sharing is safe because all per-request state
+   * (tenant, credentials) is passed to {@link RerankingProvider#rerank}.
+   */
+  private final Map<DirectProviderKey, RerankingProvider> directProviders =
+      new ConcurrentHashMap<>();
+
+  private record DirectProviderKey(ModelProvider modelProvider, String modelName) {}
 
   public RerankingProvider create(
       Tenant tenant,
@@ -111,7 +127,9 @@ public class RerankingProviderFactory {
           Map.of(
               "errorMessage", "unknown service provider '%s'".formatted(modelProvider.apiName())));
     }
-    return ctor.create(modelConfig);
+    return directProviders.computeIfAbsent(
+        new DirectProviderKey(modelProvider, modelName),
+        key -> ctor.create(modelProvider, modelConfig));
   }
 
   public RerankingProvidersConfig getRerankingConfig() {

--- a/src/main/resources/test-reranking-providers-config.yaml
+++ b/src/main/resources/test-reranking-providers-config.yaml
@@ -29,3 +29,21 @@ stargate:
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
                 max-batch-size: 10
+        # Example of an externally hosted, NIM-compatible reranking endpoint. Not in the shipped
+        # production config; deployments add their own 'custom' block via RERANKING_CONFIG_RESOURCE.
+        custom:
+          display-name: Custom
+          enabled: true
+          supported-authentications:
+            NONE:
+              enabled: true
+            HEADER:
+              enabled: true
+              tokens:
+                - accepted: reranking-api-key
+                  forwarded: Authorization
+          models:
+            - name: my-org/my-nim-reranker
+              url: http://my-reranker.internal:8000/v1/ranking
+              properties:
+                max-batch-size: 10

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindRerankingProvidersIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindRerankingProvidersIntegrationTest.java
@@ -125,6 +125,30 @@ public class FindRerankingProvidersIntegrationTest extends AbstractKeyspaceInteg
     }
 
     @Test
+    public final void customNimCompatibleProviderIsListed() {
+      // the 'custom' provider from test-reranking-providers-config.yaml is listed like any other
+      givenHeadersAndJson(
+              """
+                    {
+                      "findRerankingProviders": {
+                      }
+                    }
+                    """)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("$", responseIsStatusOnly())
+          .body("status.rerankingProviders.custom.displayName", equalTo("Custom"))
+          .body("status.rerankingProviders.custom.models", hasSize(1))
+          .body(
+              "status.rerankingProviders.custom.models[0].name", equalTo("my-org/my-nim-reranker"))
+          .body(
+              "status.rerankingProviders.custom.models[0].apiModelSupport.status",
+              equalTo(ApiModelSupport.SupportStatus.SUPPORTED.name()));
+    }
+
+    @Test
     public final void failedWithRandomStatus() {
       givenHeadersAndJson(
               """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProviderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProviderTest.java
@@ -10,6 +10,7 @@ import io.stargate.sgv2.jsonapi.TestConstants;
 import io.stargate.sgv2.jsonapi.api.request.RerankingCredentials;
 import io.stargate.sgv2.jsonapi.exception.SchemaException;
 import io.stargate.sgv2.jsonapi.service.provider.ApiModelSupport;
+import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfigImpl;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
@@ -41,7 +42,8 @@ public class NvidiaRerankingProviderTest {
 
   @Test
   void testEmptyApiKeyThrowsException() {
-    NvidiaRerankingProvider provider = new NvidiaRerankingProvider(MODEL_CONFIG);
+    NvidiaRerankingProvider provider =
+        new NvidiaRerankingProvider(ModelProvider.NVIDIA, MODEL_CONFIG);
 
     RerankingCredentials emptyApiKeyCredentials =
         new RerankingCredentials(testConstants.TENANT, "");
@@ -69,7 +71,8 @@ public class NvidiaRerankingProviderTest {
   void testTenantIdIsExtractedFromCredentials() {
     // Verify that the tenant from RerankingCredentials is correctly accessible
     // This ensures the tenant ID will be correctly passed as "tenant-id" header
-    NvidiaRerankingProvider provider = new NvidiaRerankingProvider(MODEL_CONFIG);
+    NvidiaRerankingProvider provider =
+        new NvidiaRerankingProvider(ModelProvider.NVIDIA, MODEL_CONFIG);
 
     String expectedTenantId = testConstants.TENANT.toString();
     RerankingCredentials credentials =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactoryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactoryTest.java
@@ -1,0 +1,169 @@
+package io.stargate.sgv2.jsonapi.service.reranking.operation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.jsonapi.TestConstants;
+import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.SchemaException;
+import io.stargate.sgv2.jsonapi.service.provider.ApiModelSupport;
+import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
+import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
+import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfigImpl;
+import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link RerankingProviderFactory} provider wiring and instance caching. */
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class RerankingProviderFactoryTest {
+
+  private static final TestConstants testConstants = new TestConstants();
+
+  private static final String CUSTOM_MODEL_NAME = "my-org/my-nim-reranker";
+  private static final String OTHER_CUSTOM_MODEL_NAME = "my-org/my-other-nim-reranker";
+  private static final String NVIDIA_MODEL_NAME = "nvidia/llama-3.2-nv-rerankqa-1b-v2";
+
+  private static final RerankingProvidersConfig.RerankingProviderConfig.ModelConfig
+          .RequestProperties
+      REQUEST_PROPERTIES =
+          new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl
+              .RequestPropertiesImpl(3, 100, 5000, 500, 0.5, 10);
+
+  private static RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig(
+      String name, String url) {
+    return new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl(
+        name,
+        new ApiModelSupport.ApiModelSupportImpl(
+            ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
+        false,
+        url,
+        REQUEST_PROPERTIES);
+  }
+
+  private static RerankingProvidersConfig.RerankingProviderConfig providerConfig(
+      String displayName, RerankingProvidersConfig.RerankingProviderConfig.ModelConfig... models) {
+    return new RerankingProvidersConfigImpl.RerankingProviderConfigImpl(
+        false,
+        displayName,
+        true,
+        Map.of(
+            RerankingProvidersConfig.RerankingProviderConfig.AuthenticationType.NONE,
+            new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.AuthenticationConfigImpl(
+                true, List.of())),
+        List.of(models));
+  }
+
+  private static final RerankingProvidersConfig CONFIG =
+      new RerankingProvidersConfigImpl(
+          Map.of(
+              ModelProvider.NVIDIA.apiName(),
+              providerConfig(
+                  "Nvidia",
+                  modelConfig(
+                      NVIDIA_MODEL_NAME,
+                      "https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking")),
+              ModelProvider.CUSTOM.apiName(),
+              providerConfig(
+                  "Custom",
+                  modelConfig(CUSTOM_MODEL_NAME, "http://localhost:8000/v1/ranking"),
+                  modelConfig(OTHER_CUSTOM_MODEL_NAME, "http://localhost:8001/v1/ranking"))));
+
+  private static RerankingProviderFactory factory() {
+    var factory = new RerankingProviderFactory();
+    factory.rerankingConfig = CONFIG;
+    factory.operationsConfig = mock(OperationsConfig.class);
+    when(factory.operationsConfig.enableEmbeddingGateway()).thenReturn(false);
+    return factory;
+  }
+
+  private static RerankingProvider create(
+      RerankingProviderFactory factory, ModelProvider provider, String modelName) {
+    return factory.create(
+        testConstants.TENANT, "test-token", provider.apiName(), modelName, null, "testCommand");
+  }
+
+  private static void assertServiceUnavailable(ThrowingCallable call) {
+    assertThatThrownBy(call)
+        .isInstanceOf(SchemaException.class)
+        .satisfies(
+            e ->
+                assertThat(((SchemaException) e).code)
+                    .isEqualTo(SchemaException.Code.RERANKING_SERVICE_TYPE_UNAVAILABLE.name()));
+  }
+
+  @Test
+  public void customProviderCreatesNimClientWithCustomAttribution() {
+    var provider = create(factory(), ModelProvider.CUSTOM, CUSTOM_MODEL_NAME);
+
+    assertThat(provider).isInstanceOf(NvidiaRerankingProvider.class);
+    assertThat(provider.modelProvider())
+        .as("metrics/usage attribute to 'custom', not 'nvidia'")
+        .isEqualTo(ModelProvider.CUSTOM);
+    assertThat(provider.modelName()).isEqualTo(CUSTOM_MODEL_NAME);
+  }
+
+  @Test
+  public void nvidiaProviderAttributionUnchanged() {
+    var provider = create(factory(), ModelProvider.NVIDIA, NVIDIA_MODEL_NAME);
+
+    assertThat(provider).isInstanceOf(NvidiaRerankingProvider.class);
+    assertThat(provider.modelProvider()).isEqualTo(ModelProvider.NVIDIA);
+    assertThat(provider.modelName()).isEqualTo(NVIDIA_MODEL_NAME);
+  }
+
+  @Test
+  public void unknownModelThrows() {
+    assertServiceUnavailable(() -> create(factory(), ModelProvider.CUSTOM, "no-such-model"));
+  }
+
+  @Test
+  public void providerNotInConfigThrows() {
+    // 'cohere' is a known ModelProvider but is not registered in the reranking config
+    assertServiceUnavailable(() -> create(factory(), ModelProvider.COHERE, "rerank-english-v3.0"));
+  }
+
+  @Test
+  public void repeatedCreateReturnsSameCachedInstance() {
+    var factory = factory();
+
+    var first = create(factory, ModelProvider.CUSTOM, CUSTOM_MODEL_NAME);
+    var second = create(factory, ModelProvider.CUSTOM, CUSTOM_MODEL_NAME);
+    var otherTenant =
+        factory.create(
+            testConstants.CASSANDRA_TENANT,
+            "other-token",
+            ModelProvider.CUSTOM.apiName(),
+            CUSTOM_MODEL_NAME,
+            null,
+            "otherCommand");
+
+    assertThat(second)
+        .as("same (provider, model) reuses the provider and its HTTP connection pool")
+        .isSameAs(first);
+    assertThat(otherTenant)
+        .as("tenant and auth are per-rerank() state, so the cache is tenant-agnostic")
+        .isSameAs(first);
+  }
+
+  @Test
+  public void differentModelsGetDistinctInstances() {
+    var factory = factory();
+
+    var custom = create(factory, ModelProvider.CUSTOM, CUSTOM_MODEL_NAME);
+    var otherCustom = create(factory, ModelProvider.CUSTOM, OTHER_CUSTOM_MODEL_NAME);
+    var nvidia = create(factory, ModelProvider.NVIDIA, NVIDIA_MODEL_NAME);
+
+    assertThat(otherCustom).isNotSameAs(custom);
+    assertThat(nvidia).isNotSameAs(custom).isNotSameAs(otherCustom);
+    assertThat(otherCustom.modelName()).isEqualTo(OTHER_CUSTOM_MODEL_NAME);
+  }
+}


### PR DESCRIPTION
Adds a `custom` reranking provider: an externally hosted, NIM-compatible endpoint (e.g. a self-hosted NIM container) registered in the reranking providers config. It reuses the existing Nvidia client (same wire format), with metrics/usage attributed to `custom`. Selectable per collection (`rerank.service`) or per request (`findAndRerank` `options.rerank`), with the caller's key forwarded via the `reranking-api-key` header.

Direct-path providers are now cached per (provider, model) so HTTP connection pools are reused (#2536).

The shipped production config is unchanged; deployments opt in via `RERANKING_CONFIG_RESOURCE`. The `custom` block in `test-reranking-providers-config.yaml` shows the shape.

Testing: new `RerankingProviderFactoryTest` (wiring, attribution, caching, error cases) plus a `findRerankingProviders` integration test.