### PR TITLE
Improved test for FAILED_TO_READ_METADATA error

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
@@ -318,7 +318,7 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
       }
 
       LOGGER.error(
-          "validateSession() - session invalid, metadata was empty, closing session and returning error: {}, tenant={}, refreshedKeyspaces:{}, metadataEnabled:{}",
+          "validateSession() - session invalid, metadata was empty, closing session and returning error: {}, tenant:{}, refreshedKeyspaces:{}, metadataEnabled:{}",
           DatabaseException.Code.FAILED_TO_READ_METADATA.name(),
           tenant,
           refreshedKeyspaces,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
@@ -238,9 +238,6 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
       Tenant tenant, CqlSession cqlSession, Throwable throwable) {
 
     if (throwable == null) {
-      LOGGER.debug(
-          "unwrapBuildException() - throwable null. tenant={}, cqlSession={}", tenant, cqlSession);
-
       return cqlSession;
     }
 
@@ -261,9 +258,9 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
     var err =
         new DatabaseDriverExceptionHandler(new DatabaseSchemaObject(tenant)).maybeHandle(toHandle);
     LOGGER.debug(
-        "unwrapBuildException() - throwable not null. tenant={}, APIException={}",
+        "unwrapBuildException() - session build error mapped to APIException. tenant={}",
         tenant,
-        err.toString());
+        err);
     throw err;
   }
 
