### PR TITLE
fix: cache direct-path reranking providers to reuse HTTP connection pools

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactory.java
@@ -11,6 +11,7 @@ import io.stargate.sgv2.jsonapi.service.reranking.gateway.RerankingEGWClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,19 @@ public class RerankingProviderFactory {
       Map.ofEntries(
           Map.entry(ModelProvider.NVIDIA, NvidiaRerankingProvider::new),
           Map.entry(ModelProvider.CUSTOM, NvidiaRerankingProvider::new));
+
+  /**
+   * Direct-mode (non-gateway) providers, keyed by (provider, model). A direct provider builds its
+   * own REST client — and with it a connection pool — in its constructor, while everything
+   * per-request (credentials, tenant) arrives via {@link RerankingProvider#rerank}, so one instance
+   * is safely shared across commands and tenants. Constructing a provider per command instead gives
+   * every findAndRerank a fresh pool whose connections are discarded after use, which under burst
+   * load exhausts ephemeral ports with TIME_WAIT sockets.
+   */
+  private final Map<DirectProviderKey, RerankingProvider> directProviders =
+      new ConcurrentHashMap<>();
+
+  private record DirectProviderKey(ModelProvider modelProvider, String modelName) {}
 
   public RerankingProvider create(
       Tenant tenant,
@@ -117,7 +131,9 @@ public class RerankingProviderFactory {
           Map.of(
               "errorMessage", "unknown service provider '%s'".formatted(modelProvider.apiName())));
     }
-    return ctor.create(modelProvider, modelConfig);
+    return directProviders.computeIfAbsent(
+        new DirectProviderKey(modelProvider, modelName),
+        key -> ctor.create(modelProvider, modelConfig));
   }
 
   public RerankingProvidersConfig getRerankingConfig() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactoryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactoryTest.java
@@ -32,6 +32,7 @@ public class RerankingProviderFactoryTest {
   private static final TestConstants testConstants = new TestConstants();
 
   private static final String CUSTOM_MODEL_NAME = "my-org/my-nim-reranker";
+  private static final String OTHER_CUSTOM_MODEL_NAME = "my-org/my-other-nim-reranker";
   private static final String NVIDIA_MODEL_NAME = "nvidia/llama-3.2-nv-rerankqa-1b-v2";
 
   private static final RerankingProvidersConfig.RerankingProviderConfig.ModelConfig
@@ -52,7 +53,7 @@ public class RerankingProviderFactoryTest {
   }
 
   private static RerankingProvidersConfig.RerankingProviderConfig providerConfig(
-      String displayName, RerankingProvidersConfig.RerankingProviderConfig.ModelConfig model) {
+      String displayName, RerankingProvidersConfig.RerankingProviderConfig.ModelConfig... models) {
     return new RerankingProvidersConfigImpl.RerankingProviderConfigImpl(
         false,
         displayName,
@@ -61,7 +62,7 @@ public class RerankingProviderFactoryTest {
             RerankingProvidersConfig.RerankingProviderConfig.AuthenticationType.NONE,
             new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.AuthenticationConfigImpl(
                 true, List.of())),
-        List.of(model));
+        List.of(models));
   }
 
   private static final RerankingProvidersConfig CONFIG =
