### PR TITLE
fix: cache direct-path embedding providers to reuse HTTP connection pools

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactory.java
@@ -13,8 +13,11 @@ import io.stargate.sgv2.jsonapi.syncservice.SyncServiceClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +61,37 @@ public class EmbeddingProviderFactory {
           Map.entry(ModelProvider.UPSTAGE_AI, UpstageAIEmbeddingProvider::new),
           Map.entry(ModelProvider.VERTEXAI, VertexAIEmbeddingProvider::new),
           Map.entry(ModelProvider.VOYAGE_AI, VoyageAIEmbeddingProvider::new));
+
+  /**
+   * Direct-mode (non-gateway) providers, keyed by (provider, model, dimension, vectorize service
+   * parameters). A direct provider builds its own REST client — and with it a connection pool — in
+   * its constructor, while everything per-request (credentials, tenant) arrives via {@link
+   * EmbeddingProvider#vectorize}, so one instance is safely shared across commands and tenants.
+   * Constructing a provider per command instead gives every vectorize a fresh pool whose
+   * connections are discarded after use, which under burst load exhausts ephemeral ports with
+   * TIME_WAIT sockets.
+   *
+   * <p>Unlike the reranking equivalent, dimension and vectorizeServiceParameters must be part of
+   * the key: provider constructors consume both (dimension for the request shape, parameters for
+   * URL placeholders like Azure's resource/deployment or Vertex's project). The CUSTOM (test-only
+   * reflection) and embedding-gateway paths return earlier and are not cached, and the per-request
+   * {@link SyncServiceCredentialResolvingProvider} wrapper is applied outside the cache.
+   */
+  private final Map<DirectProviderKey, EmbeddingProvider> directProviders =
+      new ConcurrentHashMap<>();
+
+  private record DirectProviderKey(
+      ModelProvider modelProvider,
+      String modelName,
+      int dimension,
+      Map<String, Object> vectorizeServiceParameters) {
+    private DirectProviderKey {
+      // defensive copy: a key's hash must not change while it lives in the cache
+      // (not Map.copyOf: vectorize parameter values may legitimately be null)
+      vectorizeServiceParameters =
+          Collections.unmodifiableMap(new HashMap<>(vectorizeServiceParameters));
+    }
+  }
 
   public EmbeddingProvider create(
       Tenant tenant,
@@ -194,10 +228,18 @@ public class EmbeddingProviderFactory {
     }
 
     var provider =
-        ctor.create(
-            providerConfig, modelConfig, serviceConfig, dimension, vectorizeServiceParameters);
+        directProviders.computeIfAbsent(
+            new DirectProviderKey(modelProvider, modelName, dimension, vectorizeServiceParameters),
+            key ->
+                ctor.create(
+                    providerConfig,
+                    modelConfig,
+                    serviceConfig,
+                    key.dimension(),
+                    key.vectorizeServiceParameters()));
 
     // Wrap with credential resolver if shared-secret authentication is configured
+    // (never cached: the wrapper carries per-request tenant and auth token)
     if (authentication != null && !authentication.isEmpty()) {
       provider =
           new SyncServiceCredentialResolvingProvider(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/SyncServiceCredentialResolvingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/SyncServiceCredentialResolvingProvider.java
@@ -53,6 +53,11 @@ public class SyncServiceCredentialResolvingProvider extends EmbeddingProvider {
     this.authToken = authToken;
   }
 
+  /** The direct provider this wrapper decorates; package-visible so tests can assert caching. */
+  EmbeddingProvider delegate() {
+    return delegate;
+  }
+
   @Override
   protected String errorMessageJsonPtr() {
     // Not used directly — this wrapper never makes HTTP calls itself

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactoryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProviderFactoryTest.java
@@ -1,0 +1,225 @@
+package io.stargate.sgv2.jsonapi.service.embedding.operation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.jsonapi.TestConstants;
+import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProvidersConfig;
+import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProvidersConfigImpl;
+import io.stargate.sgv2.jsonapi.service.embedding.configuration.ServiceConfigStore;
+import io.stargate.sgv2.jsonapi.service.embedding.operation.test.CustomITEmbeddingProvider;
+import io.stargate.sgv2.jsonapi.service.provider.ApiModelSupport;
+import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
+import io.stargate.sgv2.jsonapi.syncservice.SyncServiceClient;
+import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
+import jakarta.enterprise.inject.Instance;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EmbeddingProviderFactory}, in particular that direct-mode (non-gateway)
+ * providers are cached and reused across commands so their REST clients keep one HTTP connection
+ * pool, mirroring the equivalent RerankingProviderFactory caching. The cache key is (provider,
+ * model, dimension, vectorize service parameters) because provider constructors consume all four,
+ * while credentials and tenant arrive per {@code vectorize()} call.
+ */
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class EmbeddingProviderFactoryTest {
+
+  private static final TestConstants testConstants = new TestConstants();
+
+  private static final String NVIDIA_MODEL_NAME = "nvidia/nv-embedqa-e5-v5";
+  private static final String OTHER_NVIDIA_MODEL_NAME = "nvidia/llama-3.2-nv-embedqa-1b-v2";
+
+  private static final EmbeddingProvidersConfig.EmbeddingProviderConfig.RequestProperties
+      REQUEST_PROPERTIES =
+          new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.RequestPropertiesImpl(
+              3, 100, 5000, 500, 0.5, Optional.empty(), Optional.empty(), Optional.empty(), 10);
+
+  private static EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig(
+      String name) {
+    return new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.ModelConfigImpl(
+        name,
+        new ApiModelSupport.ApiModelSupportImpl(
+            ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
+        Optional.empty(),
+        List.of(),
+        Map.of(),
+        Optional.empty());
+  }
+
+  private static final EmbeddingProvidersConfig CONFIG =
+      new EmbeddingProvidersConfigImpl(
+          Map.of(
+              ModelProvider.NVIDIA.apiName(),
+              new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl(
+                  "Nvidia",
+                  true,
+                  Optional.of("http://localhost:8000/v1/embeddings"),
+                  false,
+                  Map.of(),
+                  List.of(),
+                  REQUEST_PROPERTIES,
+                  List.of(modelConfig(NVIDIA_MODEL_NAME), modelConfig(OTHER_NVIDIA_MODEL_NAME)))),
+          null);
+
+  private static final ServiceConfigStore.ServiceConfig NVIDIA_SERVICE_CONFIG =
+      ServiceConfigStore.ServiceConfig.forKnownProvider(
+          ModelProvider.NVIDIA,
+          "http://localhost:8000/v1/embeddings",
+          new ServiceConfigStore.ServiceRequestProperties(
+              3, 100, 5000, 500, 0.5, Optional.empty(), Optional.empty(), 10),
+          Map.of());
+
+  private static EmbeddingProviderFactory factoryWith(
+      ServiceConfigStore.ServiceConfig serviceConfig) {
+    var factory = new EmbeddingProviderFactory();
+    factory.embeddingProvidersConfig = CONFIG;
+
+    @SuppressWarnings("unchecked")
+    Instance<ServiceConfigStore> storeInstance = mock(Instance.class);
+    when(storeInstance.get()).thenReturn(modelProvider -> serviceConfig);
+    factory.embeddingProviderConfigStore = storeInstance;
+
+    factory.operationsConfig = mock(OperationsConfig.class);
+    when(factory.operationsConfig.enableEmbeddingGateway()).thenReturn(false);
+
+    factory.syncServiceClient = mock(SyncServiceClient.class);
+    return factory;
+  }
+
+  private static EmbeddingProvider create(
+      EmbeddingProviderFactory factory,
+      String modelName,
+      int dimension,
+      Map<String, Object> vectorizeServiceParameters,
+      Map<String, String> authentication) {
+    return factory.create(
+        testConstants.TENANT,
+        "test-token",
+        ModelProvider.NVIDIA.apiName(),
+        modelName,
+        dimension,
+        vectorizeServiceParameters,
+        authentication,
+        "testCommand");
+  }
+
+  @Test
+  public void repeatedCreateReturnsSameCachedInstance() {
+    var factory = factoryWith(NVIDIA_SERVICE_CONFIG);
+
+    var first = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of("k", "v"), null);
+    var second = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of("k", "v"), null);
+    var otherTenant =
+        factory.create(
+            testConstants.CASSANDRA_TENANT,
+            "other-token",
+            ModelProvider.NVIDIA.apiName(),
+            NVIDIA_MODEL_NAME,
+            1024,
+            Map.of("k", "v"),
+            null,
+            "otherCommand");
+
+    assertThat(second)
+        .as(
+            "same (provider, model, dimension, parameters) must reuse the provider and its HTTP connection pool")
+        .isSameAs(first);
+    assertThat(otherTenant)
+        .as("tenant and auth are per-vectorize() state, so the cached instance is tenant-agnostic")
+        .isSameAs(first);
+  }
+
+  @Test
+  public void nullAndEmptyParametersShareTheSameCacheEntry() {
+    var factory = factoryWith(NVIDIA_SERVICE_CONFIG);
+
+    var nullParams = create(factory, NVIDIA_MODEL_NAME, 1024, null, null);
+    var emptyParams = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of(), null);
+
+    assertThat(emptyParams)
+        .as("null parameters are normalized to an empty map before keying the cache")
+        .isSameAs(nullParams);
+  }
+
+  @Test
+  public void differentKeyComponentsGetDistinctInstances() {
+    var factory = factoryWith(NVIDIA_SERVICE_CONFIG);
+
+    var base = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of(), null);
+    var differentModel = create(factory, OTHER_NVIDIA_MODEL_NAME, 1024, Map.of(), null);
+    var differentDimension = create(factory, NVIDIA_MODEL_NAME, 512, Map.of(), null);
+    var differentParameters =
+        create(factory, NVIDIA_MODEL_NAME, 1024, Map.of("autoTruncate", true), null);
+
+    assertThat(differentModel)
+        .as("different models under the same provider must not share an instance")
+        .isNotSameAs(base);
+    assertThat(differentModel.modelName()).isEqualTo(OTHER_NVIDIA_MODEL_NAME);
+    assertThat(differentDimension)
+        .as("dimension is consumed by provider constructors, so it is part of the cache key")
+        .isNotSameAs(base);
+    assertThat(differentParameters)
+        .as(
+            "vectorize service parameters are consumed by provider constructors (e.g. URL placeholders), so they are part of the cache key")
+        .isNotSameAs(base);
+  }
+
+  @Test
+  public void sharedSecretAuthenticationWrapsCachedProviderPerCall() {
+    var factory = factoryWith(NVIDIA_SERVICE_CONFIG);
+    Map<String, String> authentication = Map.of("providerKey", "my-cred");
+
+    var wrappedFirst = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of(), authentication);
+    var wrappedSecond = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of(), authentication);
+    var bare = create(factory, NVIDIA_MODEL_NAME, 1024, Map.of(), null);
+
+    assertThat(wrappedFirst).isInstanceOf(SyncServiceCredentialResolvingProvider.class);
+    assertThat(wrappedSecond)
+        .as("the wrapper carries per-request tenant/auth state and must never be cached")
+        .isNotSameAs(wrappedFirst);
+    assertThat(((SyncServiceCredentialResolvingProvider) wrappedFirst).delegate())
+        .as("the wrapped inner provider must still come from the cache")
+        .isSameAs(bare)
+        .isSameAs(((SyncServiceCredentialResolvingProvider) wrappedSecond).delegate());
+  }
+
+  @Test
+  public void customReflectionProviderIsNotCached() {
+    var factory =
+        factoryWith(
+            ServiceConfigStore.ServiceConfig.forCustomProvider(CustomITEmbeddingProvider.class));
+
+    var first =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.CUSTOM.apiName(),
+            "custom-model",
+            3,
+            null,
+            null,
+            "testCommand");
+    var second =
+        factory.create(
+            testConstants.TENANT,
+            "test-token",
+            ModelProvider.CUSTOM.apiName(),
+            "custom-model",
+            3,
+            null,
+            null,
+            "testCommand");
+
+    assertThat(first).isInstanceOf(CustomITEmbeddingProvider.class);
+    assertThat(second).as("the test-only CUSTOM reflection path stays uncached").isNotSameAs(first);
+  }
+}


