### PR TITLE
test: allow injecting a raw auth token for ITs against a deployed instance

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractKeyspaceIntegrationTestBase.java
@@ -196,14 +196,9 @@ public abstract class AbstractKeyspaceIntegrationTestBase {
   }
 
   protected Map<String, ?> getHeaders() {
-    String credential =
-        "Cassandra:"
-            + Base64.getEncoder().encodeToString(getCassandraUsername().getBytes())
-            + ":"
-            + Base64.getEncoder().encodeToString(getCassandraPassword().getBytes());
     return Map.of(
         HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME,
-        credential,
+        getAuthToken(),
         HttpConstants.EMBEDDING_AUTHENTICATION_TOKEN_HEADER_NAME,
         CustomITEmbeddingProvider.TEST_API_KEY);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/mcp/McpIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/mcp/McpIntegrationTestBase.java
@@ -15,7 +15,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.URI;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -90,13 +89,8 @@ public abstract class McpIntegrationTestBase {
 
   /** Build authentication headers matching the Token header format used by the REST API. */
   protected MultiMap authHeaders() {
-    String credential =
-        "Cassandra:"
-            + Base64.getEncoder().encodeToString(getCassandraUsername().getBytes())
-            + ":"
-            + Base64.getEncoder().encodeToString(getCassandraPassword().getBytes());
     return MultiMap.caseInsensitiveMultiMap()
-        .add(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, credential);
+        .add(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken());
   }
 
   /** Create a keyspace via the MCP createKeyspace tool. */

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenderBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/DataApiCommandSenderBase.java
@@ -1,8 +1,7 @@
 package io.stargate.sgv2.jsonapi.api.v1.util;
 
 import static io.restassured.RestAssured.given;
-import static io.stargate.sgv2.jsonapi.api.v1.util.IntegrationTestUtils.getCassandraPassword;
-import static io.stargate.sgv2.jsonapi.api.v1.util.IntegrationTestUtils.getCassandraUsername;
+import static io.stargate.sgv2.jsonapi.api.v1.util.IntegrationTestUtils.getAuthToken;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
@@ -11,7 +10,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandName;
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.test.CustomITEmbeddingProvider;
 import jakarta.ws.rs.core.Response;
-import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -110,15 +108,9 @@ public abstract class DataApiCommandSenderBase<T extends DataApiCommandSenderBas
     }
 
     private static Map<String, String> collectDefaultHeaders() {
-
-      String credential =
-          "Cassandra:"
-              + Base64.getEncoder().encodeToString(getCassandraUsername().getBytes())
-              + ":"
-              + Base64.getEncoder().encodeToString(getCassandraPassword().getBytes());
       return Map.of(
           HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME,
-          credential,
+          getAuthToken(),
           HttpConstants.EMBEDDING_AUTHENTICATION_TOKEN_HEADER_NAME,
           CustomITEmbeddingProvider.TEST_API_KEY);
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/IntegrationTestUtils.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/util/IntegrationTestUtils.java
@@ -1,5 +1,7 @@
 package io.stargate.sgv2.jsonapi.api.v1.util;
 
+import java.util.Base64;
+
 /** Utilities for integration test. */
 public final class IntegrationTestUtils {
 
@@ -7,6 +9,7 @@ public final class IntegrationTestUtils {
   public static final String CASSANDRA_CQL_PORT_PROP = "stargate.int-test.cassandra.cql-port";
   public static final String CASSANDRA_USERNAME_PROP = "stargate.int-test.cassandra.username";
   public static final String CASSANDRA_PASSWORD_PROP = "stargate.int-test.cassandra.password";
+  public static final String AUTH_TOKEN_PROP = "stargate.int-test.auth-token";
 
   private IntegrationTestUtils() {}
 
@@ -22,5 +25,27 @@ public final class IntegrationTestUtils {
    */
   public static String getCassandraPassword() {
     return System.getProperty(CASSANDRA_PASSWORD_PROP, "cassandra");
+  }
+
+  /**
+   * Value to send in the {@code Token} header of integration test requests.
+   *
+   * <p>Defaults to a Cassandra-style credential built from {@link #getCassandraUsername()} and
+   * {@link #getCassandraPassword()}, which is what a containerized backend expects. When running
+   * against an already-deployed Data API that validates real tokens (see the "Executing against a
+   * running application" section of the README), set {@value #AUTH_TOKEN_PROP} and that value is
+   * sent verbatim instead.
+   *
+   * @return Auth token to send, never null
+   */
+  public static String getAuthToken() {
+    String token = System.getProperty(AUTH_TOKEN_PROP);
+    if (token != null && !token.isBlank()) {
+      return token;
+    }
+    return "Cassandra:"
+        + Base64.getEncoder().encodeToString(getCassandraUsername().getBytes())
+        + ":"
+        + Base64.getEncoder().encodeToString(getCassandraPassword().getBytes());
   }
 }


### PR DESCRIPTION
## Summary

Unblocks running the Data API integration tests against an **already-deployed** instance — needed for INC-1007 follow-up, where we need to run the IT suite against a dev deployment with a mini-PCU behind it to validate the cql-router sidecar bump.

The README already documents this workflow:

> #### Executing against a running application
> ```
> ./mvnw verify -DskipUnitTests -Dquarkus.http.test-host=1.2.3.4 -Dquarkus.http.test-port=4321 -Dstargate.int-test.auth-token=[AUTH_TOKEN]
> ```

The `quarkus.http.test-host` half works — `StargateTestResource.shouldSkip()` returns true when it's set, so no containers start. **But `stargate.int-test.auth-token` was not read anywhere in `src/`.** Every IT built a Cassandra-style credential inline:

```java
String credential = "Cassandra:" + base64(getCassandraUsername()) + ":" + base64(getCassandraPassword());
```

and sent it as the `Token` header. So the suite could only ever authenticate against a backend accepting those credentials; pointed at a deployment that validates real tokens it just returns 401. The documented flag was silently a no-op.

## Change

Adds `IntegrationTestUtils.getAuthToken()`:

- returns `stargate.int-test.auth-token` **verbatim** when set and non-blank
- otherwise builds the same Cassandra-style credential as before

and routes the three call sites that send a *valid* token through it:

- `DataApiCommandSenderBase.collectDefaultHeaders()`
- `AbstractKeyspaceIntegrationTestBase.getHeaders()`
- `McpIntegrationTestBase.authHeaders()`

`AbstractKeyspaceIntegrationTestBase.getInvalidHeaders()` is deliberately **not** changed — it builds a bogus credential on purpose to exercise the auth-failure path, and routing it through `getAuthToken()` would break that test.

Net effect on the callers is deduplication: the same 5-line credential construction was copy-pasted in four places, now it lives in one.

## Backward compatibility

**Default behaviour is unchanged.** With no property set, `getAuthToken()` returns a byte-identical string to the previous inline construction, so existing container-based runs are unaffected. Verified directly:

| Case | Result |
|---|---|
| No property set | Identical to legacy `Cassandra:<b64user>:<b64pass>` |
| `-Dstargate.int-test.auth-token=AstraCS:…` | Sent verbatim |
| Property set but blank | Falls back to default (won't send an empty header) |
| Custom `…cassandra.username`/`.password` | Still honoured |

A blank value falling back matters: otherwise a shell expanding an unset variable would silently send an empty token and produce a confusing 401.

This also makes the existing README instructions true, so no docs change is needed.

## Test plan

- [x] `./mvnw test-compile` passes (JDK 21)
- [x] All four `getAuthToken()` cases verified against the compiled class
- [ ] Full IT suite green locally against containers (no behaviour change expected — default path is byte-identical)
- [ ] IT suite run against the dev deployment + mini-PCU once Sean has it up

Note: `SessionEvictionIntegrationTest` drives the backend container directly (stop/start to simulate failure) and is inherently not runnable against a remote target — it'll need excluding for remote runs. That's out of scope here.

## Related

- INC-1007
- riptano/serverless-platform-charts#1859 (the sidecar pin bump this testing validates)
