### PR TITLE
feat: reranking concurrency gate, total deadline, and 512-passage nemotron batches

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -81,3 +81,25 @@ Other Quarkus properties that are specifically relevant for the service:
 | Property                        | Type      | Default | Description                                                                                                         |
 |---------------------------------|-----------|---------|---------------------------------------------------------------------------------------------------------------------|
 | `stargate.feature.flags.tables` | `boolean` | `true` (enabled by default)   | Setting it to `true` enables Tables functionality; `false` disables; leaving as `null` uses the default (enabled).|
+
+## Reranking configuration
+*Configuration for reranking providers and the reranking concurrency gate, defined by [RerankingProvidersConfig.java](src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java). Providers and models are loaded from `reranking-providers-config.yaml` (overridable with the `RERANKING_CONFIG_PATH` env var or the `RERANKING_CONFIG_RESOURCE` system property); when the embedding gateway is enabled the provider/model list is served by the gateway instead.*
+
+Each model under `stargate.jsonapi.reranking.providers.<provider>.models[]` supports the following `properties`:
+
+| Property                 | Type     | Default | Description                                                                                                                                                                                                            |
+|--------------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `at-most-retries`        | `int`    | `3`     | Maximum attempts per batch call before failing (1 request + 2 retries).                                                                                                                                                |
+| `initial-back-off-millis`| `int`    | `100`   | Initial retry delay, doubling up to `max-back-off-millis`.                                                                                                                                                             |
+| `read-timeout-millis`    | `int`    | `5000`  | HTTP read timeout for a single batch call.                                                                                                                                                                             |
+| `max-back-off-millis`    | `int`    | `500`   | Maximum retry delay.                                                                                                                                                                                                   |
+| `jitter`                 | `double` | `0.5`   | Random variation applied to retry delays.                                                                                                                                                                              |
+| `max-batch-size`         | `int`    | (none)  | Maximum passages per reranking call; a rerank request fans out into `ceil(passages / max-batch-size)` calls.                                                                                                            |
+| `max-concurrent-batches` | `int`    | `8`     | Per-request fan-out cap: how many batch calls a single rerank request runs concurrently.                                                                                                                                |
+| `max-concurrent-calls`   | `int`    | `32`    | Per-process bulkhead: reranking calls in flight at once across all requests for this model. Excess calls wait in a FIFO queue.                                                                                          |
+| `max-queued-calls`       | `int`    | `1000`  | Bounded FIFO queue depth for calls waiting on `max-concurrent-calls`. When full, further calls fail immediately with `RERANKING_PROVIDER_OVERLOADED` without calling the provider. `0` disables queueing (fail fast).   |
+| `total-timeout-millis`   | `int`    | `30000` | Overall deadline for one rerank request, covering queue wait, all batch calls, and retries. Must be at least `read-timeout-millis`. On expiry the request fails with `RERANKING_PROVIDER_TIMEOUT` and parked work is abandoned without ever calling the provider. |
+
+Sizing rule of thumb: a queue entry only makes sense if it can be served within the deadline, so keep `max-queued-calls` at or below `max-concurrent-calls x (total-timeout-millis / typical-call-latency-millis)`; entries beyond that will burn their whole deadline waiting and still fail.
+
+The gate exposes Micrometer metrics per provider+model: `rerank.all.queue.depth` and `rerank.all.inflight.calls` (gauges), `rerank.all.queue.wait.duration` (timer, recorded for calls that actually waited), and `rerank.all.queue.rejected.count` (counter).

--- a/docs/reranking-egw-coordination.md
+++ b/docs/reranking-egw-coordination.md
@@ -1,0 +1,47 @@
+# Reranking concurrency gate: embedding gateway (EGW) coordination
+
+On EGW-enabled deployments (Astra), `RerankingProviderConfigProducer` sources the reranking
+provider/model configuration from the gateway's `getSupportedRerankingProviders` gRPC response —
+**not** from this repo's `reranking-providers-config.yaml`. Two EGW-side changes are needed for the
+concurrency-gate work to be fully effective on Astra.
+
+## 1. Mirror the new proto fields
+
+`embedding_gateway.proto`, message
+`GetSupportedRerankingProvidersResponse.ProviderConfig.ModelConfig.RequestProperties`, gained four
+fields (7–10, all `optional int32` — `optional` so the Data API can distinguish "not served" from
+zero):
+
+```proto
+optional int32 max_concurrent_batches = 7;   // per-request fan-out cap        (Data API default 8)
+optional int32 max_concurrent_calls  = 8;    // per-pod in-flight bulkhead     (Data API default 32)
+optional int32 max_queued_calls      = 9;    // bounded FIFO wait queue        (Data API default 1000)
+optional int32 total_timeout_millis  = 10;   // overall per-request deadline   (Data API default 30000)
+```
+
+The EGW repo must copy these fields into its own proto and populate them from its model config.
+
+**Fallback semantics on the Data API side** (already shipped, so deploy order is safe): a field
+that is unset, or set below its minimum (1 for fields 7/8/10; 0 for `max_queued_calls`, where 0 is
+a valid explicit "no queueing"), falls back to the Data API default listed above. An old gateway
+therefore yields safe defaults — never zero permits.
+
+## 2. Serve the nemotron model with max_batch_size 512
+
+The Data API yaml adds `nvidia/llama-3.2-nemoretriever-500m-rerank-v2` with `max-batch-size: 512`,
+but on Astra the served model list comes from EGW. Until EGW adds the same model entry:
+
+- Astra tenants cannot select the nemotron model at all, and
+- once EGW adds it, `max_batch_size` **must be 512** there. If EGW serves a smaller value the
+  fan-out collapse (10 calls → 1 call per findAndRerank) — the main throughput lever for the
+  PepsiCo 1000-burst target — silently does not happen on Astra.
+
+The gate concurrency fields can initially be left unserved (Data API defaults apply); serving them
+from EGW is what makes them tunable per environment without a Data API release.
+
+## Timeout interaction note
+
+On the EGW path the Data API's `read-timeout-millis` is not applied (the gRPC deadline is
+EGW-side). The new `total_timeout_millis` deadline IS applied on the EGW path — it wraps the whole
+rerank request in the Data API — so make sure EGW's own upstream timeout for reranking calls is at
+or below it, or EGW will keep working on requests the Data API has already failed.