@@ -279,20 +276,55 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
    */
   private static CompletionStage<CqlSession> validateSession(Tenant tenant, CqlSession cqlSession) {
 
-    var keyspaces =
-        String.join(
-            ", ",
-            cqlSession.getMetadata().getKeyspaces().keySet().stream()
-                .map(Object::toString)
-                .toList());
-    LOGGER.debug("validateSession() - keyspaces. tenant={}, keyspaces=[{}]", tenant, keyspaces);
-
-    if (cqlSession.getMetadata().getKeyspace("system").isPresent()) {
+    if (!cqlSession.getMetadata().getKeyspaces().isEmpty()) {
+      if (LOGGER.isDebugEnabled()) {
+        var keyspaces =
+            String.join(
+                ", ",
+                cqlSession.getMetadata().getKeyspaces().keySet().stream()
+                    .map(Object::toString)
+                    .toList());
+        LOGGER.debug(
+            "validateSession() - session is valid, metadata is not empty. tenant={}, keyspaces=[{}]",
+            tenant,
+            keyspaces);
+      }
       return CompletableFuture.completedStage(cqlSession);
     }
 
-    LOGGER.error(
-        "validateSession() - system ks not found. tenant={}, keyspaces=[{}]", tenant, keyspaces);
+    // there could be zero keyspaces if metadata fresh is not enabled, or the keyspace filters
+    // prohibit it.
+    if (LOGGER.isErrorEnabled()) {
+
+      List<String> refreshedKeyspaces = null;
+      Boolean metadataEnabled = null;
+      try {
+        refreshedKeyspaces =
+            cqlSession
+                .getContext()
+                .getConfig()
+                .getDefaultProfile()
+                .getStringList(DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES);
+        metadataEnabled =
+            cqlSession
+                .getContext()
+                .getConfig()
+                .getDefaultProfile()
+                .getBoolean(DefaultDriverOption.METADATA_SCHEMA_ENABLED);
+      } catch (Exception e) {
+        LOGGER.error(
+            "validateSession() - error trying to read from default driver profile, will not know metadata config, continuing.",
+            e);
+      }
+
+      LOGGER.error(
+          "validateSession() - session invalid, metadata was empty, closing session and returning error: {}, tenant={}, refreshedKeyspaces:{}, metadataEnabled:{}",
+          DatabaseException.Code.FAILED_TO_READ_METADATA.name(),
+          tenant,
+          refreshedKeyspaces,
+          metadataEnabled);
+    }
+
     // NOTE: while throwing the error will prevent the session from getting into the
     // CqlSessionCache we use ExceptionFlags.UNRELIABLE_DB_SESSION tells the CommandProcessor we
     // want to evict the session when from cache when the request is over as belt and braces
@@ -302,14 +334,10 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
             (ignored, closeError) -> {
               if (closeError != null) {
                 LOGGER.error(
-                    "validateSession() - error closing session when metadata not read, tenant={}",
+                    "validateSession() - error closing session when metadata is empty, continuing. tenant={}",
                     tenant,
                     closeError);
               }
-              LOGGER.error(
-                  "validateSession() - throwing FAILED_TO_READ_METADATA. tenant={}, keyspaces=[{}]",
-                  tenant,
-                  keyspaces);
               // this is the real error we want to get back to the user
               throw DatabaseException.Code.FAILED_TO_READ_METADATA.get(
                   EnumSet.of(ExceptionFlags.UNRELIABLE_DB_SESSION));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactory.java
@@ -169,8 +169,8 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
   public CompletionStage<CqlSession> apply(Tenant tenant, CqlCredentials credentials) {
     Objects.requireNonNull(credentials, "credentials must not be null");
 
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Creating CQL Session tenant={}, credentials={}", tenant, credentials);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Creating CQL Session tenant={}, credentials={}", tenant, credentials);
     }
 
     // the driver TypedDriverOption is only used with DriverConfigLoader.fromMap()
@@ -238,6 +238,9 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
       Tenant tenant, CqlSession cqlSession, Throwable throwable) {
 
     if (throwable == null) {
+      LOGGER.debug(
+          "unwrapBuildException() - throwable null. tenant={}, cqlSession={}", tenant, cqlSession);
+
       return cqlSession;
     }
 
@@ -249,8 +252,19 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
         (throwable instanceof CompletionException && throwable.getCause() != null)
             ? throwable.getCause()
             : throwable;
-    throw new DatabaseDriverExceptionHandler(new DatabaseSchemaObject(tenant))
-        .maybeHandle(toHandle);
+    LOGGER.debug(
+        "unwrapBuildException() - throwable not null. tenant={}, throwable={}, toHandle={}",
+        tenant,
+        throwable.toString(),
+        toHandle.toString());
+
+    var err =
+        new DatabaseDriverExceptionHandler(new DatabaseSchemaObject(tenant)).maybeHandle(toHandle);
+    LOGGER.debug(
+        "unwrapBuildException() - throwable not null. tenant={}, APIException={}",
+        tenant,
+        err.toString());
+    throw err;
   }
 
   /**
@@ -265,10 +279,20 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
    */
   private static CompletionStage<CqlSession> validateSession(Tenant tenant, CqlSession cqlSession) {
 
+    var keyspaces =
+        String.join(
+            ", ",
+            cqlSession.getMetadata().getKeyspaces().keySet().stream()
+                .map(Object::toString)
+                .toList());
+    LOGGER.debug("validateSession() - keyspaces. tenant={}, keyspaces=[{}]", tenant, keyspaces);
+
     if (cqlSession.getMetadata().getKeyspace("system").isPresent()) {
       return CompletableFuture.completedStage(cqlSession);
     }
 
+    LOGGER.error(
+        "validateSession() - system ks not found. tenant={}, keyspaces=[{}]", tenant, keyspaces);
     // NOTE: while throwing the error will prevent the session from getting into the
     // CqlSessionCache we use ExceptionFlags.UNRELIABLE_DB_SESSION tells the CommandProcessor we
     // want to evict the session when from cache when the request is over as belt and braces
@@ -282,7 +306,10 @@ public class CqlSessionFactory implements CQLSessionCache.SessionFactory {
                     tenant,
                     closeError);
               }
-
+              LOGGER.error(
+                  "validateSession() - throwing FAILED_TO_READ_METADATA. tenant={}, keyspaces=[{}]",
+                  tenant,
+                  keyspaces);
               // this is the real error we want to get back to the user
               throw DatabaseException.Code.FAILED_TO_READ_METADATA.get(
                   EnumSet.of(ExceptionFlags.UNRELIABLE_DB_SESSION));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -131,12 +131,6 @@ quarkus:
         level: ERROR
       'com.datastax.oss.driver':
         level: WARN
-      'com.datastax.oss.driver.internal.core.adminrequest':
-        level: DEBUG
-      'com.datastax.oss.driver.internal.core.metadata':
-        level: DEBUG
-      'com.datastax.oss.driver.internal.core.session':
-        level:DEBUG
       'io.quarkus.http.access-log':
         level: INFO
       'io.stargate':

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,7 +113,7 @@ quarkus:
 
   log:
     console:
-      format: "%-5p [%t] %d{yyyy-MM-dd HH:mm:ss,SSS} %F:%L - %m%n"
+      format: "%-5p [%t] %d{yyyy-MM-dd HH:mm:ss,SSS} %c:%L - %m%n"
 
     handler:
       console:
@@ -131,6 +131,12 @@ quarkus:
         level: ERROR
       'com.datastax.oss.driver':
         level: WARN
+      'com.datastax.oss.driver.internal.core.adminrequest':
+        level: DEBUG
+      'com.datastax.oss.driver.internal.core.metadata':
+        level: DEBUG
+      'com.datastax.oss.driver.internal.core.session':
+        level:DEBUG
       'io.quarkus.http.access-log':
         level: INFO
       'io.stargate':

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactoryTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/CqlSessionFactoryTests.java
@@ -23,9 +23,7 @@ import io.stargate.sgv2.jsonapi.exception.DatabaseException;
 import io.stargate.sgv2.jsonapi.exception.ExceptionFlags;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.optvector.SubtypeOnlyFloatVectorToArrayCodec;
 import java.net.InetSocketAddress;
-import java.util.AbstractMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
@@ -225,19 +223,21 @@ public class CqlSessionFactoryTests {
     // we are testing that the CqlSessionFactory calls the session builder correctly,
     // so we mock the session builder and verify that it is called correctly.
     var session = mock(CqlSession.class);
-
-    // CqlSession guarantees a Metdata obj, and we now check it
-    var metadata = mock(Metadata.class);
-    when(session.getMetadata()).thenReturn(metadata);
     if (closingError == null) {
       when(session.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
     } else {
       when(session.closeAsync()).thenReturn(CompletableFuture.failedFuture(closingError));
     }
-    Optional<KeyspaceMetadata> keyspaceMetadata =
-        withMetadata ? Optional.of(mock(KeyspaceMetadata.class)) : Optional.empty();
-    when(metadata.getKeyspace(any(CqlIdentifier.class))).thenReturn(keyspaceMetadata);
-    when(metadata.getKeyspace(anyString())).thenReturn(keyspaceMetadata);
+
+    // CqlSession guarantees a Metdata obj, and we now check it
+    var metadata = mock(Metadata.class);
+    when(session.getMetadata()).thenReturn(metadata);
+
+    Map<CqlIdentifier, KeyspaceMetadata> keyspaces = new HashMap<>();
+    if (withMetadata) {
+      keyspaces.put(CqlIdentifier.fromInternal("system"), mock(KeyspaceMetadata.class));
+    }
+    when(metadata.getKeyspaces()).thenReturn(keyspaces);
 
     var sessionBuilder = mock(CqlSessionBuilder.class);
     when(sessionBuilder.withLocalDatacenter(any())).thenReturn(sessionBuilder);


### PR DESCRIPTION
now just check if there is any keyspaces, and log
the config which may hide all keyspaces when throwing
the error

**Which issue(s) this PR fixes**:
Fixes #2556

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
