### PR TITLE
fix: disable provenance attestations to remove unknown/unknown manife…

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          provenance: false
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          provenance: false
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v6
@@ -68,10 +66,15 @@ jobs:
           mask-password: 'true'
 
       - name: Build and push (Amazon ECR)
+        env:
+          # avoid unknown/unknown attestation manifests
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' ${{ matrix.profile }}
 
       - name: Build and push image for profiling (Amazon ECR)
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm ${{ matrix.profile }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,8 +158,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          provenance: false
 
       # only set version here
       - name: Install
@@ -175,6 +173,9 @@ jobs:
 
       - name: Build data-api image and push (Docker Hub)
         if: ${{ !inputs.skipPublish }}
+        env:
+          # avoid unknown/unknown attestation manifests
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true  -Dquarkus.container-image.tag=${{needs.resolve-tag.outputs.release-tag}} -Dquarkus.container-image.name=data-api ${{ matrix.profile }}
 
@@ -204,8 +205,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          provenance: false
 
       # only set version here
       - name: Install
@@ -229,6 +228,7 @@ jobs:
       - name: Build and push (Amazon ECR)
         if: ${{ !inputs.skipPublish }}
         env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
           QUARKUS_APPLICATION_NAME: 'Astra DB Serverless Data API'
           QUARKUS_SMALLRYE_OPENAPI_INFO_DESCRIPTION: 'The Astra DB Serverless Data API modifies and queries data stored as unstructured JSON documents in collections. See the [documentation site](https://docs.datastax.com/en/astra/astra-db-vector/api-reference/data-api.html) for additional information.'
           QUARKUS_SMALLRYE_OPENAPI_INFO_TERMS_OF_SERVICE: 'https://www.ibm.com/legal'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,6 +158,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          provenance: false
 
       # only set version here
       - name: Install
@@ -202,6 +204,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          provenance: false
 
       # only set version here
       - name: Install


### PR DESCRIPTION
## Problem

When inspecting `stargateio/data-api:v1.0.49` (and earlier releases) on Docker Hub, the image index contains **four** manifests instead of the expected two:

| Platform | Expected? |
|---|---|
| `linux/amd64` | ✅ |
| `linux/arm64` | ✅ |
| `unknown/unknown` | ❌ |
| `unknown/unknown` | ❌ |

The two spurious `unknown/unknown` entries are **provenance attestation manifests** automatically generated by Docker BuildKit. This causes problems for tooling and runtimes that iterate over the manifest list and do not expect non-platform entries.

The same issue was previously observed and fixed in the **Reaper** image by disabling provenance and SBOM attestations at build time (`provenance: false`, `sbom: false`).

## Root cause

`docker/setup-buildx-action` enables BuildKit by default. Starting with BuildKit 0.11, multi-platform builds automatically attach two OCI artefacts to the image index:

1. A **provenance attestation** (SLSA) — recorded as `unknown/unknown` with `mediaType: application/vnd.in-toto+json`
2. An **SBOM attestation** — also recorded as `unknown/unknown`

Neither is requested explicitly in our workflows; they are injected by the BuildKit daemon unless explicitly suppressed.

## Fix

Add `provenance: false` to every `docker/setup-buildx-action` step. This tells BuildKit not to generate or attach attestation manifests, leaving the image index with only the intended platform-specific entries.

Three steps were updated:

- `.github/workflows/release.yaml` — `publish-image-dockerhub` job
- `.github/workflows/release.yaml` — `publish-image-ecr` job
- `.github/workflows/docker-image-publish.yaml` — `main` job

```yaml
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v4
  with:
    provenance: false   # prevents unknown/unknown attestation manifests
```

## Verification

After merging, inspect the next published image with:

```bash
docker buildx imagetools inspect stargateio/data-api:<tag>
```

The manifest list should contain exactly two entries: `linux/amd64` and `linux/arm64`.