### PR TITLE
Fix typo in RERANKING_PROVIDER_TIMEOUT‎ error message

### DIFF
--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -2810,7 +2810,7 @@ server-errors:
     code: RERANKING_PROVIDER_TIMEOUT
     title: Reranking Provider timed out
     body: |-
-      The command called an reranking provider to rerank results, but the provider did not respond within the allowed time.
+      The command called a reranking provider to rerank results, but the provider did not respond within the allowed time.
       
       The reranking provider was: ${modelProvider}.
       The HTTP status code was: ${httpStatus}.


### PR DESCRIPTION
**What this PR does**:

Fix a typo in the "reranking provider timeout" error message.

**Which issue(s) this PR fixes**:
Fixes #2557 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
