### PR TITLE
Session metadata check looks for any keyspace, not system (#2539)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
@@ -264,7 +264,7 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
    * CassandraSchemaQueries.executeOnAdminExecutor() and DefaultSession.initialSchemaRefresh()
    *
    * <p>When the initial read fails the driver keeps its empty starting metadata, so "no keyspaces
-   * at all" signals the failure.
+   * at all" signals a failure.
    */
   private static CompletionStage<CqlSession> validateSession(Tenant tenant, CqlSession cqlSession) {
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
@@ -264,8 +264,7 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
    * CassandraSchemaQueries.executeOnAdminExecutor() and DefaultSession.initialSchemaRefresh()
    *
    * <p>When the initial read fails the driver keeps its empty starting metadata, so "no keyspaces
-   * at all" is the signal. We do not look for a specific keyspace, which system keyspaces a tenant
-   * can see depends on the deployment.
+   * at all" signals the failure.
    */
   private static CompletionStage<CqlSession> validateSession(Tenant tenant, CqlSession cqlSession) {
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
@@ -262,10 +262,14 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
    * / user+password somehow cannot read the schema tables or if some coordinators do and some do
    * not validate the credentials. In Java Driver see
    * CassandraSchemaQueries.executeOnAdminExecutor() and DefaultSession.initialSchemaRefresh()
+   *
+   * <p>When the initial read fails the driver keeps its empty starting metadata, so "no keyspaces
+   * at all" is the signal. We do not look for a specific keyspace, which system keyspaces a tenant
+   * can see depends on the deployment.
    */
   private static CompletionStage<CqlSession> validateSession(Tenant tenant, CqlSession cqlSession) {
 
-    if (cqlSession.getMetadata().getKeyspace("system").isPresent()) {
+    if (!cqlSession.getMetadata().getKeyspaces().isEmpty()) {
       return CompletableFuture.completedStage(cqlSession);
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactoryTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactoryTests.java
@@ -25,7 +25,7 @@ import io.stargate.sgv2.jsonapi.service.cqldriver.executor.optvector.SubtypeOnly
 import java.net.InetSocketAddress;
 import java.util.AbstractMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
@@ -226,18 +226,19 @@ public class CqlSessionFactoryTests {
     // so we mock the session builder and verify that it is called correctly.
     var session = mock(CqlSession.class);
 
-    // CqlSession guarantees a Metdata obj, and we now check it
+    // CqlSession guarantees a Metdata obj, and we now check it has keyspaces
     var metadata = mock(Metadata.class);
     when(session.getMetadata()).thenReturn(metadata);
+    when(metadata.getKeyspaces())
+        .thenReturn(
+            withMetadata
+                ? Map.of(CqlIdentifier.fromInternal("system"), mock(KeyspaceMetadata.class))
+                : Map.of());
     if (closingError == null) {
       when(session.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
     } else {
       when(session.closeAsync()).thenReturn(CompletableFuture.failedFuture(closingError));
     }
-    Optional<KeyspaceMetadata> keyspaceMetadata =
-        withMetadata ? Optional.of(mock(KeyspaceMetadata.class)) : Optional.empty();
-    when(metadata.getKeyspace(any(CqlIdentifier.class))).thenReturn(keyspaceMetadata);
-    when(metadata.getKeyspace(anyString())).thenReturn(keyspaceMetadata);
 
     var sessionBuilder = mock(CqlSessionBuilder.class);
     when(sessionBuilder.withLocalDatacenter(any())).thenReturn(sessionBuilder);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactoryTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactoryTests.java
@@ -226,7 +226,7 @@ public class CqlSessionFactoryTests {
     // so we mock the session builder and verify that it is called correctly.
     var session = mock(CqlSession.class);
 
-    // CqlSession guarantees a Metdata obj, and we now check it has keyspaces
+    // CqlSession guarantees a Metadata obj, and we now check it has keyspaces
     var metadata = mock(Metadata.class);
     when(session.getMetadata()).thenReturn(metadata);
     when(metadata.getKeyspaces())


### PR DESCRIPTION
**What this PR does**:

Follow up to #2542. The check that a new `CqlSession` has metadata now looks for *any* keyspace rather than the `system` keyspace.

When the driver's initial schema read fails it keeps its starting `DefaultMetadata.EMPTY`, so no keyspaces at all is the signal. `system` is only in the metadata because `application.conf` overrides the driver default `refreshed-keyspaces` filter (which excludes `system` and `system_*`), and driver config can be overridden per deployment.

Context: dev started returning `FAILED_TO_READ_METADATA` for every request after v1.0.49.

**Which issue(s) this PR fixes**:
Related #2539

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)