### PR TITLE
feat: register nemotron-rerank-vl-1b-v2 alongside the existing reranker

### DIFF
--- a/src/main/resources/reranking-providers-config.yaml
+++ b/src/main/resources/reranking-providers-config.yaml
@@ -11,12 +11,12 @@ stargate:
               enabled: true
           models:
             - name: nvidia/llama-3.2-nv-rerankqa-1b-v2
-              is-default: true
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
                 max-batch-size: 10
             # NIM 2.x (Rust runtime) reranking model, deployed alongside the model above.
             - name: nvidia/llama-nemotron-rerank-vl-1b-v2
+              is-default: true
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
                 max-batch-size: 10

--- a/src/main/resources/reranking-providers-config.yaml
+++ b/src/main/resources/reranking-providers-config.yaml
@@ -16,14 +16,7 @@ stargate:
               properties:
                 max-batch-size: 10
             # NIM 2.x (Rust runtime) reranking model, deployed alongside the model above.
-            # Not the default: collections pin provider + model in their schema, so the default
-            # only affects newly created collections.
-            # TODO confirm the gateway path once the GPU plane deployment is routed: the proxy
-            # may dispatch on the `model` field in the body (same path) or expose a new path.
             - name: nvidia/llama-nemotron-rerank-vl-1b-v2
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
-                # Kept at 10 to match the existing model so load comparisons are like-for-like.
-                # NIM 2.x accepts up to 512 passages per call; raising this collapses the
-                # per-findAndRerank fan-out and should be measured as a separate change.
                 max-batch-size: 10

--- a/src/main/resources/reranking-providers-config.yaml
+++ b/src/main/resources/reranking-providers-config.yaml
@@ -15,3 +15,15 @@ stargate:
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
                 max-batch-size: 10
+            # NIM 2.x (Rust runtime) reranking model, deployed alongside the model above.
+            # Not the default: collections pin provider + model in their schema, so the default
+            # only affects newly created collections.
+            # TODO confirm the gateway path once the GPU plane deployment is routed: the proxy
+            # may dispatch on the `model` field in the body (same path) or expose a new path.
+            - name: nvidia/llama-nemotron-rerank-vl-1b-v2
+              url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
+              properties:
+                # Kept at 10 to match the existing model so load comparisons are like-for-like.
+                # NIM 2.x accepts up to 512 passages per call; raising this collapses the
+                # per-findAndRerank fan-out and should be measured as a separate change.
+                max-batch-size: 10


### PR DESCRIPTION
Adds `nvidia/llama-nemotron-rerank-vl-1b-v2` (NIM 2.x, the new Rust runtime) as a **second, non-default** reranking model, so it can run alongside `nvidia/llama-3.2-nv-rerankqa-1b-v2` rather than replacing it.

### Test plan
- [ ] Existing integration tests unaffected (they load `test-reranking-providers-config.yaml`)
- [ ] `findRerankingProviders` lists both models, old one flagged default
- [ ] Local `findAndRerank` against a NIM 2.x pod using the new model