### PR TITLE
FIX #2562: send "dimensions" to Nvidia embedding NIM for variable-dimension models

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -148,8 +148,7 @@ public abstract class EmbeddingProvider extends ProviderBase {
 
   /**
    * Helper method that has logic wrt whether an Nvidia model accepts {@code "dimensions"} parameter
-   * or not: only models without a fixed {@code vector-dimension} (i.e. with a {@code
-   * vectorDimension} parameter, like {@code nvidia/llama-3.2-nv-embedqa-1b-v2}) do.
+   * or not.
    */
   protected static boolean acceptsNvidiaDimensions(
       EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -152,7 +152,8 @@ public abstract class EmbeddingProvider extends ProviderBase {
    */
   protected static boolean acceptsNvidiaDimensions(
       EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig) {
-    return modelConfig.vectorDimension().filter(dimension -> dimension > 0).isEmpty();
+    return modelConfig.parameters().stream()
+        .anyMatch(parameter -> parameter.name().equals("vectorDimension"));
   }
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -146,10 +146,7 @@ public abstract class EmbeddingProvider extends ProviderBase {
     return modelName.endsWith("titan-embed-text-v2:0");
   }
 
-  /**
-   * Helper method that has logic wrt whether an Nvidia model accepts {@code "dimensions"} parameter
-   * or not.
-   */
+  /** {@code NV-Embed-QA} and {@code nvidia/nv-embedqa-e5-v5} do not accept {@code dimensions}. */
   protected static boolean acceptsNvidiaDimensions(
       EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig) {
     return modelConfig.parameters().stream()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -147,6 +147,16 @@ public abstract class EmbeddingProvider extends ProviderBase {
   }
 
   /**
+   * Helper method that has logic wrt whether an Nvidia model accepts {@code "dimensions"} parameter
+   * or not: only models without a fixed {@code vector-dimension} (i.e. with a {@code
+   * vectorDimension} parameter, like {@code nvidia/llama-3.2-nv-embedqa-1b-v2}) do.
+   */
+  protected static boolean acceptsNvidiaDimensions(
+      EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig) {
+    return modelConfig.vectorDimension().filter(dimension -> dimension > 0).isEmpty();
+  }
+
+  /**
    * Replace parameters in a messageTemplate string with values from a map: placeholders are of form
    * {@code {parameterName}} and matching value to look for in the map is String {@code
    * "parameterName"}.

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/EmbeddingProvider.java
@@ -146,7 +146,10 @@ public abstract class EmbeddingProvider extends ProviderBase {
     return modelName.endsWith("titan-embed-text-v2:0");
   }
 
-  /** {@code NV-Embed-QA} and {@code nvidia/nv-embedqa-e5-v5} do not accept {@code dimensions}. */
+  /**
+   * Returns whether an Nvidia model accepts {@code dimensions}; {@code NV-Embed-QA} and {@code
+   * nvidia/nv-embedqa-e5-v5} do not.
+   */
   protected static boolean acceptsNvidiaDimensions(
       EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig) {
     return modelConfig.parameters().stream()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingProvider.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.embedding.operation;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.api.request.EmbeddingCredentials;
@@ -38,12 +39,13 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
       ServiceConfigStore.ServiceConfig serviceConfig,
       int dimension,
       Map<String, Object> vectorizeServiceParameters) {
+    // "dimensions" is only sent for variable-dimension models, 0 omits it from the request
     super(
         ModelProvider.NVIDIA,
         providerConfig,
         modelConfig,
         serviceConfig,
-        dimension,
+        acceptsNvidiaDimensions(modelConfig) ? dimension : 0,
         vectorizeServiceParameters);
 
     nvidiaClient =
@@ -81,7 +83,7 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
     var input_type = embeddingRequestType == EmbeddingRequestType.INDEX ? "passage" : "query";
     var nvidiaRequest =
         new NvidiaEmbeddingRequest(
-            texts.toArray(new String[texts.size()]), modelName(), input_type);
+            texts.toArray(new String[texts.size()]), modelName(), input_type, dimension);
 
     // user specified the embedding key in the request header, use that.
     // fall back to whatever they provided as the auth token for the API
@@ -141,11 +143,15 @@ public class NvidiaEmbeddingProvider extends EmbeddingProvider {
   }
 
   /**
-   * Request structure of the Nidia REST service.
+   * Request structure of the Nvidia REST service.
    *
-   * <p>..
+   * <p>{@code dimensions} is omitted when 0 (fixed-dimension models); the NIM rejects {@code 0}.
    */
-  public record NvidiaEmbeddingRequest(String[] input, String model, String input_type) {}
+  public record NvidiaEmbeddingRequest(
+      String[] input,
+      String model,
+      String input_type,
+      @JsonInclude(value = JsonInclude.Include.NON_DEFAULT) int dimensions) {}
 
   /**
    * Response structure of the Nvidia REST service.

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingClientTest.java
@@ -1,0 +1,188 @@
+package io.stargate.sgv2.jsonapi.service.embedding.operation;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.sgv2.jsonapi.TestConstants;
+import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProvidersConfig;
+import io.stargate.sgv2.jsonapi.service.embedding.configuration.EmbeddingProvidersConfigImpl;
+import io.stargate.sgv2.jsonapi.service.embedding.configuration.ServiceConfigStore;
+import io.stargate.sgv2.jsonapi.service.provider.ApiModelSupport;
+import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code dimensions} parameter is sent to the Nvidia NIM only for variable-dimension
+ * models. Relies on {@link EmbeddingClientTestResource}: input text must contain {@code
+ * application/json} to get the mocked success response.
+ */
+@QuarkusTest
+@WithTestResource(EmbeddingClientTestResource.class)
+public class NvidiaEmbeddingClientTest {
+
+  private static final String VARIABLE_DIMENSION_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2";
+  private static final String FIXED_DIMENSION_MODEL = "NV-Embed-QA";
+
+  private final TestConstants testConstants = new TestConstants();
+
+  private final EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig
+      VARIABLE_DIMENSION_MODEL_CONFIG =
+          new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.ModelConfigImpl(
+              VARIABLE_DIMENSION_MODEL,
+              new ApiModelSupport.ApiModelSupportImpl(
+                  ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
+              Optional.empty(),
+              List.of(),
+              Map.of(),
+              Optional.empty());
+
+  private final EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig
+      FIXED_DIMENSION_MODEL_CONFIG =
+          new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.ModelConfigImpl(
+              FIXED_DIMENSION_MODEL,
+              new ApiModelSupport.ApiModelSupportImpl(
+                  ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
+              Optional.of(1024),
+              List.of(),
+              Map.of(),
+              Optional.empty());
+
+  private final EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.RequestPropertiesImpl
+      REQUEST_PROPERTIES =
+          new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.RequestPropertiesImpl(
+              3, 10, 100, 100, 0.5, Optional.empty(), Optional.empty(), Optional.empty(), 10);
+
+  private final EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl PROVIDER_CONFIG =
+      new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl(
+          ModelProvider.NVIDIA.apiName(),
+          true,
+          Optional.of(EmbeddingClientTestResource.NVIDIA_URL),
+          false,
+          Map.of(),
+          List.of(),
+          REQUEST_PROPERTIES,
+          List.of());
+
+  private final ServiceConfigStore.ServiceConfig SERVICE_CONFIG =
+      new ServiceConfigStore.ServiceConfig(
+          ModelProvider.NVIDIA,
+          EmbeddingClientTestResource.NVIDIA_URL,
+          Optional.empty(),
+          new ServiceConfigStore.ServiceRequestProperties(
+              REQUEST_PROPERTIES.atMostRetries(),
+              REQUEST_PROPERTIES.initialBackOffMillis(),
+              REQUEST_PROPERTIES.readTimeoutMillis(),
+              REQUEST_PROPERTIES.maxBackOffMillis(),
+              REQUEST_PROPERTIES.jitter(),
+              REQUEST_PROPERTIES.taskTypeRead(),
+              REQUEST_PROPERTIES.taskTypeStore(),
+              REQUEST_PROPERTIES.maxBatchSize()),
+          Map.of());
+
+  private NvidiaEmbeddingProvider createProvider(
+      EmbeddingProvidersConfig.EmbeddingProviderConfig.ModelConfig modelConfig, int dimension) {
+    return new NvidiaEmbeddingProvider(
+        PROVIDER_CONFIG, modelConfig, SERVICE_CONFIG, dimension, Map.of());
+  }
+
+  private EmbeddingProvider.BatchedEmbeddingResponse runVectorize(
+      EmbeddingProvider embeddingProvider,
+      List<String> texts,
+      EmbeddingProvider.EmbeddingRequestType requestType) {
+
+    return embeddingProvider
+        .vectorize(1, texts, testConstants.EMBEDDING_CREDENTIALS, requestType)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .awaitItem()
+        .getItem();
+  }
+
+  private static RequestPatternBuilder embeddingRequestFor(String inputText) {
+    return postRequestedFor(urlEqualTo(EmbeddingClientTestResource.NVIDIA_PATH))
+        .withRequestBody(matchingJsonPath("$.input[0]", equalTo(inputText)));
+  }
+
+  private static void assertVectorized(EmbeddingProvider.BatchedEmbeddingResponse response) {
+    assertThat(response)
+        .isInstanceOf(EmbeddingProvider.BatchedEmbeddingResponse.class)
+        .satisfies(
+            r -> {
+              assertThat(r.embeddings()).isNotNull();
+              assertThat(r.embeddings().size()).isEqualTo(1);
+              assertThat(r.embeddings().get(0).length).isEqualTo(3);
+            });
+  }
+
+  @Nested
+  class DimensionsParameter {
+
+    @Test
+    public void variableDimensionModelSendsDimensionsForIndex() {
+      var inputText = MediaType.APPLICATION_JSON + " variable-dimension-index";
+
+      var response =
+          runVectorize(
+              createProvider(VARIABLE_DIMENSION_MODEL_CONFIG, 512),
+              List.of(inputText),
+              EmbeddingProvider.EmbeddingRequestType.INDEX);
+      assertVectorized(response);
+
+      verify(
+          embeddingRequestFor(inputText)
+              .withRequestBody(matchingJsonPath("$.model", equalTo(VARIABLE_DIMENSION_MODEL)))
+              .withRequestBody(matchingJsonPath("$.input_type", equalTo("passage")))
+              .withRequestBody(matchingJsonPath("$.dimensions", equalTo("512"))));
+    }
+
+    @Test
+    public void variableDimensionModelSendsDimensionsForSearch() {
+      var inputText = MediaType.APPLICATION_JSON + " variable-dimension-search";
+
+      var response =
+          runVectorize(
+              createProvider(VARIABLE_DIMENSION_MODEL_CONFIG, 384),
+              List.of(inputText),
+              EmbeddingProvider.EmbeddingRequestType.SEARCH);
+      assertVectorized(response);
+
+      verify(
+          embeddingRequestFor(inputText)
+              .withRequestBody(matchingJsonPath("$.input_type", equalTo("query")))
+              .withRequestBody(matchingJsonPath("$.dimensions", equalTo("384"))));
+    }
+
+    @Test
+    public void fixedDimensionModelOmitsDimensions() {
+      var inputText = MediaType.APPLICATION_JSON + " fixed-dimension";
+
+      var response =
+          runVectorize(
+              createProvider(FIXED_DIMENSION_MODEL_CONFIG, 1024),
+              List.of(inputText),
+              EmbeddingProvider.EmbeddingRequestType.INDEX);
+      assertVectorized(response);
+
+      verify(
+          embeddingRequestFor(inputText)
+              .withRequestBody(matchingJsonPath("$.model", equalTo(FIXED_DIMENSION_MODEL))));
+      verify(
+          WireMock.exactly(0),
+          embeddingRequestFor(inputText).withRequestBody(matchingJsonPath("$.dimensions")));
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/NvidiaEmbeddingClientTest.java
@@ -46,7 +46,18 @@ public class NvidiaEmbeddingClientTest {
               new ApiModelSupport.ApiModelSupportImpl(
                   ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
               Optional.empty(),
-              List.of(),
+              List.of(
+                  new EmbeddingProvidersConfigImpl.EmbeddingProviderConfigImpl.ParameterConfigImpl(
+                      "vectorDimension",
+                      EmbeddingProvidersConfig.EmbeddingProviderConfig.ParameterType.NUMBER,
+                      false,
+                      Optional.of("2048"),
+                      Map.of(
+                          EmbeddingProvidersConfig.EmbeddingProviderConfig.ValidationType.OPTIONS,
+                          List.of(384, 512, 768, 1024, 2048)),
+                      Optional.empty(),
+                      Optional.empty(),
+                      Optional.empty())),
               Map.of(),
               Optional.empty());
 


### PR DESCRIPTION
## Summary

`NvidiaEmbeddingRequest` never carried `dimensions`, so the Collection/Table dimension never reached the NIM. For variable-dimension models (`nvidia/llama-3.2-nv-embedqa-1b-v2`: 384/512/768/1024/2048, default 2048) the NIM always returned 2048-dim vectors and vectorize failed:

```
EMBEDDING_PROVIDER_UNEXPECTED_RESPONSE: Embedding provider 'nvidia' did not return expected embedding length. Expect: '512'. Actual: '2048'.
```

## Changes

- `NvidiaEmbeddingRequest.dimensions`, serialized only when non-zero.  The NIM rejects `dimensions: 0` with HTTP 400, so it must be omitted (not zeroed) for fixed-dimension models.

## Verification

- Dev GPU-plane NIM, direct calls: no `dimensions` → 2048; `512` → 512; `384` → 384; `0` → HTTP 400.
- `./mvnw test -Dtest=NvidiaEmbeddingClientTest,EmbeddingProviderErrorMessageTest,EmbeddingGatewayClientTest,OpenAiEmbeddingClientTest` → 19 tests, 0 failures.