### PR DESCRIPTION
## Summary

`EmbeddingProviderFactory.create()` constructed a new `EmbeddingProvider` on every command. On the direct (non-gateway) path, each provider builds its own `QuarkusRestClientBuilder` REST client — and with it a fresh connection pool — in its constructor, so no HTTP connection was ever reused across commands. Under burst load, short-lived connections pile up in TIME_WAIT and exhaust ephemeral ports. This is the embedding-side counterpart of #2536, which fixed the identical issue in `RerankingProviderFactory`.

Direct providers are safely shareable: all 12 provider constructors consume only `(providerConfig, modelConfig, serviceConfig, dimension, vectorizeServiceParameters)`, and credentials/tenant arrive per `vectorize()` call. Instances are now cached in a `ConcurrentHashMap` via `computeIfAbsent`.

Unlike the reranking fix, the cache key must be wider than `(provider, model)`: constructors also consume the per-request `dimension` (request shape) and `vectorizeServiceParameters` (URL placeholders such as Azure's resource/deployment or Vertex's project), so the key is `(provider, model, dimension, parameters)`. The key defensively copies the parameter map so its hash cannot change while cached (a plain unmodifiable copy rather than `Map.copyOf`, since parameter values may be null).

Deliberately left uncached:
- the **CUSTOM reflection path** (test-only),
- the **embedding-gateway path** (already shares an injected gRPC channel),
- the **`SyncServiceCredentialResolvingProvider` wrapper**, which carries per-request tenant/auth-token state — it is now constructed per call *around* the cached inner provider. A package-private `delegate()` accessor was added so tests can assert the inner instance is still shared.

## Test plan

- [x] New `EmbeddingProviderFactoryTest` mirroring `RerankingProviderFactoryTest`'s caching tests:
  - [x] repeated `create()` with identical `(provider, model, dimension, parameters)` returns the same instance, including across tenants/auth tokens
  - [x] `null` and empty parameter maps share one cache entry
  - [x] differing model, dimension, or parameters each yield distinct instances
  - [x] shared-secret authentication wraps a fresh credential resolver per call around the same cached delegate
  - [x] the CUSTOM reflection path stays uncached (new instance per call)
- [x] `./mvnw test -Dtest=EmbeddingProviderFactoryTest` green on JDK 21 (5/5)
- [x] Embedding package suite run; the one `DataVectorizerTest` error (`ServiceConfigurationError` from Quarkus classloader restarts in filtered runs) reproduces identically on the unmodified base and passes when run normally — pre-existing, unrelated
- [ ] CI green