@@ -75,7 +76,9 @@ public class RerankingProviderFactoryTest {
                       "https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking")),
               ModelProvider.CUSTOM.apiName(),
               providerConfig(
-                  "Custom", modelConfig(CUSTOM_MODEL_NAME, "http://localhost:8000/v1/ranking"))));
+                  "Custom",
+                  modelConfig(CUSTOM_MODEL_NAME, "http://localhost:8000/v1/ranking"),
+                  modelConfig(OTHER_CUSTOM_MODEL_NAME, "http://localhost:8001/v1/ranking"))));
 
   private static RerankingProviderFactory factoryWith(RerankingProvidersConfig config) {
     var factory = new RerankingProviderFactory();
@@ -140,6 +143,79 @@ public class RerankingProviderFactoryTest {
             e ->
                 assertThat(((SchemaException) e).code)
                     .isEqualTo(SchemaException.Code.RERANKING_SERVICE_TYPE_UNAVAILABLE.name()));
+  }
+
+  @Test
+  public void repeatedCreateReturnsSameCachedInstance() {
+    var factory = factoryWith(CONFIG);
+
+    var first =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.CUSTOM.apiName(),
+            CUSTOM_MODEL_NAME,
+            null,
+            "testCommand");
+    var second =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.CUSTOM.apiName(),
+            CUSTOM_MODEL_NAME,
+            null,
+            "testCommand");
+    var otherTenant =
+        factory.create(
+            testConstants.CASSANDRA_TENANT,
+            "other-token",
+            ModelProvider.CUSTOM.apiName(),
+            CUSTOM_MODEL_NAME,
+            null,
+            "otherCommand");
+
+    assertThat(second)
+        .as("same (provider, model) must reuse the provider and its HTTP connection pool")
+        .isSameAs(first);
+    assertThat(otherTenant)
+        .as("tenant and auth are per-rerank() state, so the cached instance is tenant-agnostic")
+        .isSameAs(first);
+  }
+
+  @Test
+  public void differentModelsGetDistinctInstances() {
+    var factory = factoryWith(CONFIG);
+
+    var custom =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.CUSTOM.apiName(),
+            CUSTOM_MODEL_NAME,
+            null,
+            "testCommand");
+    var otherCustom =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.CUSTOM.apiName(),
+            OTHER_CUSTOM_MODEL_NAME,
+            null,
+            "testCommand");
+    var nvidia =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.NVIDIA.apiName(),
+            NVIDIA_MODEL_NAME,
+            null,
+            "testCommand");
+
+    assertThat(otherCustom)
+        .as("different models under the same provider must not share an instance")
+        .isNotSameAs(custom);
+    assertThat(nvidia).isNotSameAs(custom).isNotSameAs(otherCustom);
+    assertThat(otherCustom.modelName()).isEqualTo(OTHER_CUSTOM_MODEL_NAME);
   }
 
   @Test


### PR DESCRIPTION
## What

`RerankingProviderFactory.create()` constructed a new `RerankingProvider` on every `findAndRerank` command. On the direct (non-embedding-gateway) path, each instance builds its own `QuarkusRestClientBuilder` REST client with its own connection pool, so no HTTP connection was ever reused across commands.

This PR caches direct-path provider instances in the factory, keyed by `(ModelProvider, modelName)`, via `ConcurrentHashMap.computeIfAbsent`. The embedding-gateway path is unchanged — it already shares a gRPC channel injected into the factory and carries per-request state in its client wrapper.

## Why

Under a 2000-command burst load test against a localhost reranker, per-command connection churn exhausted macOS ephemeral ports: 596 Netty `AnnotatedSocketException: Can't assign requested address` errors to the reranker endpoint as short-lived connections piled up in TIME_WAIT (0 errors from the reranker itself). Reusing one provider — and therefore one connection pool — per (provider, model) eliminates the churn.

## Why sharing is safe

`NvidiaRerankingProvider`'s constructor only consumes the model config (URL, timeouts). Everything per-request — credentials, tenant — arrives via `rerank()`, so one instance is safely shared across commands and tenants.

## Testing

- New unit tests in `RerankingProviderFactoryTest`: repeated `create()` calls with the same provider/model return the same instance (`isSameAs`), including across different tenants/auth tokens; different models (second custom model, nvidia vs custom) get distinct instances.
- All 15 reranking unit tests pass.

## Notes

- Stacked on #2534 (`feat/custom-nim-reranker`), since the fix builds on the CUSTOM provider wiring there.
- `EmbeddingProviderFactory` has the same per-command construction pattern on its direct path, but its providers also take per-request `dimension` and `vectorizeServiceParameters`, so it needs a wider cache key (and its `SyncServiceCredentialResolvingProvider` wrapper must stay per-call). Left for a follow-up.