--- a/docs/reranking-nim-capacity-recommendations.md
+++ b/docs/reranking-nim-capacity-recommendations.md
@@ -1,0 +1,71 @@
+# Reranking NIM capacity recommendations (GPU plane)
+
+Companion to the Data API reranking concurrency gate (`max-concurrent-batches` /
+`max-concurrent-calls` / `max-queued-calls` / `total-timeout-millis`, see
+[CONFIGURATION.md](../CONFIGURATION.md#reranking-configuration)). The gate makes a burst degrade
+gracefully on the Data API side; this document covers the `gpu-helm-charts` / NIM side changes that
+give the burst somewhere to go. Target scenario: PepsiCo's requirement of **1000 simultaneous
+`findAndRerank` requests with zero errors**.
+
+## Why the model change is the main lever
+
+Queuing converts errors into latency; it does not create throughput. The measured drain rate of a
+single `llama-3.2-nv-rerankqa-1b-v2` pod (NIM 1.3.1.0, 10-passage batches) is ~12–16 calls/s, and
+each `findAndRerank` fans out ~10 batch calls, so a 1000-request burst is ~10,000 calls — minutes
+of queue at any realistic replica count.
+
+`llama-3.2-nemoretriever-500m-rerank-v2` (NIM 2.x runtime) accepts **512 passages per call**, so a
+typical `findAndRerank` becomes **one** reranking call. PepsiCo's own benchmark (their infra,
+nemotron v2 on NIM 2.0.0, 2 pods x 1 engine) absorbed an 1800-request burst with 0% errors at
+~25 calls/s aggregate. That is the existence proof for the 1000-burst target on a small deployment.
+
+## Chart changes needed (gpu-helm-charts)
+
+1. **Deploy the nemotron rerank NIM**: `nemo-reranking` currently ships only
+   `llama-3.2-nv-rerankqa-1b-v2` at image tag `1.3.1.0`. Add a
+   `llama-3.2-nemoretriever-500m-rerank-v2` service on the NIM 2.x runtime.
+2. **Ingress route**: add the per-model route the Data API config points at:
+   `/nvidia/v1/ranking/nvidia-llama-3-2-nemoretriever-500m-rerank-v2` →
+   `nvidia-llama-3-2-nemoretriever-500m-rerank-v2.reranking-nim.svc.cluster.local` (same pattern as
+   the existing `nvidia-llama-3-2-nv-rerankqa-1b-v2` route in `ingress/chart/templates/config.yaml`).
+   The default `/nvidia/v1/ranking` route stays on the legacy model until cutover.
+3. **NIM queue/shedding env vars** (2.x runtime only — the 1.x runtime does not expose them):
+   - `NIM_SERVER_REQUEST_TIMEOUT_S`: set **at or below** the Data API `total-timeout-millis`
+     (default 30s → set 30). The default is 120s, which makes the NIM serve answers nobody is
+     waiting for once the Data API deadline has fired.
+   - `NIM_SERVER_MAX_QUEUE_SIZE`: cap the NIM-side queue so overload sheds (503) instead of
+     queueing unboundedly. Size it to at least the worst-case aggregate in-flight from the Data
+     API: `data_api_pods x max-concurrent-calls / nim_replicas` (e.g. 4 Data API pods x 32 / 2
+     replicas = 64), plus headroom. With the Data API gate in place the NIM queue should rarely
+     grow beyond that — the Data API queue does the shedding with a client-friendly error instead.
+
+## Replica sizing
+
+```
+replicas >= burst_calls / (per_pod_drain_rate x deadline_seconds)
+```
+
+Worked example for the 1000-burst target with 512-passage calls, ~12.5 calls/s per pod (PepsiCo's
+measured aggregate ~25/s on 2 pods) and the 30s Data API deadline:
+
+```
+replicas >= 1000 / (12.5 x 30) ≈ 2.7  →  3 replicas (2 minimum + headroom)
+```
+
+**Measure `per_pod_drain_rate` on our own L40S (g6e-xlarge) nodes before committing** — the
+PepsiCo figure comes from their hardware, and 512-passage calls have very different per-call cost
+than 10-passage calls. The `retrieval-eval/tools/rerank-loadtest` tool in burst mode
+(`--iterations-per-user 1`) reproduces the scenario; Triton queue depth is visible only in the
+`nv_inference_*` metrics on port 8002.
+
+## Interplay with the Data API gate (deploy order)
+
+1. Data API ships first: gate defaults (32 in-flight/pod, queue 1000, 30s deadline) are safe
+   against the existing NIM.
+2. NIM 2.x model + ingress route next (this document).
+3. Tune `NIM_SERVER_*` and replica count from the load-test measurements.
+
+Under a 1000-burst with 4 Data API pods, at most 128 calls hit the GPU plane simultaneously; the
+rest wait in the Data API queues and either get served within their deadline or fail fast with
+`RERANKING_PROVIDER_OVERLOADED` / `RERANKING_PROVIDER_TIMEOUT` — the queue depth, wait time, and
+rejection metrics (`rerank.all.queue.*`) show which regime the system is in.

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/RerankingProviderException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/RerankingProviderException.java
@@ -9,6 +9,7 @@ public class RerankingProviderException extends ServerException {
   }
 
   public enum Code implements ErrorCode<RerankingProviderException> {
+    RERANKING_PROVIDER_OVERLOADED,
     RERANKING_PROVIDER_TIMEOUT;
 
     private final ErrorTemplate<RerankingProviderException> template;

--- a/src/main/java/io/stargate/sgv2/jsonapi/metrics/MetricsConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/metrics/MetricsConstants.java
@@ -19,7 +19,11 @@ public interface MetricsConstants {
   interface MetricNames {
     String HTTP_SERVER_REQUESTS = "http.server.requests";
     String RERANK_ALL_CALL_DURATION_METRIC = "rerank.all.call.duration";
+    String RERANK_ALL_INFLIGHT_CALLS_METRIC = "rerank.all.inflight.calls";
     String RERANK_ALL_PASSAGE_COUNT_METRIC = "rerank.all.passage.count";
+    String RERANK_ALL_QUEUE_DEPTH_METRIC = "rerank.all.queue.depth";
+    String RERANK_ALL_QUEUE_REJECTED_METRIC = "rerank.all.queue.rejected.count";
+    String RERANK_ALL_QUEUE_WAIT_DURATION_METRIC = "rerank.all.queue.wait.duration";
     String RERANK_TENANT_CALL_DURATION_METRIC = "rerank.tenant.call.duration";
     String RERANK_TENANT_PASSAGE_COUNT_METRIC = "rerank.tenant.passage.count";
     String VECTORIZE_CALL_DURATION_METRIC = "vectorize.call.duration";

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderConfigProducer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderConfigProducer.java
@@ -145,7 +145,8 @@ public class RerankingProviderConfigProducer {
     }
   }
 
-  private RerankingProvidersConfig grpcResponseToConfig(
+  // package-private for testing the gateway property mapping and its fallbacks
+  RerankingProvidersConfig grpcResponseToConfig(
       EmbeddingGateway.GetSupportedRerankingProvidersResponse grpcResponse) {
     Map<String, RerankingProvidersConfig.RerankingProviderConfig> providerMap = new HashMap<>();
 
@@ -214,7 +215,32 @@ public class RerankingProviderConfigProducer {
                             model.getProperties().getReadTimeoutMillis(),
                             model.getProperties().getMaxBackOffMillis(),
                             model.getProperties().getJitter(),
-                            model.getProperties().getMaxBatchSize())))
+                            model.getProperties().getMaxBatchSize(),
+                            concurrencyPropertyOrDefault(
+                                model.getProperties().hasMaxConcurrentBatches(),
+                                model.getProperties().getMaxConcurrentBatches(),
+                                1,
+                                RerankingProvidersConfig.RerankingProviderConfig.ModelConfig
+                                    .RequestProperties.DEFAULT_MAX_CONCURRENT_BATCHES),
+                            concurrencyPropertyOrDefault(
+                                model.getProperties().hasMaxConcurrentCalls(),
+                                model.getProperties().getMaxConcurrentCalls(),
+                                1,
+                                RerankingProvidersConfig.RerankingProviderConfig.ModelConfig
+                                    .RequestProperties.DEFAULT_MAX_CONCURRENT_CALLS),
+                            concurrencyPropertyOrDefault(
+                                model.getProperties().hasMaxQueuedCalls(),
+                                model.getProperties().getMaxQueuedCalls(),
+                                // 0 is valid here: an explicit "no queueing, fail fast"
+                                0,
+                                RerankingProvidersConfig.RerankingProviderConfig.ModelConfig
+                                    .RequestProperties.DEFAULT_MAX_QUEUED_CALLS),
+                            concurrencyPropertyOrDefault(
+                                model.getProperties().hasTotalTimeoutMillis(),
+                                model.getProperties().getTotalTimeoutMillis(),
+                                1,
+                                RerankingProvidersConfig.RerankingProviderConfig.ModelConfig
+                                    .RequestProperties.DEFAULT_TOTAL_TIMEOUT_MILLIS))))
             .collect(Collectors.toList());
 
     return new RerankingProvidersConfigImpl.RerankingProviderConfigImpl(
@@ -223,5 +249,15 @@ public class RerankingProviderConfigProducer {
         grpcProviderConfig.getEnabled(),
         supportedAuthenticationsMap,
         models);
+  }
+
+  /**
+   * Concurrency-gate properties served by the embedding gateway, falling back to the Data API
+   * defaults when the gateway predates the fields or serves an out-of-range value: zero concurrent
+   * calls would deadlock every rerank request, so unset must never map to zero.
+   */
+  private static int concurrencyPropertyOrDefault(
+      boolean served, int value, int minValue, String defaultValue) {
+    return served && value >= minValue ? value : Integer.parseInt(defaultValue);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfig.java
@@ -74,6 +74,18 @@ public interface RerankingProvidersConfig {
 
       interface RequestProperties {
         /**
+         * Defaults shared between the SmallRye {@code @WithDefault} bindings below and the
+         * embedding gateway fallback in {@code RerankingProviderConfigProducer}: when an older
+         * gateway does not serve these fields, the same defaults apply instead of zero (zero
+         * concurrent calls would deadlock every rerank request).
+         */
+        String DEFAULT_MAX_CONCURRENT_BATCHES = "8";
+
+        String DEFAULT_MAX_CONCURRENT_CALLS = "32";
+        String DEFAULT_MAX_QUEUED_CALLS = "1000";
+        String DEFAULT_TOTAL_TIMEOUT_MILLIS = "30000";
+
+        /**
          * Specifies the maximum number of attempts before failing. Default is 3 (1 request + 2
          * retries).
          *
@@ -120,6 +132,39 @@ public interface RerankingProvidersConfig {
 
         /** Maximum batch size supported by the provider. */
         int maxBatchSize();
+
+        /**
+         * The maximum number of batch calls a single rerank request runs concurrently. Batches
+         * beyond this limit start as earlier batches finish. Bounds the per-request burst a large
+         * passage list can put on the reranking service.
+         */
+        @WithDefault(DEFAULT_MAX_CONCURRENT_BATCHES)
+        int maxConcurrentBatches();
+
+        /**
+         * The maximum number of reranking calls in flight at once across all requests on this
+         * process for this model. Calls beyond this limit wait in a FIFO queue (see {@link
+         * #maxQueuedCalls()}).
+         */
+        @WithDefault(DEFAULT_MAX_CONCURRENT_CALLS)
+        int maxConcurrentCalls();
+
+        /**
+         * The maximum number of reranking calls that may wait for a permit (see {@link
+         * #maxConcurrentCalls()}). When the queue is full, further calls fail immediately with
+         * {@code RERANKING_PROVIDER_OVERLOADED} without calling the provider.
+         */
+        @WithDefault(DEFAULT_MAX_QUEUED_CALLS)
+        int maxQueuedCalls();
+
+        /**
+         * Overall deadline for one rerank request in milliseconds, covering queue wait, every batch
+         * call, and retries. Must be at least {@link #readTimeoutMillis()}. On expiry the request
+         * fails with {@code RERANKING_PROVIDER_TIMEOUT}; parked work is abandoned without ever
+         * calling the provider.
+         */
+        @WithDefault(DEFAULT_TOTAL_TIMEOUT_MILLIS)
+        int totalTimeoutMillis();
       }
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfigImpl.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfigImpl.java
@@ -35,8 +35,41 @@ public record RerankingProvidersConfigImpl(Map<String, RerankingProviderConfig> 
           int readTimeoutMillis,
           int maxBackOffMillis,
           double jitter,
-          int maxBatchSize)
-          implements RerankingProviderConfig.ModelConfig.RequestProperties {}
+          int maxBatchSize,
+          int maxConcurrentBatches,
+          int maxConcurrentCalls,
+          int maxQueuedCalls,
+          int totalTimeoutMillis)
+          implements RerankingProviderConfig.ModelConfig.RequestProperties {
+
+        /** Convenience constructor applying the concurrency-gate defaults. */
+        public RequestPropertiesImpl(
+            int atMostRetries,
+            int initialBackOffMillis,
+            int readTimeoutMillis,
+            int maxBackOffMillis,
+            double jitter,
+            int maxBatchSize) {
+          this(
+              atMostRetries,
+              initialBackOffMillis,
+              readTimeoutMillis,
+              maxBackOffMillis,
+              jitter,
+              maxBatchSize,
+              Integer.parseInt(
+                  RerankingProviderConfig.ModelConfig.RequestProperties
+                      .DEFAULT_MAX_CONCURRENT_BATCHES),
+              Integer.parseInt(
+                  RerankingProviderConfig.ModelConfig.RequestProperties
+                      .DEFAULT_MAX_CONCURRENT_CALLS),
+              Integer.parseInt(
+                  RerankingProviderConfig.ModelConfig.RequestProperties.DEFAULT_MAX_QUEUED_CALLS),
+              Integer.parseInt(
+                  RerankingProviderConfig.ModelConfig.RequestProperties
+                      .DEFAULT_TOTAL_TIMEOUT_MILLIS));
+        }
+      }
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/gateway/RerankingEGWClient.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/gateway/RerankingEGWClient.java
@@ -12,6 +12,7 @@ import io.stargate.sgv2.jsonapi.exception.SchemaException;
 import io.stargate.sgv2.jsonapi.exception.ServerException;
 import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
+import io.stargate.sgv2.jsonapi.service.reranking.operation.RerankingConcurrencyGate;
 import io.stargate.sgv2.jsonapi.service.reranking.operation.RerankingProvider;
 import java.util.*;
 
@@ -33,12 +34,13 @@ public class RerankingEGWClient extends RerankingProvider {
   public RerankingEGWClient(
       ModelProvider modelProvider,
       RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig,
+      RerankingConcurrencyGate concurrencyGate,
       Tenant tenant,
       String authToken,
       RerankingService grpcGatewayService,
       Map<String, String> authentication,
       String commandName) {
-    super(modelProvider, modelConfig);
+    super(modelProvider, modelConfig, concurrencyGate);
 
     this.tenant = tenant;
     this.authToken = authToken;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProvider.java
@@ -72,8 +72,9 @@ public class NvidiaRerankingProvider extends RerankingProvider {
   private static final String TRUNCATE_PASSAGE = "NONE";
 
   public NvidiaRerankingProvider(
-      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig) {
-    super(ModelProvider.NVIDIA, modelConfig);
+      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig,
+      RerankingConcurrencyGate concurrencyGate) {
+    super(ModelProvider.NVIDIA, modelConfig, concurrencyGate);
 
     nvidiaClient =
         QuarkusRestClientBuilder.newBuilder()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingConcurrencyGate.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingConcurrencyGate.java
@@ -1,0 +1,282 @@
+package io.stargate.sgv2.jsonapi.service.reranking.operation;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+import io.stargate.sgv2.jsonapi.exception.RerankingProviderException;
+import io.stargate.sgv2.jsonapi.metrics.MetricsConstants;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * A non-blocking bulkhead for reranking provider calls, shared by every request on this pod for one
+ * provider+model pair.
+ *
+ * <p>At most {@code maxConcurrentCalls} reranking calls run at once; up to {@code maxQueuedCalls}
+ * further calls park in a FIFO queue. When both limits are reached, new calls fail immediately with
+ * {@link RerankingProviderException.Code#RERANKING_PROVIDER_OVERLOADED} without ever reaching the
+ * provider. Cancelling a caller (e.g. the total rerank deadline firing) while it is parked frees
+ * its queue slot without consuming a permit.
+ *
+ * <p>Providers are constructed per API request (see {@link RerankingProviderFactory}), so instances
+ * of this class must be shared — obtain them from {@link RerankingConcurrencyGateRegistry}.
+ *
+ * <p>Never blocks a thread: acquisition either completes synchronously, fails synchronously, or
+ * parks a {@link UniEmitter} that is completed later by whichever thread releases a permit.
+ */
+public class RerankingConcurrencyGate {
+
+  private final String providerName;
+  private final String modelName;
+  private final int maxConcurrentCalls;
+  private final int maxQueuedCalls;
+
+  private final AtomicInteger inFlight = new AtomicInteger();
+  private final AtomicInteger queued = new AtomicInteger();
+  private final ConcurrentLinkedQueue<Waiter> waiters = new ConcurrentLinkedQueue<>();
+
+  private final Timer queueWaitTimer;
+  private final Counter rejectedCounter;
+
+  public RerankingConcurrencyGate(
+      String providerName,
+      String modelName,
+      int maxConcurrentCalls,
+      int maxQueuedCalls,
+      MeterRegistry meterRegistry) {
+    if (maxConcurrentCalls <= 0) {
+      throw new IllegalArgumentException(
+          "maxConcurrentCalls must be positive, got " + maxConcurrentCalls);
+    }
+    if (maxQueuedCalls < 0) {
+      throw new IllegalArgumentException("maxQueuedCalls must be >= 0, got " + maxQueuedCalls);
+    }
+    this.providerName = providerName;
+    this.modelName = modelName;
+    this.maxConcurrentCalls = maxConcurrentCalls;
+    this.maxQueuedCalls = maxQueuedCalls;
+
+    var tags =
+        Tags.of(
+            MetricsConstants.MetricTags.RERANKING_PROVIDER_TAG, providerName,
+            MetricsConstants.MetricTags.RERANKING_MODEL_TAG, modelName);
+    // strongReference: the gate outlives any single request, the registry must not GC the gauges
+    Gauge.builder(
+            MetricsConstants.MetricNames.RERANK_ALL_INFLIGHT_CALLS_METRIC, inFlight::doubleValue)
+        .tags(tags)
+        .strongReference(true)
+        .register(meterRegistry);
+    Gauge.builder(MetricsConstants.MetricNames.RERANK_ALL_QUEUE_DEPTH_METRIC, queued::doubleValue)
+        .tags(tags)
+        .strongReference(true)
+        .register(meterRegistry);
+    this.queueWaitTimer =
+        Timer.builder(MetricsConstants.MetricNames.RERANK_ALL_QUEUE_WAIT_DURATION_METRIC)
+            .tags(tags)
+            .register(meterRegistry);
+    this.rejectedCounter =
+        Counter.builder(MetricsConstants.MetricNames.RERANK_ALL_QUEUE_REJECTED_METRIC)
+            .tags(tags)
+            .register(meterRegistry);
+  }
+
+  /** Current number of in-flight calls holding a permit. Exposed for gauges and tests. */
+  public int inFlight() {
+    return inFlight.get();
+  }
+
+  /** Current number of parked waiters. Exposed for gauges and tests. */
+  public int queueDepth() {
+    return queued.get();
+  }
+
+  /**
+   * Runs {@code work} once a permit is available, parking FIFO behind earlier callers when the gate
+   * is full. The permit is released exactly once when the work emits an item, fails, or is
+   * cancelled. Fails with {@code RERANKING_PROVIDER_OVERLOADED} when the wait queue is full; {@code
+   * work} is then never invoked.
+   */
+  public <T> Uni<T> withPermit(Supplier<Uni<? extends T>> work) {
+    return acquire()
+        .onItem()
+        .transformToUni(
+            permit -> {
+              permit.markConsumed();
+              return Uni.createFrom().<T>deferred(work).onTermination().invoke(permit::release);
+            });
+  }
+
+  private Uni<Permit> acquire() {
+    return Uni.createFrom()
+        .emitter(
+            emitter -> {
+              // fast path only when nobody is parked, so new arrivals cannot barge past waiters
+              if (waiters.isEmpty() && tryReserveSlot()) {
+                var permit = new Permit();
+                // covers the race where the caller is cancelled between the grant and the
+                // downstream consuming it: an unconsumed permit must not leak the slot
+                emitter.onTermination(permit::releaseIfNotConsumed);
+                emitter.complete(permit);
+                return;
+              }
+
+              if (queued.incrementAndGet() > maxQueuedCalls) {
+                queued.decrementAndGet();
+                rejectedCounter.increment();
+                emitter.fail(overloadedException());
+                return;
+              }
+
+              var waiter = new Waiter(emitter);
+              emitter.onTermination(waiter::onCallerTerminated);
+              waiters.add(waiter);
+              // a permit may have been released between the fast-path check and parking
+              drain();
+            });
+  }
+
+  private void release() {
+    inFlight.decrementAndGet();
+    drain();
+  }
+
+  /** Grants permits to parked waiters, oldest first, while capacity is available. */
+  private void drain() {
+    while (true) {
+      if (waiters.isEmpty() || !tryReserveSlot()) {
+        return;
+      }
+      // holding one reserved slot; find the oldest waiter not already abandoned
+      Waiter granted = null;
+      Waiter candidate;
+      while ((candidate = waiters.poll()) != null) {
+        // the permit is attached BEFORE the claim CAS: a concurrent cancellation that loses
+        // the claim race must be able to see it and free the slot (see onCallerTerminated)
+        candidate.prepareGrant(new Permit());
+        if (candidate.tryClaimForGrant()) {
+          granted = candidate;
+          break;
+        }
+        // abandoned waiter: its queue accounting was already reverted, keep polling
+      }
+      if (granted == null) {
+        // no live waiter for the reserved slot: put it back and re-check, another caller
+        // may have parked concurrently
+        inFlight.decrementAndGet();
+        if (waiters.isEmpty()) {
+          return;
+        }
+        continue;
+      }
+      queued.decrementAndGet();
+      queueWaitTimer.record(System.nanoTime() - granted.enqueuedNanos, TimeUnit.NANOSECONDS);
+      granted.grant();
+    }
+  }
+
+  private boolean tryReserveSlot() {
+    while (true) {
+      int current = inFlight.get();
+      if (current >= maxConcurrentCalls) {
+        return false;
+      }
+      if (inFlight.compareAndSet(current, current + 1)) {
+        return true;
+      }
+    }
+  }
+
+  private RerankingProviderException overloadedException() {
+    return RerankingProviderException.Code.RERANKING_PROVIDER_OVERLOADED.get(
+        Map.of(
+            "modelProvider",
+            providerName,
+            "modelName",
+            modelName,
+            "maxConcurrentCalls",
+            String.valueOf(maxConcurrentCalls),
+            "maxQueuedCalls",
+            String.valueOf(maxQueuedCalls)));
+  }
+
+  /**
+   * One reserved slot. Consumed by the downstream continuation in {@link #withPermit(Supplier)};
+   * released exactly once, either by the work's termination or — when the caller was cancelled
+   * before the grant reached it — by the emitter's termination callback.
+   */
+  private final class Permit {
+    private final AtomicBoolean consumed = new AtomicBoolean();
+    private final AtomicBoolean released = new AtomicBoolean();
+
+    void markConsumed() {
+      consumed.set(true);
+    }
+
+    void release() {
+      if (released.compareAndSet(false, true)) {
+        RerankingConcurrencyGate.this.release();
+      }
+    }
+
+    void releaseIfNotConsumed() {
+      if (!consumed.get()) {
+        release();
+      }
+    }
+  }
+
+  /**
+   * A parked caller. The {@code claimed} flag is CAS-raced between the granting side ({@link
+   * #drain()}) and the abandoning side (caller cancelled while parked) so exactly one wins.
+   */
+  private final class Waiter {
+    private final UniEmitter<? super Permit> emitter;
+    private final AtomicBoolean claimed = new AtomicBoolean();
+    private final AtomicReference<Permit> grantedPermit = new AtomicReference<>();
+    private final long enqueuedNanos = System.nanoTime();
+
+    Waiter(UniEmitter<? super Permit> emitter) {
+      this.emitter = emitter;
+    }
+
+    void prepareGrant(Permit permit) {
+      grantedPermit.set(permit);
+    }
+
+    boolean tryClaimForGrant() {
+      return claimed.compareAndSet(false, true);
+    }
+
+    void grant() {
+      emitter.complete(grantedPermit.get());
+    }
+
+    /**
+     * Runs when the caller's subscription terminates: after a successful grant delivery, or on
+     * cancellation (deadline fired / client disconnected) whether parked or mid-grant.
+     */
+    void onCallerTerminated() {
+      if (claimed.compareAndSet(false, true)) {
+        // abandoned before any grant: free the queue capacity, no permit was consumed.
+        // drain() lazily skips this node when polling.
+        queued.decrementAndGet();
+        return;
+      }
+      // the grant won the race; if it never reached the downstream continuation
+      // (cancelled in between), the slot must be freed here
+      var permit = grantedPermit.get();
+      if (permit != null) {
+        permit.releaseIfNotConsumed();
+      }
+    }
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingConcurrencyGateRegistry.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingConcurrencyGateRegistry.java
@@ -1,0 +1,64 @@
+package io.stargate.sgv2.jsonapi.service.reranking.operation;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
+import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds the singleton {@link RerankingConcurrencyGate} for each provider+model pair.
+ *
+ * <p>{@link RerankingProviderFactory} constructs a fresh {@link RerankingProvider} (and REST
+ * client) for every API request, so the shared per-pod concurrency state cannot live on the
+ * provider itself — it is looked up here and handed to each new provider instance.
+ */
+@ApplicationScoped
+public class RerankingConcurrencyGateRegistry {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(RerankingConcurrencyGateRegistry.class);
+
+  @Inject MeterRegistry meterRegistry;
+
+  private final Map<String, RerankingConcurrencyGate> gates = new ConcurrentHashMap<>();
+
+  public RerankingConcurrencyGate gateFor(
+      ModelProvider modelProvider,
+      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig) {
+    return gates.computeIfAbsent(
+        modelProvider.apiName() + "/" + modelConfig.name(),
+        key -> createGate(modelProvider, modelConfig));
+  }
+
+  private RerankingConcurrencyGate createGate(
+      ModelProvider modelProvider,
+      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig) {
+    var properties = modelConfig.properties();
+    if (properties.totalTimeoutMillis() < properties.readTimeoutMillis()) {
+      LOGGER.warn(
+          "Reranking model {}/{} has total-timeout-millis {} below read-timeout-millis {}: "
+              + "every call that reaches the read timeout will already have failed the total deadline",
+          modelProvider.apiName(),
+          modelConfig.name(),
+          properties.totalTimeoutMillis(),
+          properties.readTimeoutMillis());
+    }
+    LOGGER.info(
+        "Creating reranking concurrency gate for {}/{}: maxConcurrentCalls={}, maxQueuedCalls={}",
+        modelProvider.apiName(),
+        modelConfig.name(),
+        properties.maxConcurrentCalls(),
+        properties.maxQueuedCalls());
+    return new RerankingConcurrencyGate(
+        modelProvider.apiName(),
+        modelConfig.name(),
+        properties.maxConcurrentCalls(),
+        properties.maxQueuedCalls(),
+        meterRegistry);
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProvider.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProvider.java
@@ -24,19 +24,27 @@ public abstract class RerankingProvider extends ProviderBase {
 
   protected final RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig;
 
+  /**
+   * Per-pod bulkhead shared with every other provider instance for the same provider+model — the
+   * factory creates a fresh provider per API request, so the gate is the only shared state.
+   */
+  protected final RerankingConcurrencyGate concurrencyGate;
+
   protected final Duration initialBackOffDuration;
 
   protected final Duration maxBackOffDuration;
 
   protected RerankingProvider(
       ModelProvider modelProvider,
-      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig) {
+      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig,
+      RerankingConcurrencyGate concurrencyGate) {
     super(
         modelProvider,
         ModelType.RERANKING,
         new RerankingProviderExceptionHandler(modelProvider, ModelType.RERANKING));
 
     this.modelConfig = modelConfig;
+    this.concurrencyGate = concurrencyGate;
 
     this.initialBackOffDuration =
         Duration.ofMillis(modelConfig.properties().initialBackOffMillis());
@@ -84,11 +92,38 @@ public abstract class RerankingProvider extends ProviderBase {
     List<Uni<BatchedRerankingResponse>> batchRerankings = new ArrayList<>();
 
     for (int batchId = 0; batchId < passageBatches.size(); batchId++) {
+      final int finalBatchId = batchId;
+      final List<String> passageBatch = passageBatches.get(batchId);
+      // the gate parks the call FIFO behind every other request on this pod when the per-pod
+      // in-flight limit is reached; retries (retryHTTPCall in subclasses) run while holding the
+      // permit so a retrying call cannot re-enter the queue and amplify overload
       batchRerankings.add(
-          rerank(batchId, query, passageBatches.get(batchId), rerankingCredentials));
+          concurrencyGate.withPermit(
+              () -> rerank(finalBatchId, query, passageBatch, rerankingCredentials)));
     }
 
-    return Uni.join().all(batchRerankings).andFailFast().map(this::aggregateRanks);
+    return Uni.join()
+        .all(batchRerankings)
+        .usingConcurrencyOf(modelConfig.properties().maxConcurrentBatches())
+        .andFailFast()
+        .map(this::aggregateRanks)
+        // total deadline covers queue wait, every batch, and retries; expiry cancels upstream,
+        // which abandons parked waiters (they never reach the provider) and frees held permits
+        .ifNoItem()
+        .after(Duration.ofMillis(modelConfig.properties().totalTimeoutMillis()))
+        .failWith(this::totalDeadlineExceeded);
+  }
+
+  private RerankingProviderException totalDeadlineExceeded() {
+    return RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.get(
+        Map.of(
+            "modelProvider",
+            modelProvider().apiName(),
+            "httpStatus",
+            "N/A",
+            "errorMessage",
+            "total reranking deadline of %d ms exceeded (includes queue wait, all batch calls and retries)"
+                .formatted(modelConfig.properties().totalTimeoutMillis())));
   }
 
   /**
@@ -122,6 +157,8 @@ public abstract class RerankingProvider extends ProviderBase {
 
   @Override
   protected boolean decideRetry(Throwable throwable) {
+    // note: RERANKING_PROVIDER_OVERLOADED is deliberately not retryable — it is raised by the
+    // local concurrency gate when this pod is already saturated, so retrying deepens the overload
     boolean retry =
         throwable instanceof RerankingProviderException rpe
             && RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.name().equals(rpe.code);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactory.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderFactory.java
@@ -20,6 +20,7 @@ public class RerankingProviderFactory {
 
   @Inject RerankingProvidersConfig rerankingConfig;
   @Inject OperationsConfig operationsConfig;
+  @Inject RerankingConcurrencyGateRegistry concurrencyGateRegistry;
 
   @GrpcClient("embedding")
   RerankingService grpcGatewayService;
@@ -27,7 +28,8 @@ public class RerankingProviderFactory {
   @FunctionalInterface
   interface ProviderConstructor {
     RerankingProvider create(
-        RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig);
+        RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig,
+        RerankingConcurrencyGate concurrencyGate);
   }
 
   private static final Map<ModelProvider, ProviderConstructor> RERANKING_PROVIDER_CTORS =
@@ -93,11 +95,16 @@ public class RerankingProviderFactory {
                     SchemaException.Code.RERANKING_SERVICE_TYPE_UNAVAILABLE.get(
                         Map.of("errorMessage", "unknown model name '%s'".formatted(modelName))));
 
+    // the gate is shared by every provider instance for this provider+model on this pod,
+    // on both the direct and the embedding gateway path
+    var concurrencyGate = concurrencyGateRegistry.gateFor(modelProvider, modelConfig);
+
     if (operationsConfig.enableEmbeddingGateway()) {
       // return the reranking Grpc client to embedding gateway service
       return new RerankingEGWClient(
           modelProvider,
           modelConfig,
+          concurrencyGate,
           tenant,
           authToken,
           grpcGatewayService,
@@ -111,7 +118,7 @@ public class RerankingProviderFactory {
           Map.of(
               "errorMessage", "unknown service provider '%s'".formatted(modelProvider.apiName())));
     }
-    return ctor.create(modelConfig);
+    return ctor.create(modelConfig, concurrencyGate);
   }
 
   public RerankingProvidersConfig getRerankingConfig() {

--- a/src/main/proto/embedding_gateway.proto
+++ b/src/main/proto/embedding_gateway.proto
@@ -280,6 +280,13 @@ message GetSupportedRerankingProvidersResponse {
         int32 max_back_off_millis = 4;
         double jitter = 5;
         int32 max_batch_size = 6;
+        // Concurrency gate properties. Declared optional so the Data API can tell "not served
+        // by this gateway" apart from zero and fall back to its own defaults; zero permits
+        // would deadlock every rerank request.
+        optional int32 max_concurrent_batches = 7;
+        optional int32 max_concurrent_calls = 8;
+        optional int32 max_queued_calls = 9;
+        optional int32 total_timeout_millis = 10;
       }
     }
 

--- a/src/main/resources/errors.yaml
+++ b/src/main/resources/errors.yaml
@@ -2807,13 +2807,26 @@ server-errors:
 # ================================================================================================================
 
   - scope: RERANKING_PROVIDER
+    code: RERANKING_PROVIDER_OVERLOADED
+    title: Reranking Provider is overloaded
+    body: |-
+      The command called a reranking provider to rerank results, but the reranking service is at capacity: the maximum number of concurrent reranking calls and the maximum number of queued reranking calls were both reached, so the request was rejected without calling the provider.
+
+      The reranking provider was: ${modelProvider}.
+      The reranking model was: ${modelName}.
+      The maximum concurrent reranking calls was: ${maxConcurrentCalls}.
+      The maximum queued reranking calls was: ${maxQueuedCalls}.
+
+      ${SNIPPET.RETRY}
+
+  - scope: RERANKING_PROVIDER
     code: RERANKING_PROVIDER_TIMEOUT
     title: Reranking Provider timed out
     body: |-
       The command called a reranking provider to rerank results, but the provider did not respond within the allowed time.
-      
+
       The reranking provider was: ${modelProvider}.
       The HTTP status code was: ${httpStatus}.
       The error message was: ${errorMessage}.
-      
+
       ${SNIPPET.RETRY}

--- a/src/main/resources/reranking-providers-config.yaml
+++ b/src/main/resources/reranking-providers-config.yaml
@@ -15,3 +15,10 @@ stargate:
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
                 max-batch-size: 10
+            # NIM 2.x model; accepts up to 512 passages per call, so a typical findAndRerank
+            # is a single reranking call instead of a fan-out of max-batch-size-10 batches.
+            - name: nvidia/llama-3.2-nemoretriever-500m-rerank-v2
+              is-default: false
+              url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking/nvidia-llama-3-2-nemoretriever-500m-rerank-v2
+              properties:
+                max-batch-size: 512

--- a/src/main/resources/test-reranking-providers-config.yaml
+++ b/src/main/resources/test-reranking-providers-config.yaml
@@ -15,6 +15,11 @@ stargate:
               url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking
               properties:
                 max-batch-size: 10
+            - name: nvidia/llama-3.2-nemoretriever-500m-rerank-v2
+              is-default: false
+              url: https://us-west-2.api-dev.ai.datastax.com/nvidia/v1/ranking/nvidia-llama-3-2-nemoretriever-500m-rerank-v2
+              properties:
+                max-batch-size: 512
             - name: nvidia/a-random-deprecated-model
               api-model-support:
                 status: DEPRECATED

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindRerankingProvidersIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindRerankingProvidersIntegrationTest.java
@@ -39,12 +39,18 @@ public class FindRerankingProvidersIntegrationTest extends AbstractKeyspaceInteg
           .statusCode(200)
           .body("$", responseIsStatusOnly())
           .body("status.rerankingProviders", notNullValue())
-          .body("status.rerankingProviders.nvidia.models", hasSize(1))
+          .body("status.rerankingProviders.nvidia.models", hasSize(2))
           .body(
               "status.rerankingProviders.nvidia.models[0].name",
-              equalTo("nvidia/llama-3.2-nv-rerankqa-1b-v2"))
+              equalTo("nvidia/llama-3.2-nemoretriever-500m-rerank-v2"))
           .body(
               "status.rerankingProviders.nvidia.models[0].apiModelSupport.status",
+              equalTo(ApiModelSupport.SupportStatus.SUPPORTED.name()))
+          .body(
+              "status.rerankingProviders.nvidia.models[1].name",
+              equalTo("nvidia/llama-3.2-nv-rerankqa-1b-v2"))
+          .body(
+              "status.rerankingProviders.nvidia.models[1].apiModelSupport.status",
               equalTo(ApiModelSupport.SupportStatus.SUPPORTED.name()));
     }
 
@@ -76,7 +82,7 @@ public class FindRerankingProvidersIntegrationTest extends AbstractKeyspaceInteg
           .statusCode(200)
           .body("$", responseIsStatusOnly())
           .body("status.rerankingProviders", notNullValue())
-          .body("status.rerankingProviders.nvidia.models", hasSize(3))
+          .body("status.rerankingProviders.nvidia.models", hasSize(4))
           .body(
               "status.rerankingProviders.nvidia.models[0].name",
               equalTo("nvidia/a-random-EOL-model"))
@@ -91,9 +97,15 @@ public class FindRerankingProvidersIntegrationTest extends AbstractKeyspaceInteg
               equalTo(ApiModelSupport.SupportStatus.DEPRECATED.name()))
           .body(
               "status.rerankingProviders.nvidia.models[2].name",
-              equalTo("nvidia/llama-3.2-nv-rerankqa-1b-v2"))
+              equalTo("nvidia/llama-3.2-nemoretriever-500m-rerank-v2"))
           .body(
               "status.rerankingProviders.nvidia.models[2].apiModelSupport.status",
+              equalTo(ApiModelSupport.SupportStatus.SUPPORTED.name()))
+          .body(
+              "status.rerankingProviders.nvidia.models[3].name",
+              equalTo("nvidia/llama-3.2-nv-rerankqa-1b-v2"))
+          .body(
+              "status.rerankingProviders.nvidia.models[3].apiModelSupport.status",
               equalTo(ApiModelSupport.SupportStatus.SUPPORTED.name()));
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderConfigProducerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProviderConfigProducerTest.java
@@ -1,0 +1,117 @@
+package io.stargate.sgv2.jsonapi.service.reranking.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stargate.embedding.gateway.EmbeddingGateway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the mapping of the embedding gateway's reranking provider config onto {@link
+ * RerankingProvidersConfig}, in particular the fallback for the concurrency-gate properties: a
+ * gateway that predates proto fields 7-10 must yield the Data API defaults, never zero — zero
+ * concurrent calls would deadlock every rerank request on EGW-enabled (Astra) deployments.
+ */
+public class RerankingProviderConfigProducerTest {
+
+  private static final String MODEL_NAME = "nvidia/llama-3.2-nv-rerankqa-1b-v2";
+
+  private final RerankingProviderConfigProducer producer = new RerankingProviderConfigProducer();
+
+  private EmbeddingGateway.GetSupportedRerankingProvidersResponse responseWithProperties(
+      EmbeddingGateway.GetSupportedRerankingProvidersResponse.ProviderConfig.ModelConfig
+              .RequestProperties
+          properties) {
+    var model =
+        EmbeddingGateway.GetSupportedRerankingProvidersResponse.ProviderConfig.ModelConfig
+            .newBuilder()
+            .setName(MODEL_NAME)
+            .setApiModelSupport(
+                EmbeddingGateway.ApiModelSupport.newBuilder().setStatus("SUPPORTED").build())
+            .setIsDefault(true)
+            .setUrl("http://testing.com")
+            .setProperties(properties)
+            .build();
+    var provider =
+        EmbeddingGateway.GetSupportedRerankingProvidersResponse.ProviderConfig.newBuilder()
+            .setIsDefault(true)
+            .setDisplayName("Nvidia")
+            .setEnabled(true)
+            .addModels(model)
+            .build();
+    return EmbeddingGateway.GetSupportedRerankingProvidersResponse.newBuilder()
+        .putSupportedProviders("nvidia", provider)
+        .build();
+  }
+
+  private RerankingProvidersConfig.RerankingProviderConfig.ModelConfig.RequestProperties mapped(
+      EmbeddingGateway.GetSupportedRerankingProvidersResponse.ProviderConfig.ModelConfig
+              .RequestProperties
+          properties) {
+    var config = producer.grpcResponseToConfig(responseWithProperties(properties));
+    return config.providers().get("nvidia").models().get(0).properties();
+  }
+
+  private static EmbeddingGateway.GetSupportedRerankingProvidersResponse.ProviderConfig.ModelConfig
+          .RequestProperties.Builder
+      baseProperties() {
+    return EmbeddingGateway.GetSupportedRerankingProvidersResponse.ProviderConfig.ModelConfig
+        .RequestProperties.newBuilder()
+        .setAtMostRetries(3)
+        .setInitialBackOffMillis(100)
+        .setReadTimeoutMillis(5000)
+        .setMaxBackOffMillis(500)
+        .setJitter(0.5)
+        .setMaxBatchSize(10);
+  }
+
+  @Test
+  @DisplayName("a gateway that does not serve the gate properties yields the defaults, not zero")
+  void unservedConcurrencyPropertiesFallBackToDefaults() {
+    var properties = mapped(baseProperties().build());
+
+    assertThat(properties.maxBatchSize()).isEqualTo(10);
+    assertThat(properties.maxConcurrentBatches()).isEqualTo(8);
+    assertThat(properties.maxConcurrentCalls()).isEqualTo(32);
+    assertThat(properties.maxQueuedCalls()).isEqualTo(1000);
+    assertThat(properties.totalTimeoutMillis()).isEqualTo(30000);
+  }
+
+  @Test
+  @DisplayName("gateway-served gate properties pass through unchanged")
+  void servedConcurrencyPropertiesPassThrough() {
+    var properties =
+        mapped(
+            baseProperties()
+                .setMaxConcurrentBatches(4)
+                .setMaxConcurrentCalls(16)
+                .setMaxQueuedCalls(50)
+                .setTotalTimeoutMillis(20000)
+                .build());
+
+    assertThat(properties.maxConcurrentBatches()).isEqualTo(4);
+    assertThat(properties.maxConcurrentCalls()).isEqualTo(16);
+    assertThat(properties.maxQueuedCalls()).isEqualTo(50);
+    assertThat(properties.totalTimeoutMillis()).isEqualTo(20000);
+  }
+
+  @Test
+  @DisplayName("out-of-range served values fall back to defaults; explicit zero queue is honored")
+  void outOfRangeServedValuesFallBackToDefaults() {
+    var properties =
+        mapped(
+            baseProperties()
+                .setMaxConcurrentBatches(0)
+                .setMaxConcurrentCalls(0)
+                .setMaxQueuedCalls(0)
+                .setTotalTimeoutMillis(0)
+                .build());
+
+    // zero permits or a zero deadline would break every request: fall back
+    assertThat(properties.maxConcurrentBatches()).isEqualTo(8);
+    assertThat(properties.maxConcurrentCalls()).isEqualTo(32);
+    assertThat(properties.totalTimeoutMillis()).isEqualTo(30000);
+    // zero queued calls is a valid explicit "fail fast, no queueing"
+    assertThat(properties.maxQueuedCalls()).isZero();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfigOverrideTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfigOverrideTest.java
@@ -1,0 +1,59 @@
+package io.stargate.sgv2.jsonapi.service.reranking.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves the concurrency-gate properties are tunable per deployment through standard config
+ * overrides (system properties / env vars / chart values), not only through the bundled yaml.
+ */
+@QuarkusTest
+@TestProfile(RerankingProvidersConfigOverrideTest.Profile.class)
+public class RerankingProvidersConfigOverrideTest {
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public boolean disableGlobalTestResources() {
+      return true;
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return ImmutableMap.<String, String>builder()
+          .put(
+              "stargate.jsonapi.reranking.providers.nvidia.models[0].properties.max-concurrent-batches",
+              "2")
+          .put(
+              "stargate.jsonapi.reranking.providers.nvidia.models[0].properties.max-concurrent-calls",
+              "5")
+          .put(
+              "stargate.jsonapi.reranking.providers.nvidia.models[0].properties.max-queued-calls",
+              "7")
+          .put(
+              "stargate.jsonapi.reranking.providers.nvidia.models[0].properties.total-timeout-millis",
+              "12345")
+          .build();
+    }
+  }
+
+  @Inject RerankingProvidersConfig config;
+
+  @Test
+  @DisplayName("concurrency gate properties are overridable via standard config keys")
+  void overridesApply() {
+    var properties = config.providers().get("nvidia").models().get(0).properties();
+
+    assertThat(properties.maxConcurrentBatches()).isEqualTo(2);
+    assertThat(properties.maxConcurrentCalls()).isEqualTo(5);
+    assertThat(properties.maxQueuedCalls()).isEqualTo(7);
+    assertThat(properties.totalTimeoutMillis()).isEqualTo(12345);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfigTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/configuration/RerankingProvidersConfigTest.java
@@ -1,0 +1,63 @@
+package io.stargate.sgv2.jsonapi.service.reranking.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts the reranking provider configuration loaded from the main {@code
+ * reranking-providers-config.yaml} (unit tests resolve against the main yaml, not the
+ * integration-test one), in particular the concurrency-gate defaults introduced for the reranking
+ * bulkhead.
+ */
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class RerankingProvidersConfigTest {
+
+  private static final String RERANKQA_MODEL = "nvidia/llama-3.2-nv-rerankqa-1b-v2";
+  private static final String NEMOTRON_MODEL = "nvidia/llama-3.2-nemoretriever-500m-rerank-v2";
+
+  @Inject RerankingProvidersConfig config;
+
+  private RerankingProvidersConfig.RerankingProviderConfig.ModelConfig model(String name) {
+    return config.providers().get("nvidia").models().stream()
+        .filter(model -> model.name().equals(name))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("model not found in config: " + name));
+  }
+
+  @Test
+  @DisplayName("concurrency gate properties default from @WithDefault when absent in yaml")
+  void concurrencyGateDefaultsApplied() {
+    var properties = model(RERANKQA_MODEL).properties();
+
+    assertThat(properties.maxBatchSize()).isEqualTo(10);
+    assertThat(properties.maxConcurrentBatches()).isEqualTo(8);
+    assertThat(properties.maxConcurrentCalls()).isEqualTo(32);
+    assertThat(properties.maxQueuedCalls()).isEqualTo(1000);
+    assertThat(properties.totalTimeoutMillis()).isEqualTo(30000);
+  }
+
+  @Test
+  @DisplayName("nemotron model reranks 512 passages per call to collapse the fan-out")
+  void nemotronModelHasLargeBatchSize() {
+    var nemotron = model(NEMOTRON_MODEL);
+
+    assertThat(nemotron.isDefault()).isFalse();
+    assertThat(nemotron.properties().maxBatchSize()).isEqualTo(512);
+    // gate defaults apply to the new model too
+    assertThat(nemotron.properties().maxConcurrentCalls()).isEqualTo(32);
+    assertThat(nemotron.properties().totalTimeoutMillis()).isEqualTo(30000);
+  }
+
+  @Test
+  @DisplayName("the legacy model stays the default model")
+  void legacyModelStaysDefault() {
+    assertThat(model(RERANKQA_MODEL).isDefault()).isTrue();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/gateway/RerankingGatewayClientTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/gateway/RerankingGatewayClientTest.java
@@ -20,6 +20,7 @@ import io.stargate.sgv2.jsonapi.service.provider.ModelType;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfigImpl;
 import io.stargate.sgv2.jsonapi.service.reranking.operation.RerankingProvider;
+import io.stargate.sgv2.jsonapi.service.reranking.operation.TestRerankingProvider;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +100,7 @@ public class RerankingGatewayClientTest {
         new RerankingEGWClient(
             ModelProvider.NVIDIA,
             MODEL_CONFIG,
+            TestRerankingProvider.permissiveGate(),
             testConstants.TENANT,
             "default",
             rerankService,
@@ -152,6 +154,7 @@ public class RerankingGatewayClientTest {
         new RerankingEGWClient(
             ModelProvider.NVIDIA,
             MODEL_CONFIG,
+            TestRerankingProvider.permissiveGate(),
             testConstants.TENANT,
             "default",
             rerankService,

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProviderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/NvidiaRerankingProviderTest.java
@@ -41,7 +41,8 @@ public class NvidiaRerankingProviderTest {
 
   @Test
   void testEmptyApiKeyThrowsException() {
-    NvidiaRerankingProvider provider = new NvidiaRerankingProvider(MODEL_CONFIG);
+    NvidiaRerankingProvider provider =
+        new NvidiaRerankingProvider(MODEL_CONFIG, TestRerankingProvider.permissiveGate());
 
     RerankingCredentials emptyApiKeyCredentials =
         new RerankingCredentials(testConstants.TENANT, "");
@@ -69,7 +70,8 @@ public class NvidiaRerankingProviderTest {
   void testTenantIdIsExtractedFromCredentials() {
     // Verify that the tenant from RerankingCredentials is correctly accessible
     // This ensures the tenant ID will be correctly passed as "tenant-id" header
-    NvidiaRerankingProvider provider = new NvidiaRerankingProvider(MODEL_CONFIG);
+    NvidiaRerankingProvider provider =
+        new NvidiaRerankingProvider(MODEL_CONFIG, TestRerankingProvider.permissiveGate());
 
     String expectedTenantId = testConstants.TENANT.toString();
     RerankingCredentials credentials =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingConcurrencyGateTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingConcurrencyGateTest.java
@@ -1,0 +1,340 @@
+package io.stargate.sgv2.jsonapi.service.reranking.operation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.smallrye.mutiny.subscription.UniEmitter;
+import io.stargate.sgv2.jsonapi.exception.RerankingProviderException;
+import io.stargate.sgv2.jsonapi.metrics.MetricsConstants;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link RerankingConcurrencyGate}, the per provider+model bulkhead that bounds in-flight
+ * reranking calls per pod and parks the overflow in a bounded FIFO queue.
+ *
+ * <p>Plain JUnit, no Quarkus: the gate has no CDI dependencies, all completion is driven manually
+ * through {@link ControlledWork} so every test is deterministic.
+ */
+public class RerankingConcurrencyGateTest {
+
+  private static final String PROVIDER = "nvidia";
+  private static final String MODEL = "testModel";
+
+  private SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+  private RerankingConcurrencyGate gate(int maxConcurrentCalls, int maxQueuedCalls) {
+    return new RerankingConcurrencyGate(
+        PROVIDER, MODEL, maxConcurrentCalls, maxQueuedCalls, meterRegistry);
+  }
+
+  /** Work whose start and completion the test controls explicitly. */
+  private static final class ControlledWork {
+    private final AtomicReference<UniEmitter<? super String>> emitter = new AtomicReference<>();
+    private final AtomicBoolean invoked = new AtomicBoolean();
+
+    Uni<String> uni() {
+      return Uni.createFrom()
+          .emitter(
+              em -> {
+                invoked.set(true);
+                emitter.set(em);
+              });
+    }
+
+    boolean invoked() {
+      return invoked.get();
+    }
+
+    void complete() {
+      emitter.get().complete("done");
+    }
+
+    void fail(Throwable t) {
+      emitter.get().fail(t);
+    }
+  }
+
+  private UniAssertSubscriber<String> submit(RerankingConcurrencyGate gate, ControlledWork work) {
+    return gate.withPermit(work::uni).subscribe().withSubscriber(UniAssertSubscriber.create());
+  }
+
+  @Test
+  @DisplayName("fast path acquires immediately when capacity is free and nothing is queued")
+  void fastPathAcquiresImmediately() {
+    var gate = gate(2, 10);
+    var work = new ControlledWork();
+
+    var sub = submit(gate, work);
+
+    assertThat(work.invoked()).as("work starts immediately when a slot is free").isTrue();
+    assertThat(gate.inFlight()).isEqualTo(1);
+    assertThat(gate.queueDepth()).isZero();
+
+    work.complete();
+    sub.assertCompleted().assertItem("done");
+    assertThat(gate.inFlight()).isZero();
+  }
+
+  @Test
+  @DisplayName("in-flight calls never exceed maxConcurrentCalls; excess is parked FIFO")
+  void capNeverExceededAndFifoOrder() {
+    var gate = gate(2, 10);
+    List<ControlledWork> works = new ArrayList<>();
+    List<UniAssertSubscriber<String>> subs = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      var work = new ControlledWork();
+      works.add(work);
+      subs.add(submit(gate, work));
+    }
+
+    // only the first two run, three are parked
+    assertThat(works.get(0).invoked()).isTrue();
+    assertThat(works.get(1).invoked()).isTrue();
+    assertThat(works.get(2).invoked()).isFalse();
+    assertThat(works.get(3).invoked()).isFalse();
+    assertThat(works.get(4).invoked()).isFalse();
+    assertThat(gate.inFlight()).isEqualTo(2);
+    assertThat(gate.queueDepth()).isEqualTo(3);
+
+    // releasing one slot grants the parked waiters in FIFO order
+    works.get(0).complete();
+    assertThat(works.get(2).invoked()).as("waiter 2 granted first (FIFO)").isTrue();
+    assertThat(works.get(3).invoked()).isFalse();
+    assertThat(gate.inFlight()).isEqualTo(2);
+    assertThat(gate.queueDepth()).isEqualTo(2);
+
+    works.get(1).complete();
+    assertThat(works.get(3).invoked()).as("waiter 3 granted second (FIFO)").isTrue();
+    assertThat(works.get(4).invoked()).isFalse();
+
+    works.get(2).complete();
+    assertThat(works.get(4).invoked()).as("waiter 4 granted last (FIFO)").isTrue();
+    works.get(3).complete();
+    works.get(4).complete();
+
+    subs.forEach(sub -> sub.assertCompleted().assertItem("done"));
+    assertThat(gate.inFlight()).isZero();
+    assertThat(gate.queueDepth()).isZero();
+  }
+
+  @Test
+  @DisplayName("a new arrival cannot barge past parked waiters")
+  void noBargingWhilstWaitersParked() {
+    var gate = gate(1, 10);
+    var holder = new ControlledWork();
+    submit(gate, holder);
+
+    var parked = new ControlledWork();
+    submit(gate, parked);
+    assertThat(parked.invoked()).isFalse();
+
+    var late = new ControlledWork();
+    submit(gate, late);
+
+    holder.complete();
+    assertThat(parked.invoked()).as("parked waiter wins over the later arrival").isTrue();
+    assertThat(late.invoked()).isFalse();
+
+    parked.complete();
+    assertThat(late.invoked()).isTrue();
+    late.complete();
+  }
+
+  @Test
+  @DisplayName("queue overflow fails fast with RERANKING_PROVIDER_OVERLOADED, work never invoked")
+  void overflowRejectsImmediately() {
+    var gate = gate(1, 1);
+    var holder = new ControlledWork();
+    submit(gate, holder);
+    var parked = new ControlledWork();
+    submit(gate, parked);
+
+    var rejectedWork = new ControlledWork();
+    var rejectedSub = submit(gate, rejectedWork);
+
+    var failure = rejectedSub.assertFailed().getFailure();
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            RerankingProviderException.class,
+            e ->
+                assertThat(e.code)
+                    .isEqualTo(
+                        RerankingProviderException.Code.RERANKING_PROVIDER_OVERLOADED.name()));
+    assertThat(rejectedWork.invoked()).as("rejected work must never start").isFalse();
+    assertThat(gate.queueDepth()).isEqualTo(1);
+
+    assertThat(
+            meterRegistry
+                .get(MetricsConstants.MetricNames.RERANK_ALL_QUEUE_REJECTED_METRIC)
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+
+    // the rejected request did not leak queue capacity: a slot frees, the parked one runs
+    holder.complete();
+    assertThat(parked.invoked()).isTrue();
+    parked.complete();
+    assertThat(gate.inFlight()).isZero();
+    assertThat(gate.queueDepth()).isZero();
+  }
+
+  @Test
+  @DisplayName("cancelling a parked waiter frees its queue slot without consuming a permit")
+  void cancelWhileParkedFreesQueueSlot() {
+    var gate = gate(1, 1);
+    var holder = new ControlledWork();
+    submit(gate, holder);
+
+    var parked = new ControlledWork();
+    var parkedSub = submit(gate, parked);
+    assertThat(gate.queueDepth()).isEqualTo(1);
+
+    parkedSub.cancel();
+    assertThat(gate.queueDepth()).as("abandoned waiter releases queue capacity").isZero();
+
+    // queue capacity is available again for a new request
+    var next = new ControlledWork();
+    submit(gate, next);
+    assertThat(gate.queueDepth()).isEqualTo(1);
+
+    holder.complete();
+    assertThat(parked.invoked()).as("cancelled waiter must never start").isFalse();
+    assertThat(next.invoked()).isTrue();
+    next.complete();
+    assertThat(gate.inFlight()).isZero();
+  }
+
+  @Test
+  @DisplayName("work failure releases the permit and grants the next waiter")
+  void workFailureReleasesPermit() {
+    var gate = gate(1, 10);
+    var failing = new ControlledWork();
+    var failingSub = submit(gate, failing);
+    var parked = new ControlledWork();
+    var parkedSub = submit(gate, parked);
+
+    failing.fail(new RuntimeException("provider blew up"));
+    failingSub.assertFailed();
+
+    assertThat(parked.invoked()).as("permit freed by the failure grants the waiter").isTrue();
+    parked.complete();
+    parkedSub.assertCompleted();
+    assertThat(gate.inFlight()).isZero();
+  }
+
+  @Test
+  @DisplayName("cancelling in-flight work releases the permit")
+  void cancelInFlightWorkReleasesPermit() {
+    var gate = gate(1, 10);
+    var inFlightWork = new ControlledWork();
+    var inFlightSub = submit(gate, inFlightWork);
+    assertThat(gate.inFlight()).isEqualTo(1);
+
+    inFlightSub.cancel();
+    assertThat(gate.inFlight()).as("cancellation of running work frees the slot").isZero();
+
+    var next = new ControlledWork();
+    submit(gate, next);
+    assertThat(next.invoked()).isTrue();
+    next.complete();
+  }
+
+  @Test
+  @DisplayName("gauges track queue depth and in-flight; wait timer records parked grants")
+  void metersTrackGateState() {
+    var gate = gate(1, 10);
+    var holder = new ControlledWork();
+    submit(gate, holder);
+    var parked = new ControlledWork();
+    submit(gate, parked);
+
+    assertThat(
+            meterRegistry
+                .get(MetricsConstants.MetricNames.RERANK_ALL_INFLIGHT_CALLS_METRIC)
+                .gauge()
+                .value())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .get(MetricsConstants.MetricNames.RERANK_ALL_QUEUE_DEPTH_METRIC)
+                .gauge()
+                .value())
+        .isEqualTo(1.0);
+
+    holder.complete();
+    parked.complete();
+
+    assertThat(
+            meterRegistry
+                .get(MetricsConstants.MetricNames.RERANK_ALL_QUEUE_WAIT_DURATION_METRIC)
+                .timer()
+                .count())
+        .as("one parked grant recorded in the wait timer")
+        .isEqualTo(1);
+    assertThat(
+            meterRegistry
+                .get(MetricsConstants.MetricNames.RERANK_ALL_INFLIGHT_CALLS_METRIC)
+                .gauge()
+                .value())
+        .isZero();
+  }
+
+  @Test
+  @DisplayName("cap holds under multi-threaded contention")
+  void capHoldsUnderContention() throws Exception {
+    final int maxConcurrent = 4;
+    final int tasks = 200;
+    var gate = gate(maxConcurrent, tasks);
+    var running = new AtomicInteger();
+    var maxObserved = new AtomicInteger();
+    var completed = new CountDownLatch(tasks);
+
+    ExecutorService pool = Executors.newFixedThreadPool(16);
+    try {
+      for (int i = 0; i < tasks; i++) {
+        pool.submit(
+            () ->
+                gate.withPermit(
+                        () ->
+                            Uni.createFrom()
+                                .item("ok")
+                                .onItem()
+                                .invoke(
+                                    ignored -> {
+                                      int now = running.incrementAndGet();
+                                      maxObserved.accumulateAndGet(now, Math::max);
+                                      // hold the slot briefly so overlap is observable
+                                      try {
+                                        Thread.sleep(1);
+                                      } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                      }
+                                      running.decrementAndGet();
+                                    }))
+                    .subscribe()
+                    .with(item -> completed.countDown(), failure -> completed.countDown()));
+      }
+      assertThat(completed.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(maxObserved.get())
+        .as("observed concurrency must never exceed the configured cap")
+        .isLessThanOrEqualTo(maxConcurrent);
+    assertThat(gate.inFlight()).isZero();
+    assertThat(gate.queueDepth()).isZero();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/RerankingProviderTest.java
@@ -2,14 +2,19 @@ package io.stargate.sgv2.jsonapi.service.reranking.operation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.sgv2.jsonapi.TestConstants;
 import io.stargate.sgv2.jsonapi.api.request.RerankingCredentials;
+import io.stargate.sgv2.jsonapi.exception.RerankingProviderException;
 import io.stargate.sgv2.jsonapi.testresource.NoGlobalResourcesTestProfile;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -98,5 +103,233 @@ public class RerankingProviderTest {
     // passage order
     IntStream.range(0, 15)
         .forEach(i -> assertThat(finalResult.ranks().get(i).index()).isEqualTo(i));
+  }
+
+  private static List<String> passages(int count) {
+    return IntStream.range(0, count).mapToObj("passage-%d"::formatted).toList();
+  }
+
+  private static RerankingConcurrencyGate gate(int maxConcurrentCalls, int maxQueuedCalls) {
+    return new RerankingConcurrencyGate(
+        "custom", "testModel", maxConcurrentCalls, maxQueuedCalls, new SimpleMeterRegistry());
+  }
+
+  /** The gate releases permits during cancellation cleanup; give async termination a moment. */
+  private static void awaitGateIdle(RerankingConcurrencyGate gate) {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while ((gate.inFlight() != 0 || gate.queueDepth() != 0) && System.nanoTime() < deadline) {
+      Thread.onSpinWait();
+    }
+    assertThat(gate.inFlight()).isZero();
+    assertThat(gate.queueDepth()).isZero();
+  }
+
+  @Test
+  @DisplayName("per-request fan-out cap bounds concurrent batches; aggregation stays correct")
+  void fanOutCapLimitsConcurrentBatches() {
+    // 100 passages / batch size 10 = 10 batches, but at most 3 in flight at once
+    var provider =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 3, 30000),
+            TestRerankingProvider.permissiveGate(),
+            Duration.ofMillis(50),
+            new TestRerankingProvider.ConcurrencyTracker());
+    List<String> passages = passages(100);
+
+    var finalResult =
+        provider
+            .rerank("query", passages, RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitItem(Duration.ofSeconds(30))
+            .getItem();
+
+    assertThat(provider.invokedBatches()).isEqualTo(10);
+    assertThat(provider.tracker().maxObserved())
+        .as("concurrent batch calls must not exceed max-concurrent-batches")
+        .isLessThanOrEqualTo(3);
+    assertThat(finalResult.ranks()).hasSize(passages.size());
+    IntStream.range(0, passages.size())
+        .forEach(i -> assertThat(finalResult.ranks().get(i).index()).isEqualTo(i));
+  }
+
+  @Test
+  @DisplayName("a shared gate bounds in-flight calls across provider instances (per-pod bulkhead)")
+  void sharedGateBoundsConcurrencyAcrossProviders() {
+    var sharedGate = gate(1, 1000);
+    var sharedTracker = new TestRerankingProvider.ConcurrencyTracker();
+    var provider1 =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 30000),
+            sharedGate,
+            Duration.ofMillis(50),
+            sharedTracker);
+    var provider2 =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 30000),
+            sharedGate,
+            Duration.ofMillis(50),
+            sharedTracker);
+
+    var sub1 =
+        provider1
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+    var sub2 =
+        provider2
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    sub1.awaitItem(Duration.ofSeconds(10));
+    sub2.awaitItem(Duration.ofSeconds(10));
+    assertThat(sharedTracker.maxObserved())
+        .as("providers created per-request must share the per-pod cap")
+        .isEqualTo(1);
+    awaitGateIdle(sharedGate);
+  }
+
+  @Test
+  @DisplayName("total deadline fails a parked request without ever calling the provider")
+  void deadlineWhileParkedNeverInvokesWork() {
+    var sharedGate = gate(1, 1000);
+    // occupies the only permit for ~10s
+    var slowProvider =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 30000),
+            sharedGate,
+            Duration.ofSeconds(10),
+            new TestRerankingProvider.ConcurrencyTracker());
+    var slowSub =
+        slowProvider
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    // parks behind the slow call, its 150ms total deadline expires while waiting
+    var parkedProvider =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 150),
+            sharedGate,
+            Duration.ZERO,
+            new TestRerankingProvider.ConcurrencyTracker());
+    var parkedSub =
+        parkedProvider
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    var failure = parkedSub.awaitFailure(Duration.ofSeconds(10)).getFailure();
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            RerankingProviderException.class,
+            e -> {
+              assertThat(e.code)
+                  .isEqualTo(RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.name());
+              assertThat(e.getMessage()).contains("150");
+            });
+    assertThat(parkedProvider.invokedBatches())
+        .as("a request that timed out while parked must never reach the provider")
+        .isZero();
+
+    slowSub.cancel();
+    awaitGateIdle(sharedGate);
+  }
+
+  @Test
+  @DisplayName("total deadline fires mid-call and the cancelled call releases its permit")
+  void deadlineWhileInFlightReleasesPermit() {
+    var sharedGate = gate(1, 1000);
+    var provider =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 150),
+            sharedGate,
+            Duration.ofSeconds(10),
+            new TestRerankingProvider.ConcurrencyTracker());
+
+    var failure =
+        provider
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure(Duration.ofSeconds(10))
+            .getFailure();
+
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            RerankingProviderException.class,
+            e ->
+                assertThat(e.code)
+                    .isEqualTo(RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.name()));
+    awaitGateIdle(sharedGate);
+  }
+
+  @Test
+  @DisplayName("gate overflow surfaces RERANKING_PROVIDER_OVERLOADED to the caller")
+  void queueOverflowSurfacesOverloaded() {
+    var sharedGate = gate(1, 0); // no queueing at all
+    var slowProvider =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 30000),
+            sharedGate,
+            Duration.ofSeconds(10),
+            new TestRerankingProvider.ConcurrencyTracker());
+    var slowSub =
+        slowProvider
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    var rejectedProvider =
+        new TestRerankingProvider(
+            TestRerankingProvider.modelConfig(10, 8, 30000),
+            sharedGate,
+            Duration.ZERO,
+            new TestRerankingProvider.ConcurrencyTracker());
+    var failure =
+        rejectedProvider
+            .rerank("query", passages(10), RERANK_CREDENTIALS)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure(Duration.ofSeconds(10))
+            .getFailure();
+
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            RerankingProviderException.class,
+            e ->
+                assertThat(e.code)
+                    .isEqualTo(
+                        RerankingProviderException.Code.RERANKING_PROVIDER_OVERLOADED.name()));
+    assertThat(rejectedProvider.invokedBatches()).isZero();
+
+    slowSub.cancel();
+    awaitGateIdle(sharedGate);
+  }
+
+  @Test
+  @DisplayName("OVERLOADED is never retried; provider TIMEOUT stays retryable")
+  void overloadedIsNotRetried() {
+    var provider = new TestRerankingProvider(10);
+
+    var overloaded =
+        RerankingProviderException.Code.RERANKING_PROVIDER_OVERLOADED.get(
+            Map.of(
+                "modelProvider", "custom",
+                "modelName", "testModel",
+                "maxConcurrentCalls", "1",
+                "maxQueuedCalls", "0"));
+    assertThat(provider.decideRetry(overloaded))
+        .as("retrying an overloaded rejection would deepen the overload")
+        .isFalse();
+
+    var timeout =
+        RerankingProviderException.Code.RERANKING_PROVIDER_TIMEOUT.get(
+            Map.of(
+                "modelProvider", "custom",
+                "httpStatus", "504",
+                "errorMessage", "upstream timeout"));
+    assertThat(provider.decideRetry(timeout)).isTrue();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/TestRerankingProvider.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/reranking/operation/TestRerankingProvider.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.service.reranking.operation;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.TestConstants;
 import io.stargate.sgv2.jsonapi.api.request.RerankingCredentials;
@@ -7,10 +8,13 @@ import io.stargate.sgv2.jsonapi.service.provider.ApiModelSupport;
 import io.stargate.sgv2.jsonapi.service.provider.ModelProvider;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfig;
 import io.stargate.sgv2.jsonapi.service.reranking.configuration.RerankingProvidersConfigImpl;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Mock a test reranking provider that returns ranks based on query and passages */
 public class TestRerankingProvider extends RerankingProvider {
@@ -39,17 +43,86 @@ public class TestRerankingProvider extends RerankingProvider {
       new RerankingProvidersConfigImpl.RerankingProviderConfigImpl(
           false, "test", true, Map.of(), List.of());
 
+  /** Tracks how many batch calls run at once, shareable between providers in a test. */
+  public static final class ConcurrencyTracker {
+    private final AtomicInteger current = new AtomicInteger();
+    private final AtomicInteger max = new AtomicInteger();
+
+    void enter() {
+      max.accumulateAndGet(current.incrementAndGet(), Math::max);
+    }
+
+    void exit() {
+      current.decrementAndGet();
+    }
+
+    public int maxObserved() {
+      return max.get();
+    }
+
+    public int current() {
+      return current.get();
+    }
+  }
+
+  private final Duration batchDelay;
+  private final ConcurrencyTracker tracker;
+  private final AtomicInteger invokedBatches = new AtomicInteger();
+
   protected TestRerankingProvider(int maxBatchSize) {
-    super(
-        ModelProvider.CUSTOM,
-        new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl(
-            "testModel",
-            new ApiModelSupport.ApiModelSupportImpl(
-                ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
-            false,
-            "http://testing.com",
-            new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl
-                .RequestPropertiesImpl(3, 100, 5000, 500, 0.5, maxBatchSize)));
+    this(
+        modelConfig(maxBatchSize, 8, 30000),
+        permissiveGate(),
+        Duration.ZERO,
+        new ConcurrencyTracker());
+  }
+
+  protected TestRerankingProvider(
+      RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig,
+      RerankingConcurrencyGate gate,
+      Duration batchDelay,
+      ConcurrencyTracker tracker) {
+    super(ModelProvider.CUSTOM, modelConfig, gate);
+    this.batchDelay = batchDelay;
+    this.tracker = tracker;
+  }
+
+  /** Builds a model config for tests that need specific batching/deadline properties. */
+  static RerankingProvidersConfig.RerankingProviderConfig.ModelConfig modelConfig(
+      int maxBatchSize, int maxConcurrentBatches, int totalTimeoutMillis) {
+    return new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl(
+        "testModel",
+        new ApiModelSupport.ApiModelSupportImpl(
+            ApiModelSupport.SupportStatus.SUPPORTED, Optional.empty()),
+        false,
+        "http://testing.com",
+        new RerankingProvidersConfigImpl.RerankingProviderConfigImpl.ModelConfigImpl
+            .RequestPropertiesImpl(
+            3,
+            100,
+            5000,
+            500,
+            0.5,
+            maxBatchSize,
+            maxConcurrentBatches,
+            32,
+            1000,
+            totalTimeoutMillis));
+  }
+
+  /** A gate large enough that it never interferes with single-provider batching tests. */
+  public static RerankingConcurrencyGate permissiveGate() {
+    return new RerankingConcurrencyGate(
+        ModelProvider.CUSTOM.apiName(), "testModel", 32, 1000, new SimpleMeterRegistry());
+  }
+
+  /** How many batch calls actually started, e.g. to prove a rejected request never ran. */
+  public int invokedBatches() {
+    return invokedBatches.get();
+  }
+
+  public ConcurrencyTracker tracker() {
+    return tracker;
   }
 
   @Override
@@ -62,6 +135,35 @@ public class TestRerankingProvider extends RerankingProvider {
   public Uni<BatchedRerankingResponse> rerank(
       int batchId, String query, List<String> passages, RerankingCredentials rerankCredentials) {
 
+    invokedBatches.incrementAndGet();
+    return Uni.createFrom()
+        .deferred(
+            () -> {
+              var started = new AtomicBoolean();
+              Uni<BatchedRerankingResponse> result =
+                  Uni.createFrom()
+                      .item(
+                          () -> {
+                            started.set(true);
+                            tracker.enter();
+                            return respond(batchId, query, passages, rerankCredentials);
+                          });
+              if (!batchDelay.isZero()) {
+                result = result.onItem().delayIt().by(batchDelay);
+              }
+              return result
+                  .onTermination()
+                  .invoke(
+                      () -> {
+                        if (started.get()) {
+                          tracker.exit();
+                        }
+                      });
+            });
+  }
+
+  private BatchedRerankingResponse respond(
+      int batchId, String query, List<String> passages, RerankingCredentials rerankCredentials) {
     List<Rank> ranks = new ArrayList<>(passages.size());
     for (int i = 0; i < passages.size(); i++) {
       String passage = passages.get(i);
@@ -70,8 +172,6 @@ public class TestRerankingProvider extends RerankingProvider {
     }
 
     ranks.sort((o1, o2) -> Float.compare(o2.score(), o1.score())); // Descending order
-    return Uni.createFrom()
-        .item(
-            new BatchedRerankingResponse(batchId, ranks, createEmptyModelUsage(rerankCredentials)));
+    return new BatchedRerankingResponse(batchId, ranks, createEmptyModelUsage(rerankCredentials));
   }
 }


### PR DESCRIPTION
## What this does

PepsiCo needs 1000 simultaneous `findAndRerank` requests to succeed without errors (latency may grow). Today each request fans out `ceil(passages/10)` concurrent rerank POSTs with no concurrency limit anywhere, so a 1000-request burst is ~10,000 concurrent calls; the reranking NIM's internal queue blows past the read timeout and requests mass-fail with `RERANKING_PROVIDER_TIMEOUT`.

Queuing alone converts errors into latency but does not create throughput, so this PR combines three things:

### 1. Reranking concurrency gate (per provider+model, per pod)
- **Per-pod bulkhead**: at most `max-concurrent-calls` (default 32) rerank calls in flight across all requests; excess calls park in a bounded FIFO queue (`max-queued-calls`, default 1000). New non-blocking `RerankingConcurrencyGate` + `@ApplicationScoped` `RerankingConcurrencyGateRegistry` (providers are constructed per request, so shared state must live in a singleton).
- **Queue overflow fails fast** with the new `RERANKING_PROVIDER_OVERLOADED` error, without ever calling the provider — and it is deliberately never retried (retrying a saturation rejection deepens the overload).
- **Per-request fan-out cap**: `max-concurrent-batches` (default 8) via `Uni.join().usingConcurrencyOf()`.
- **Total deadline**: `total-timeout-millis` (default 30000) covers queue wait + all batches + retries. Expiry surfaces `RERANKING_PROVIDER_TIMEOUT`; parked work is abandoned before it reaches the provider. The embedding-gateway path inherits the gate and deadline through the `RerankingProvider` base class — previously the gRPC path had no client-side time bound at all.
- **Metrics** per provider+model: `rerank.all.queue.depth`, `rerank.all.inflight.calls` (gauges), `rerank.all.queue.wait.duration` (timer, parked grants), `rerank.all.queue.rejected.count` (counter).

### 2. nemotron rerank model with 512-passage batches
`nvidia/llama-3.2-nemoretriever-500m-rerank-v2` (`max-batch-size: 512`, non-default) collapses a typical findAndRerank from 10 rerank calls to 1 — the lever that makes the 1000-burst arithmetically feasible (PepsiCo's own 2-pod nemotron benchmark absorbed an 1800-request burst at 0% errors).

### 3. Config plumbing + handoff docs
- New properties flow through `RequestProperties`, the yaml schema, and `embedding_gateway.proto` (`optional` fields 7–10). Unset or out-of-range gateway values fall back to the Data API defaults, never zero, so the Data API can deploy before EGW.
- `CONFIGURATION.md` gains a Reranking configuration section (there was none).
- `docs/reranking-nim-capacity-recommendations.md`: gpu-helm-charts changes (nemotron NIM deployment, ingress route, `NIM_SERVER_MAX_QUEUE_SIZE` / `NIM_SERVER_REQUEST_TIMEOUT_S`, replica sizing formula).
- `docs/reranking-egw-coordination.md`: EGW proto mirror + serving nemotron with batch 512 for Astra.

## Behavior changes to note
- Enabled by default with generous limits: steady-state traffic never queues (well below 32 in-flight/pod); only true bursts change behavior, which is the point.
- Requests with >8 batches (>80 passages on the batch-10 model) serialize past the fan-out cap — bounded latency increase, no errors.
- New terminal error code `RERANKING_PROVIDER_OVERLOADED` (clients should treat as retry-later).
- The EGW path gains a client-side total deadline (intentional gap closure).

## Test plan
- [x] `RerankingConcurrencyGateTest` (9): cap enforcement incl. multi-threaded contention, FIFO order, no barging, overflow fail-fast (work never invoked), cancel-while-parked frees the slot, release on failure/cancellation, meter tracking
- [x] `RerankingProviderTest` (+6): fan-out cap with correct aggregation, shared gate across provider instances, deadline-while-parked (provider never called, queue drained), deadline mid-call releases permit, overflow surfaced to caller, OVERLOADED never retried / TIMEOUT still retried
- [x] `RerankingProvidersConfigTest` / `...OverrideTest` / `RerankingProviderConfigProducerTest`: yaml defaults, per-deployment overrides, EGW proto pass-through + fallback semantics (incl. explicit `max_queued_calls=0` honored)
- [x] `AllErrorCodesLoadTest` covers the new error template
- [x] Full unit suite: 3487 tests, 0 failures
- [ ] Integration test run (DSE via colima) — `FindRerankingProvidersIntegrationTest` expectations updated for the new model entry
- [ ] Burst load test on the dev GPU plane (rerank-loadtest, 1000-request burst): expect queueing not rejection at defaults, `OVERLOADED` only beyond the configured envelope
- [ ] Confirm nemotron ingress route + model id against the gpu-helm-charts deployment before cutover (route is projected; documented in the capacity recommendations doc)
